### PR TITLE
implement and test starknet_getStorageAt

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Implementation status:
 | `starknet_getBlockTransactionCountByNumber` | :x: |
 | `starknet_getTransactionByBlockNumberAndIndex` | :x: |
 | `starknet_getTransactionByBlockHashAndIndex` | :x: |
-| `starknet_getStorageAt` | :x: |
+| `starknet_getStorageAt` | :heavy_check_mark: |
 | `starknet_getStateUpdateByHash` | :x: |
 
 ### Run Examples

--- a/rpc/api.go
+++ b/rpc/api.go
@@ -3,6 +3,7 @@ package rpc
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"math/big"
 
 	"github.com/dontpanicdao/caigo"
@@ -124,6 +125,14 @@ func (sc *Client) ClassHashAt(ctx context.Context, address string) (string, erro
 	}
 
 	return *result, nil
+}
+
+// GetStorageAt gets the value of the storage at the given address and key.
+func (sc *Client) GetStorageAt(ctx context.Context, contractAddress, key, blockHashOrTag string) (string, error) {
+	var value string
+	hashKey := fmt.Sprintf("0x%s", caigo.GetSelectorFromName(key).Text(16))
+	err := sc.do(ctx, "starknet_getStorageAt", &value, contractAddress, hashKey, blockHashOrTag)
+	return value, err
 }
 
 // TransactionByHash gets the details and status of a submitted transaction.

--- a/rpc/api.go
+++ b/rpc/api.go
@@ -131,8 +131,8 @@ func (sc *Client) ClassHashAt(ctx context.Context, address string) (string, erro
 func (sc *Client) StorageAt(ctx context.Context, contractAddress, key, blockHashOrTag string) (string, error) {
 	var value string
 	hashKey := fmt.Sprintf("0x%s", caigo.GetSelectorFromName(key).Text(16))
-		if err := sc.do(ctx, "starknet_getStorageAt", &value, contractAddress, hashKey, blockHashOrTag); err != nil {
-		return nil, err
+	if err := sc.do(ctx, "starknet_getStorageAt", &value, contractAddress, hashKey, blockHashOrTag); err != nil {
+		return "", err
 	}
 
 	return value, nil
@@ -143,7 +143,8 @@ func (sc *Client) TransactionByHash(ctx context.Context, hash string) (*types.Tr
 	var tx types.Transaction
 	if err := sc.do(ctx, "starknet_getTransactionByHash", &tx, hash); err != nil {
 		return nil, err
-	} else if tx.TransactionHash == "" {
+	}
+	if tx.TransactionHash == "" {
 		return nil, ErrNotFound
 	}
 

--- a/rpc/api.go
+++ b/rpc/api.go
@@ -128,7 +128,7 @@ func (sc *Client) ClassHashAt(ctx context.Context, address string) (string, erro
 }
 
 // GetStorageAt gets the value of the storage at the given address and key.
-func (sc *Client) GetStorageAt(ctx context.Context, contractAddress, key, blockHashOrTag string) (string, error) {
+func (sc *Client) StorageAt(ctx context.Context, contractAddress, key, blockHashOrTag string) (string, error) {
 	var value string
 	hashKey := fmt.Sprintf("0x%s", caigo.GetSelectorFromName(key).Text(16))
 	err := sc.do(ctx, "starknet_getStorageAt", &value, contractAddress, hashKey, blockHashOrTag)

--- a/rpc/api.go
+++ b/rpc/api.go
@@ -131,8 +131,11 @@ func (sc *Client) ClassHashAt(ctx context.Context, address string) (string, erro
 func (sc *Client) StorageAt(ctx context.Context, contractAddress, key, blockHashOrTag string) (string, error) {
 	var value string
 	hashKey := fmt.Sprintf("0x%s", caigo.GetSelectorFromName(key).Text(16))
-	err := sc.do(ctx, "starknet_getStorageAt", &value, contractAddress, hashKey, blockHashOrTag)
-	return value, err
+		if err := sc.do(ctx, "starknet_getStorageAt", &value, contractAddress, hashKey, blockHashOrTag); err != nil {
+		return nil, err
+	}
+
+	return value, nil
 }
 
 // TransactionByHash gets the details and status of a submitted transaction.

--- a/rpc/api_contract_test.go
+++ b/rpc/api_contract_test.go
@@ -193,7 +193,6 @@ func TestClass(t *testing.T) {
 // TestGetStorageAt tests GetStorageAt
 func TestGetStorageAt(t *testing.T) {
 	testConfig := beforeEach(t)
-	defer testConfig.client.Close()
 
 	type testSetType struct {
 		ContractHash   string

--- a/rpc/api_contract_test.go
+++ b/rpc/api_contract_test.go
@@ -229,7 +229,7 @@ func TestGetStorageAt(t *testing.T) {
 	}[testEnv]
 
 	for _, test := range testSet {
-		value, err := testConfig.client.GetStorageAt(context.Background(), test.ContractHash, test.StorageKey, test.BlockHashOrTag)
+		value, err := testConfig.client.StorageAt(context.Background(), test.ContractHash, test.StorageKey, test.BlockHashOrTag)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/rpc/api_contract_test.go
+++ b/rpc/api_contract_test.go
@@ -189,3 +189,52 @@ func TestClass(t *testing.T) {
 		}
 	}
 }
+
+// TestGetStorageAt tests GetStorageAt
+func TestGetStorageAt(t *testing.T) {
+	testConfig := beforeEach(t)
+	defer testConfig.client.Close()
+
+	type testSetType struct {
+		ContractHash   string
+		StorageKey     string
+		BlockHashOrTag string
+		ExpectedValue  string
+	}
+	testSet := map[string][]testSetType{
+		"mock": {
+			{
+				ContractHash:   "0xdeadbeef",
+				StorageKey:     "_signer",
+				BlockHashOrTag: "latest",
+				ExpectedValue:  "0xdeadbeef",
+			},
+		},
+		"testnet": {
+			{
+				ContractHash:   "0x6fbd460228d843b7fbef670ff15607bf72e19fa94de21e29811ada167b4ca39",
+				StorageKey:     "balance",
+				BlockHashOrTag: "latest",
+				ExpectedValue:  "0x1e240",
+			},
+		},
+		"mainnet": {
+			{
+				ContractHash:   "0x8d17e6a3B92a2b5Fa21B8e7B5a3A794B05e06C5FD6C6451C6F2695Ba77101",
+				StorageKey:     "_signer",
+				BlockHashOrTag: "latest",
+				ExpectedValue:  "0x7f72660ca40b8ca85f9c0dd38db773f17da7a52f5fc0521cb8b8d8d44e224b8",
+			},
+		},
+	}[testEnv]
+
+	for _, test := range testSet {
+		value, err := testConfig.client.GetStorageAt(context.Background(), test.ContractHash, test.StorageKey, test.BlockHashOrTag)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if value != test.ExpectedValue {
+			t.Fatalf("expecting value %s, got %s", test.ExpectedValue, value)
+		}
+	}
+}

--- a/rpc/mock_test.go
+++ b/rpc/mock_test.go
@@ -51,6 +51,8 @@ func (r *rpcMock) CallContext(ctx context.Context, result interface{}, method st
 		return mock_starknet_getClass(result, method, args...)
 	case "starknet_getEvents":
 		return mock_starknet_getEvents(result, method, args...)
+	case "starknet_getStorageAt":
+		return mock_starknet_getStorageAt(result, method, args...)
 	case "starknet_call":
 		return mock_starknet_call(result, method, args...)
 	case "starknet_addDeployTransaction":
@@ -375,6 +377,28 @@ func mock_starknet_addDeployTransaction(result interface{}, method string, args 
 		TransactionHash: "0xdeadbeef",
 		ContractAddress: "0xdeadbeef",
 	}
+	outputContent, _ := json.Marshal(output)
+	json.Unmarshal(outputContent, r)
+	return nil
+}
+
+func mock_starknet_getStorageAt(result interface{}, method string, args ...interface{}) error {
+	r, ok := result.(*json.RawMessage)
+	if !ok {
+		return errWrongType
+	}
+	if len(args) != 3 {
+		fmt.Printf("args: %d\n", len(args))
+		return errWrongArgs
+	}
+	for i := range []int{1, 2, 3} {
+		_, ok = args[i].(string)
+		if !ok {
+			fmt.Printf("args[%d] should be string, got %T\n", i, args[i])
+			return errWrongArgs
+		}
+	}
+	output := "0xdeadbeef"
 	outputContent, _ := json.Marshal(output)
 	json.Unmarshal(outputContent, r)
 	return nil


### PR DESCRIPTION
This PR implements the starknet_getStorageAt verb as documented in [starknet_api_openrpc.json](https://github.com/starkware-libs/starknet-specs/blob/master/api/starknet_api_openrpc.json):

The function is called `StorageAt` to match the manifest:
- There are 3 input parameters that are contractAddress, key, blockHashOrTag. They all are strings.
- the key parameter is encoded by the method and you should pass the name key, like `_signer` or `balance`
- The output is the value from the @storage_var return in hexa with the `0x` prefix
