### PR TITLE
manage shorter than 32-byte SplitFactStr

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -1,6 +1,7 @@
 package caigo
 
 import (
+	"bytes"
 	"crypto/hmac"
 	"crypto/rand"
 	"encoding/hex"
@@ -221,6 +222,8 @@ func ComputeFact(programHash *big.Int, programOutputs []*big.Int) *big.Int {
 func SplitFactStr(fact string) (fact_low, fact_high string) {
 	factBN := HexToBN(fact)
 	factBytes := factBN.Bytes()
+	lpadfactBytes := bytes.Repeat([]byte{0x00}, 32-len(factBytes))
+	factBytes = append(lpadfactBytes, factBytes...)
 	low := BytesToBig(factBytes[16:])
 	high := BytesToBig(factBytes[:16])
 	return BigToHex(low), BigToHex(high)

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,0 +1,21 @@
+package caigo
+
+import (
+	"testing"
+)
+
+func TestSplitFactStr(t *testing.T) {
+	data := []map[string]string{
+		{"input": "0x3", "h": "0x0", "l": "0x3"},
+		{"input": "0x300000000000000000000000000000000", "h": "0x3", "l": "0x0"},
+	}
+	for _, d := range data {
+		l, h := SplitFactStr(d["input"]) // 0x3
+		if l != d["l"] {
+			t.Errorf("expected %s, got %s", d["l"], l)
+		}
+		if h != d["h"] {
+			t.Errorf("expected %s, got %s", d["h"], h)
+		}
+	}
+}


### PR DESCRIPTION
This PR addresses the limit referenced in #22 with `SplitFactStr`