### PR TITLE
refactor(gateway): client abstraction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ vendor/
 tmp/
 
 examples/**/*.json
+examples/**/*.sum

--- a/README.md
+++ b/README.md
@@ -28,12 +28,14 @@ Caigo is currently under active development and will under go breaking changes u
 starkcurve
 ```go
 cd examples/starkcurve
+go mod tidy
 go run main.go
 ```
 
 starknet
 ```go
 cd examples/starknet
+go mod tidy
 wget https://github.com/starknet-edu/ultimate-env/blob/main/counter.cairo
 python3.7 -m venv ~/cairo_venv; source ~/cairo_venv/bin/activate; export STARKNET_NETWORK=alpha-goerli
 starknet-compile counter.cairo --output counter_compiled.json --abi counter_abi.json

--- a/block.go
+++ b/block.go
@@ -1,0 +1,44 @@
+package caigo
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/google/go-querystring/query"
+)
+
+type Block struct {
+	BlockHash           string               `json:"block_hash"`
+	ParentBlockHash     string               `json:"parent_block_hash"`
+	BlockNumber         int                  `json:"block_number"`
+	StateRoot           string               `json:"state_root"`
+	Status              string               `json:"status"`
+	Transactions        []JSTransaction      `json:"transactions"`
+	Timestamp           int                  `json:"timestamp"`
+	TransactionReceipts []TransactionReceipt `json:"transaction_receipts"`
+}
+
+type BlockOptions struct {
+	BlockNumber int    `url:"blockNumber,omitempty"`
+	BlockHash   string `url:"blockHash,omitempty"`
+}
+
+// Gets the block information from a block ID.
+//
+// [Reference](https://github.com/starkware-libs/cairo-lang/blob/f464ec4797361b6be8989e36e02ec690e74ef285/src/starkware/starknet/services/api/feeder_gateway/feeder_gateway_client.py#L27-L31)
+func (sg *StarknetGateway) Block(ctx context.Context, opts *BlockOptions) (*Block, error) {
+	req, err := sg.newRequest(ctx, http.MethodGet, "/get_block", nil)
+	if err != nil {
+		return nil, err
+	}
+	if opts != nil {
+		vs, err := query.Values(opts)
+		if err != nil {
+			return nil, err
+		}
+		appendQueryValues(req, vs)
+	}
+
+	var resp Block
+	return &resp, sg.do(req, &resp)
+}

--- a/examples/starkcurve/go.mod
+++ b/examples/starkcurve/go.mod
@@ -7,6 +7,7 @@ replace github.com/dontpanicdao/caigo => ../../
 require github.com/dontpanicdao/caigo v0.2.0
 
 require (
+	github.com/google/go-querystring v1.1.0 // indirect
 	golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2 // indirect
 	golang.org/x/sys v0.0.0-20211019181941-9d821ace8654 // indirect
 )

--- a/examples/starkcurve/go.sum
+++ b/examples/starkcurve/go.sum
@@ -1,9 +1,0 @@
-golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2 h1:It14KIkyBFYkHkwZ7k45minvA9aorojkyjGk9KJ5B/w=
-golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
-golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
-golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20211019181941-9d821ace8654 h1:id054HUawV2/6IGm2IV8KZQjqtwAOo2CYlOToYqa0d0=
-golang.org/x/sys v0.0.0-20211019181941-9d821ace8654/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
-golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/examples/starknet/go.mod
+++ b/examples/starknet/go.mod
@@ -7,6 +7,7 @@ replace github.com/dontpanicdao/caigo => ../../
 require github.com/dontpanicdao/caigo v0.2.0
 
 require (
+	github.com/google/go-querystring v1.1.0 // indirect
 	golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2 // indirect
 	golang.org/x/sys v0.0.0-20211019181941-9d821ace8654 // indirect
 )

--- a/examples/starknet/go.sum
+++ b/examples/starknet/go.sum
@@ -1,9 +1,0 @@
-golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2 h1:It14KIkyBFYkHkwZ7k45minvA9aorojkyjGk9KJ5B/w=
-golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
-golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
-golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20211019181941-9d821ace8654 h1:id054HUawV2/6IGm2IV8KZQjqtwAOo2CYlOToYqa0d0=
-golang.org/x/sys v0.0.0-20211019181941-9d821ace8654/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
-golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/gateway.go
+++ b/gateway.go
@@ -1,0 +1,144 @@
+package caigo
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+type StarknetGateway struct {
+	Base         string `json:"base"`
+	Feeder       string `json:"feeder"`
+	Gateway      string `json:"gateway"`
+	ChainId      string `json:"chainId"`
+	client       *http.Client
+	errorHandler func(e error) error
+}
+
+/*
+	Instantiate a new StarkNet Gateway client
+	- defaults to the GOERLI endpoints
+*/
+func NewGateway(opts ...GatewayOption) *StarknetGateway {
+	gopts := gatewayOptions{
+		chainID: GOERLI_ID,
+		client:  http.DefaultClient,
+	}
+
+	for _, opt := range opts {
+		opt.apply(&gopts)
+	}
+
+	var sg *StarknetGateway
+	switch id := strings.ToLower(gopts.chainID); {
+	case strings.Contains("main", id):
+		sg = &StarknetGateway{
+			Base:    MAINNET_BASE,
+			Feeder:  MAINNET_BASE + "/feeder_gateway",
+			Gateway: MAINNET_BASE + "/gateway",
+			ChainId: MAINNET_ID,
+		}
+	case strings.Contains("local", id):
+		fallthrough
+	case strings.Contains("dev", id):
+		sg = &StarknetGateway{
+			Base:    LOCAL_BASE,
+			Feeder:  LOCAL_BASE + "/feeder_gateway",
+			Gateway: LOCAL_BASE + "/gateway",
+			ChainId: GOERLI_ID,
+		}
+	default:
+		sg = &StarknetGateway{
+			Base:    GOERLI_BASE,
+			Feeder:  GOERLI_BASE + "/feeder_gateway",
+			Gateway: GOERLI_BASE + "/gateway",
+			ChainId: GOERLI_ID,
+		}
+	}
+
+	sg.client = gopts.client
+
+	return sg
+}
+
+func (sg *StarknetGateway) newRequest(
+	ctx context.Context, method, endpoint string, body interface{},
+) (*http.Request, error) {
+	req, err := http.NewRequestWithContext(ctx, method, sg.Feeder+endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			return nil, fmt.Errorf("marshal body: %w", err)
+		}
+		req.Body = ioutil.NopCloser(bytes.NewBuffer(data))
+		req.Header.Add("Content-Type", "application/json; charset=utf")
+	}
+	return req, nil
+}
+
+type Error struct {
+	StatusCode int    `json:"-"`
+	Body       []byte `json:"-"`
+
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+// Error implements the error interface.
+func (e Error) Error() string {
+	return fmt.Sprintf("%d: %s %s", e.StatusCode, e.Code, e.Message)
+}
+
+// NewError creates a new Error from an API response.
+func NewError(resp *http.Response) error {
+	apiErr := Error{StatusCode: resp.StatusCode}
+	data, err := ioutil.ReadAll(resp.Body)
+	if err == nil && data != nil {
+		apiErr.Body = data
+		if err := json.Unmarshal(data, &apiErr); err != nil {
+			apiErr.Code = "unknown_error_format"
+			apiErr.Message = string(data)
+		}
+	}
+	return &apiErr
+}
+
+func (sg *StarknetGateway) do(req *http.Request, v interface{}) error {
+	resp, err := sg.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close() // nolint: errcheck
+
+	if resp.StatusCode >= 299 {
+		e := NewError(resp)
+		if sg.errorHandler != nil {
+			return sg.errorHandler(e)
+		}
+		return e
+	}
+
+	if v != nil {
+		return json.NewDecoder(resp.Body).Decode(v)
+	}
+	return nil
+}
+
+func appendQueryValues(req *http.Request, values url.Values) {
+	q := req.URL.Query()
+	for k, vs := range values {
+		for _, v := range vs {
+			q.Add(k, v)
+		}
+	}
+	req.URL.RawQuery = q.Encode()
+}

--- a/go.mod
+++ b/go.mod
@@ -4,4 +4,7 @@ go 1.17
 
 require golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2
 
-require golang.org/x/sys v0.0.0-20211019181941-9d821ace8654 // indirect
+require (
+	github.com/google/go-querystring v1.1.0
+	golang.org/x/sys v0.0.0-20211019181941-9d821ace8654 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,6 @@
+github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
+github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2 h1:It14KIkyBFYkHkwZ7k45minvA9aorojkyjGk9KJ5B/w=
 golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
@@ -7,3 +10,4 @@ golang.org/x/sys v0.0.0-20211019181941-9d821ace8654/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/opts.go
+++ b/opts.go
@@ -52,7 +52,7 @@ func WithChain(chainID string) GatewayOption {
 func WithErrorHandler(f func(e error) error) GatewayOption {
 	return newFuncGatewayOption(func(o *gatewayOptions) {
 		o.errorHandler = f
-  })
+	})
 }
 
 // funcCurveOptions wraps a function that modifies curveOptions into an

--- a/opts.go
+++ b/opts.go
@@ -5,8 +5,9 @@ import (
 )
 
 type gatewayOptions struct {
-	client  *http.Client
-	chainID string
+	client       *http.Client
+	chainID      string
+	errorHandler func(e error) error
 }
 
 // funcGatewayOption wraps a function that modifies gatewayOptions into an
@@ -39,5 +40,12 @@ func WithHttpClient(client http.Client) GatewayOption {
 func WithChain(chainID string) GatewayOption {
 	return newFuncGatewayOption(func(o *gatewayOptions) {
 		o.chainID = chainID
+	})
+}
+
+// WithErrorHandler returns an Option to set the error handler to be used.
+func WithErrorHandler(f func(e error) error) GatewayOption {
+	return newFuncGatewayOption(func(o *gatewayOptions) {
+		o.errorHandler = f
 	})
 }

--- a/sn_models.go
+++ b/sn_models.go
@@ -2,7 +2,6 @@ package caigo
 
 import (
 	"math/big"
-	"net/http"
 	"strings"
 )
 
@@ -64,25 +63,6 @@ type Transaction struct {
 	TransactionHash    *big.Int   `json:"transaction_hash"`
 	Type               string     `json:"type"`
 	Nonce              *big.Int   `json:"nonce,omitempty"`
-}
-
-type StarknetGateway struct {
-	Base    string `json:"base"`
-	Feeder  string `json:"feeder"`
-	Gateway string `json:"gateway"`
-	ChainId string `json:"chainId"`
-	client  *http.Client
-}
-
-type Block struct {
-	BlockHash           string               `json:"block_hash"`
-	ParentBlockHash     string               `json:"parent_block_hash"`
-	BlockNumber         int                  `json:"block_number"`
-	StateRoot           string               `json:"state_root"`
-	Status              string               `json:"status"`
-	Transactions        []JSTransaction      `json:"transactions"`
-	Timestamp           int                  `json:"timestamp"`
-	TransactionReceipts []TransactionReceipt `json:"transaction_receipts"`
 }
 
 type TransactionReceipt struct {

--- a/sn_test.go
+++ b/sn_test.go
@@ -90,7 +90,7 @@ func TestLocalStarkNet(t *testing.T) {
 		t.Errorf("Could not get tx receipt: %v\n", err)
 	}
 
-	block, err := gw.Block(context.Background(), tx.BlockHash)
+	block, err := gw.Block(context.Background(), &BlockOptions{BlockHash: tx.BlockHash})
 	if err != nil || block.Status != "ACCEPTED_ON_L2" {
 		t.Errorf("Could not get block by hash: %v\n", err)
 	}


### PR DESCRIPTION
this proposes a different client abstraction, taken from my original implementation at `go-starknet`.

- makes the api interfaces safer and more explicit. 
- uses a custom error type that allows callers to easily match errors while still including useful dynamic context.
- encapsulates common components in their own file so it is easier to grok the code

if you like this approach, i can apply the same changes to other endpoints