### PR TITLE
add the the errorHandler option to the gateway

### DIFF
--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -73,6 +73,7 @@ func NewClient(opts ...Option) *Gateway {
 	}
 
 	sg.client = gopts.client
+	sg.errorHandler = gopts.errorHandler
 
 	return sg
 }

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -73,7 +73,7 @@ func NewClient(opts ...Option) *Gateway {
 	}
 
 	sg.client = gopts.client
-	// sg.errorHandler = gopts.errorHandler
+	sg.errorHandler = gopts.errorHandler
 
 	return sg
 }

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -73,7 +73,7 @@ func NewClient(opts ...Option) *Gateway {
 	}
 
 	sg.client = gopts.client
-	sg.errorHandler = gopts.errorHandler
+	// sg.errorHandler = gopts.errorHandler
 
 	return sg
 }

--- a/gateway/opts_test.go
+++ b/gateway/opts_test.go
@@ -1,0 +1,30 @@
+package gateway
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+)
+
+func TestWithErrorHandler(t *testing.T) {
+	spy := false
+	spyPtr := &spy
+
+	opt := WithErrorHandler(func(err error) error {
+		*spyPtr = true
+		fmt.Print("spy triggered\n")
+		return err
+	})
+
+	client := NewClient(opt)
+	var result string
+	request, _ := http.NewRequest(http.MethodGet, "https://httpstat.us/400", nil)
+	err := client.do(request, &result)
+
+	if err == nil {
+		t.Errorf("should fail due to http-400")
+	}
+	if !*spyPtr {
+		t.Errorf("spy should be true, got %t", *spyPtr)
+	}
+}

--- a/gateway/opts_test.go
+++ b/gateway/opts_test.go
@@ -1,7 +1,6 @@
 package gateway
 
 import (
-	"fmt"
 	"net/http"
 	"testing"
 )
@@ -12,7 +11,6 @@ func TestWithErrorHandler(t *testing.T) {
 
 	opt := WithErrorHandler(func(err error) error {
 		*spyPtr = true
-		fmt.Print("spy triggered\n")
 		return err
 	})
 


### PR DESCRIPTION
My understanding is that we are missing the code that set the errorHandler from the options when instantiating a *Gateway with NewClient. I could have provided a default function that would be,`func(err error) error {return err}` but since the function is only used in `do` and there is a test to check the function exists, it can be avoided.
