### PR TITLE
examples dir; clean up readme; curveOpts implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ vendor/
 *.txt
 
 tmp/
+
+examples/**/*.json

--- a/caigo_test.go
+++ b/caigo_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestHashAndSign(t *testing.T) {
-	curve, err := SCWithConstants("./pedersen_params.json")
+	curve, err := SC(WithConstants("./pedersen_params.json"))
 	if err != nil {
 		t.Errorf("Could not init with constant points: %v\n", err)
 	}
@@ -62,7 +62,7 @@ func TestComputeFact(t *testing.T) {
 }
 
 func TestBadSignature(t *testing.T) {
-	curve, err := SCWithConstants("./pedersen_params.json")
+	curve, err := SC(WithConstants("./pedersen_params.json"))
 	if err != nil {
 		t.Errorf("Could not init with constant points: %v\n", err)
 	}
@@ -103,7 +103,7 @@ func TestBadSignature(t *testing.T) {
 }
 
 func BenchmarkSignatureVerify(b *testing.B) {
-	curve, _ := SCWithConstants("./pedersen_params.json")
+	curve, _ := SC(WithConstants("./pedersen_params.json"))
 
 	pr, _ := curve.GetRandomPrivateKey()
 
@@ -145,7 +145,7 @@ func TestKnownSignature(t *testing.T) {
 	rIn, _ := new(big.Int).SetString("607684330780324271206686790958794501662789535258258105407533051445036595885", 10)
 	sIn, _ := new(big.Int).SetString("453590782387078613313238308551260565642934039343903827708036287031471258875", 10)
 
-	curve, err := SCWithConstants("./pedersen_params.json")
+	curve, err := SC(WithConstants("./pedersen_params.json"))
 	if err != nil {
 		t.Errorf("Could not init with constant points: %v\n", err)
 	}
@@ -170,7 +170,7 @@ func TestKnownSignature(t *testing.T) {
 }
 
 func TestDerivedSignature(t *testing.T) {
-	curve, err := SCWithConstants("./pedersen_params.json")
+	curve, err := SC(WithConstants("./pedersen_params.json"))
 	if err != nil {
 		t.Errorf("Could not init with constant points: %v\n", err)
 	}
@@ -208,34 +208,8 @@ func TestDerivedSignature(t *testing.T) {
 	}
 }
 
-// func TestTransactionHash(t *testing.T) {
-// 	curve := SC()
-
-// 	jtx := JSTransaction{
-// 		Calldata:           []string{"2914367423676101327401096153024331591451054625738519726725779300741401683065", "1284328616562954354594453552152941613439836383012703358554726925609665244667", "3", "1242951120254381876598", "9", "22108152553797646456187940211", "14"},
-// 		ContractAddress:    "0x6f8b21c8354e8ba21ead656932eaa21e728f8c81f001488c186a336d7038cf1",
-// 		EntryPointSelector: "0x240060cdb34fcc260f41eac7474ee1d7c80b7e3607daff9ac67c7ea2ebb1c44",
-// 		EntryPointType:     "EXTERNAL",
-// 		JSSignature:        []string{"1941185432155203218742540925113146991052744726484097092312705586406341211736", "1060098570318028605648271956533461104484177708855341648099672514178101492604"},
-// 		TransactionHash:    "0x14ac93b17d35cc984ff7f186172175cd4341520d32748a406627e48605b38df",
-// 		Nonce:              "0xe",
-// 	}
-
-// 	tx := jtx.ConvertTx()
-// 	hashFinal, err := curve.HashMsg(
-// 		HexToBN("0x6f8b21c8354e8ba21ead656932eaa21e728f8c81f001488c186a336d7038cf1"),
-// 		tx,
-// 	)
-// 	if err != nil {
-// 		t.Errorf("Could not hash tx arguments: %v\n", err)
-// 	}
-// 	if hashFinal.Cmp(HexToBN("0x2c50e0db592d8149ef09c215846d629206b0d2d40509d313a0b1072f172f0ad")) != 0 {
-// 		t.Errorf("Incorrect hash: got %v expected %v\n", hashFinal, HexToBN("0x2c50e0db592d8149ef09c215846d629206b0d2d40509d313a0b1072f172f0ad"))
-// 	}
-// }
-
 func TestVerifySignature(t *testing.T) {
-	curve := SC()
+	curve, _ := SC()
 	hash := HexToBN("0x7f15c38ea577a26f4f553282fcfe4f1feeb8ecfaad8f221ae41abf8224cbddd")
 	r, _ := new(big.Int).SetString("2458502865976494910213617956670505342647705497324144349552978333078363662855", 10)
 	s, _ := new(big.Int).SetString("3439514492576562277095748549117516048613512930236865921315982886313695689433", 10)
@@ -249,7 +223,7 @@ func TestVerifySignature(t *testing.T) {
 }
 
 func TestUIVerifySignature(t *testing.T) {
-	curve := SC()
+	curve, _ := SC()
 	hash := HexToBN("0x324df642fcc7d98b1d9941250840704f35b9ac2e3e2b58b6a034cc09adac54c")
 	r, _ := new(big.Int).SetString("2849277527182985104629156126825776904262411756563556603659114084811678482647", 10)
 	s, _ := new(big.Int).SetString("3156340738553451171391693475354397094160428600037567299774561739201502791079", 10)

--- a/curve.go
+++ b/curve.go
@@ -44,14 +44,20 @@ type StarkCurvePayload struct {
 	ConstantPoints [][]*big.Int `json:"CONSTANT_POINTS"`
 }
 
-func SC() StarkCurve {
-	InitCurve()
-	return sc
-}
+func SC(opts ...CurveOption) (StarkCurve, error) {
+	var gopts curveOptions
 
-func SCWithConstants(path string) (StarkCurve, error) {
-	err := InitWithConstants(path)
-	return sc, err
+	for _, opt := range opts {
+		opt.apply(&gopts)
+	}
+
+	if gopts.initConstants {
+		err := InitWithConstants(gopts.paramsPath)
+		return sc, err
+	} else {
+		InitCurve()
+		return sc, nil
+	}
 }
 
 /*

--- a/curve_test.go
+++ b/curve_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestPedersenHash(t *testing.T) {
-	curve, err := SCWithConstants("./pedersen_params.json")
+	curve, err := SC(WithConstants("./pedersen_params.json"))
 	if err != nil {
 		t.Errorf("Could not init with constant points: %v\n", err)
 	}
@@ -33,7 +33,7 @@ func TestPedersenHash(t *testing.T) {
 }
 
 func BenchmarkPedersenHash(b *testing.B) {
-	curve, _ := SCWithConstants("./pedersen_params.json")
+	curve, _ := SC(WithConstants("./pedersen_params.json"))
 
 	var suite [][]*big.Int
 	suite = append(suite, []*big.Int{HexToBN("0x12773"), HexToBN("0x872362")})
@@ -51,7 +51,7 @@ func BenchmarkPedersenHash(b *testing.B) {
 }
 
 func TestInitCurveWithConstants(t *testing.T) {
-	curve, err := SCWithConstants("./pedersen_params.json")
+	curve, err := SC(WithConstants("./pedersen_params.json"))
 	if err != nil {
 		t.Errorf("Could not init with constant points: %v\n", err)
 	}
@@ -68,7 +68,7 @@ func TestInitCurveWithConstants(t *testing.T) {
 }
 
 func TestDivMod(t *testing.T) {
-	curve := SC()
+	curve, _ := SC()
 	inX, _ := new(big.Int).SetString("311379432064974854430469844112069886938521247361583891764940938105250923060", 10)
 	inY, _ := new(big.Int).SetString("621253665351494585790174448601059271924288186997865022894315848222045687999", 10)
 	DIVMODRES, _ := new(big.Int).SetString("2577265149861519081806762825827825639379641276854712526969977081060187505740", 10)
@@ -80,7 +80,7 @@ func TestDivMod(t *testing.T) {
 }
 
 func TestAdd(t *testing.T) {
-	curve := SC()
+	curve, _ := SC()
 	pub0, _ := new(big.Int).SetString("1468732614996758835380505372879805860898778283940581072611506469031548393285", 10)
 	pub1, _ := new(big.Int).SetString("1402551897475685522592936265087340527872184619899218186422141407423956771926", 10)
 	EXPX, _ := new(big.Int).SetString("2573054162739002771275146649287762003525422629677678278801887452213127777391", 10)
@@ -97,7 +97,7 @@ func TestAdd(t *testing.T) {
 }
 
 func TestMultAir(t *testing.T) {
-	curve := SC()
+	curve, _ := SC()
 	ry, _ := new(big.Int).SetString("2458502865976494910213617956670505342647705497324144349552978333078363662855", 10)
 	pubx, _ := new(big.Int).SetString("1468732614996758835380505372879805860898778283940581072611506469031548393285", 10)
 	puby, _ := new(big.Int).SetString("1402551897475685522592936265087340527872184619899218186422141407423956771926", 10)
@@ -119,7 +119,7 @@ func TestMultAir(t *testing.T) {
 }
 
 func TestGetY(t *testing.T) {
-	curve := SC()
+	curve, _ := SC()
 	h, _ := HexToBytes("04033f45f07e1bd1a51b45fc24ec8c8c9908db9e42191be9e169bfcac0c0d997450319d0f53f6ca077c4fa5207819144a2a4165daef6ee47a7c1d06c0dcaa3e456")
 	x, y := elliptic.Unmarshal(curve, h)
 

--- a/examples/starkcurve/go.mod
+++ b/examples/starkcurve/go.mod
@@ -1,0 +1,12 @@
+module github.com/dontpanicdao/caigo/examples/starkcurve
+
+go 1.18
+
+replace github.com/dontpanicdao/caigo => ../../
+
+require github.com/dontpanicdao/caigo v0.2.0
+
+require (
+	golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2 // indirect
+	golang.org/x/sys v0.0.0-20211019181941-9d821ace8654 // indirect
+)

--- a/examples/starkcurve/go.sum
+++ b/examples/starkcurve/go.sum
@@ -1,0 +1,9 @@
+golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2 h1:It14KIkyBFYkHkwZ7k45minvA9aorojkyjGk9KJ5B/w=
+golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
+golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20211019181941-9d821ace8654 h1:id054HUawV2/6IGm2IV8KZQjqtwAOo2CYlOToYqa0d0=
+golang.org/x/sys v0.0.0-20211019181941-9d821ace8654/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/examples/starkcurve/main.go
+++ b/examples/starkcurve/main.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/dontpanicdao/caigo"
+)
+
+func main() {
+	/* 
+		Although the library adheres to the 'elliptic/curve' interface. 
+		All testing has been done against library function explicity. 
+		It is recommended to use in the same way(i.e. `curve.Sign` and not `ecdsa.Sign`).
+		NOTE: when not given local file path this pulls the curve data from Starkware github repo
+	*/
+	curve, err := caigo.SC(caigo.WithConstants())
+	if err != nil {
+		panic(err.Error())
+	}
+
+	hash, err := curve.PedersenHash([]*big.Int{caigo.HexToBN("0x12773"), caigo.HexToBN("0x872362")})
+	if err != nil {
+		panic(err.Error())
+	}
+
+	priv, _ := curve.GetRandomPrivateKey()
+
+	x, y, err := curve.PrivateToPoint(priv)
+	if err != nil {
+		panic(err.Error())
+	}
+
+	r, s, err := curve.Sign(hash, priv)
+	if err != nil {
+		panic(err.Error())
+	}
+
+	if curve.Verify(hash, r, s, x, y) {
+		fmt.Println("signature is valid")
+	} else {
+		fmt.Println("signature is invalid")
+	}
+}

--- a/examples/starknet/go.mod
+++ b/examples/starknet/go.mod
@@ -1,0 +1,12 @@
+module github.com/dontpanicdao/caigo/examples/starknet
+
+go 1.18
+
+replace github.com/dontpanicdao/caigo => ../../
+
+require github.com/dontpanicdao/caigo v0.2.0
+
+require (
+	golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2 // indirect
+	golang.org/x/sys v0.0.0-20211019181941-9d821ace8654 // indirect
+)

--- a/examples/starknet/go.sum
+++ b/examples/starknet/go.sum
@@ -1,0 +1,9 @@
+golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2 h1:It14KIkyBFYkHkwZ7k45minvA9aorojkyjGk9KJ5B/w=
+golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
+golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20211019181941-9d821ace8654 h1:id054HUawV2/6IGm2IV8KZQjqtwAOo2CYlOToYqa0d0=
+golang.org/x/sys v0.0.0-20211019181941-9d821ace8654/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/examples/starknet/main.go
+++ b/examples/starknet/main.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"fmt"
+	"context"
+
+	"github.com/dontpanicdao/caigo"
+)
+
+func main() {
+	// init the stark curve with constants
+	// 'WithConstants()' will pull the StarkNet 'pedersen_params.json' file if you don't have it locally
+	curve, err := caigo.SC(caigo.WithConstants())
+	if err != nil {
+		panic(err.Error())
+	}
+	
+	// init starknet gateway client
+	gw := caigo.NewGateway() //defaults to goerli
+
+	// get random value for salt
+	priv, _ := curve.GetRandomPrivateKey()
+
+	// deploy StarkNet contract with random salt
+	deployRequest := caigo.DeployRequest{
+		ContractAddressSalt: caigo.BigToHex(priv),
+		ConstructorCalldata: []string{},
+	}
+
+	// example: https://github.com/starknet-edu/ultimate-env/blob/main/counter.cairo
+	// starknet-compile counter.cairo --output counter_compiled.json --abi counter_abi.json
+	deployResponse, err := gw.Deploy(context.Background(), "counter_compiled.json", deployRequest)
+	if err != nil {
+		panic(err.Error())
+	}
+	fmt.Printf("Deployment Response: \n\t%+v\n\n", deployResponse)
+
+	// poll until the desired transaction status
+	pollInterval := 5
+	n, status, err := gw.PollTx(context.Background(), deployResponse.TransactionHash, caigo.ACCEPTED_ON_L2, pollInterval, 150)
+	if err != nil {
+		panic(err.Error())
+	}
+	fmt.Printf("Poll %dsec %dx \n\ttransaction(%s) status: %s\n\n", n * pollInterval, n, deployResponse.TransactionHash, status)
+
+	// fetch transaction details
+	tx, err := gw.Transaction(context.Background(), deployResponse.TransactionHash)
+	if err != nil {
+		panic(err.Error())
+	}
+
+	// call StarkNet contract
+	callResp, err := gw.Call(context.Background(), caigo.StarknetRequest{
+		ContractAddress:    tx.Transaction.ContractAddress,
+		EntryPointSelector: caigo.BigToHex(caigo.GetSelectorFromName("get_count")),
+	})
+	if err != nil {
+		panic(err.Error())
+	}
+	fmt.Println("Counter is currently at: ", callResp[0])
+	
+	// invoke StarkNet contract external function
+	invResp, err := gw.Invoke(context.Background(), caigo.StarknetRequest{
+		ContractAddress:    tx.Transaction.ContractAddress,
+		EntryPointSelector: caigo.BigToHex(caigo.GetSelectorFromName("increment")),
+	})
+	if err != nil {
+		panic(err.Error())
+	}
+
+	n, status, err = gw.PollTx(context.Background(), invResp.TransactionHash, caigo.ACCEPTED_ON_L2, 5, 150)
+	if err != nil {
+		panic(err.Error())
+	}
+	fmt.Printf("Poll %dsec %dx \n\ttransaction(%s) status: %s\n\n", n * pollInterval, n, deployResponse.TransactionHash, status)
+
+	callResp, err = gw.Call(context.Background(), caigo.StarknetRequest{
+		ContractAddress:    tx.Transaction.ContractAddress,
+		EntryPointSelector: caigo.BigToHex(caigo.GetSelectorFromName("get_count")),
+	})
+	if err != nil {
+		panic(err.Error())
+	}
+	fmt.Println("Counter is currently at: ", callResp[0])
+}

--- a/opts.go
+++ b/opts.go
@@ -9,6 +9,11 @@ type gatewayOptions struct {
 	chainID string
 }
 
+type curveOptions struct {
+	initConstants bool
+	paramsPath    string
+}
+
 // funcGatewayOption wraps a function that modifies gatewayOptions into an
 // implementation of the GatewayOption interface.
 type funcGatewayOption struct {
@@ -39,5 +44,37 @@ func WithHttpClient(client http.Client) GatewayOption {
 func WithChain(chainID string) GatewayOption {
 	return newFuncGatewayOption(func(o *gatewayOptions) {
 		o.chainID = chainID
+	})
+}
+
+// funcCurveOptions wraps a function that modifies curveOptions into an
+// implementation of the CurveOption interface.
+type funcCurveOption struct {
+	f func(*curveOptions)
+}
+
+func (fso *funcCurveOption) apply(do *curveOptions) {
+	fso.f(do)
+}
+
+func newFuncCurveOption(f func(*curveOptions)) *funcCurveOption {
+	return &funcCurveOption{
+		f: f,
+	}
+}
+
+type CurveOption interface {
+	apply(*curveOptions)
+}
+
+// functions that require pedersen hashes must be run on
+// a curve initialized with constant points
+func WithConstants(paramsPath ...string) CurveOption {
+	return newFuncCurveOption(func(o *curveOptions) {
+		o.initConstants = true
+
+		if len(paramsPath) == 1 && paramsPath[0] != "" {
+			o.paramsPath = paramsPath[0]
+		}
 	})
 }

--- a/sn_test.go
+++ b/sn_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestExecuteGoerli(t *testing.T) {
-	curve, err := SCWithConstants("./pedersen_params.json")
+	curve, err := SC(WithConstants("./pedersen_params.json"))
 	if err != nil {
 		t.Errorf("Could not init with constant points: %v\n", err)
 	}
@@ -64,7 +64,7 @@ func TestInvokeContract(t *testing.T) {
 func TestLocalStarkNet(t *testing.T) {
 	setupTestEnvironment()
 
-	curve := SC()
+	curve, _ := SC()
 
 	gw := NewGateway(WithChain("local"))
 

--- a/typed_test.go
+++ b/typed_test.go
@@ -52,7 +52,7 @@ func MockTypedData() (ttd TypedData) {
 func TestGetMessageHash(t *testing.T) {
 	ttd := MockTypedData()
 
-	curve, err := SCWithConstants("./pedersen_params.json")
+	curve, err := SC(WithConstants("./pedersen_params.json"))
 	if err != nil {
 		t.Errorf("Could not init with constant points: %v\n", err)
 	}
@@ -83,7 +83,7 @@ func TestGetMessageHash(t *testing.T) {
 func BenchmarkGetMessageHash(b *testing.B) {
 	ttd := MockTypedData()
 
-	curve, _ := SCWithConstants("./pedersen_params.json")
+	curve, _ := SC(WithConstants("./pedersen_params.json"))
 
 	mail := Mail{
 		From: Person{
@@ -105,7 +105,7 @@ func BenchmarkGetMessageHash(b *testing.B) {
 func TestGetDomainHash(t *testing.T) {
 	ttd := MockTypedData()
 
-	curve, err := SCWithConstants("./pedersen_params.json")
+	curve, err := SC(WithConstants("./pedersen_params.json"))
 	if err != nil {
 		t.Errorf("Could not init with constant points: %v\n", err)
 	}
@@ -137,7 +137,7 @@ func TestGetTypedMessageHash(t *testing.T) {
 		Contents: "Hello, Bob!",
 	}
 
-	curve, err := SCWithConstants("./pedersen_params.json")
+	curve, err := SC(WithConstants("./pedersen_params.json"))
 	if err != nil {
 		t.Errorf("Could not init with constant points: %v\n", err)
 	}


### PR DESCRIPTION
- GatewayOptions implementation for the StarkCurve
  - deprecate 'SCWithConstants'

- Break examples out from the README