### PR TITLE
Implement starknet_getstateupdatebyhash

### DIFF
--- a/rpc/api.go
+++ b/rpc/api.go
@@ -138,6 +138,64 @@ func (sc *Client) StorageAt(ctx context.Context, contractAddress, key, blockHash
 	return value, nil
 }
 
+// StorageDiff is a change in a single storage item
+type StorageDiff struct {
+	// ContractAddress is the contract address for which the state changed
+	ContractAddress string `json:"address"`
+	// Key returns the key of the changed value
+	Key string `json:"key"`
+	// Value is the new value applied to the given address
+	Value string `json:"value"`
+}
+
+// ContractItem is a new contract added as part of the new state
+type ContractItem struct {
+	// ContractAddress is the address of the contract
+	Address string `json:"address"`
+	// ContractHash is the hash of the contract code
+	ContractHash string `json:"contract_hash"`
+}
+
+// Nonce is a the updated nonce per contract address
+type Nonce struct {
+	// ContractAddress is the address of the contract
+	ContractAddress string `json:"contract_address"`
+	// Nonce is the nonce for the given address at the end of the block"
+	Nonce string `json:"nonce"`
+}
+
+// StateDiff is the change in state applied in this block, given as a
+// mapping of addresses to the new values and/or new contracts.
+type StateDiff struct {
+	// StorageDiffs list storage changes
+	StorageDiffs []StorageDiff `json:"storage_diffs"`
+	// Contracts list new contracts added as part of the new state
+	Contracts []ContractItem `json:"contracts"`
+	// Nonces provides the updated nonces per contract addresses
+	Nonces []Nonce `json:"nonces"`
+}
+
+type GetStateUpdateOutput struct {
+	// BlockHash is the block identifier,
+	BlockHash string `json:"block_hash"`
+	// NewRoot is the new global state root.
+	NewRoot string `json:"new_root"`
+	// OldRoot is the previous global state root.
+	OldRoot string `json:"old_root"`
+	// AcceptedTime is when the block was accepted on L1.
+	AcceptedTime int `json:"accepted_time"`
+	// StateDiff is the change in state applied in this block, given as a
+	// mapping of addresses to the new values and/or new contracts.
+	StateDiff StateDiff `json:"state_diff"`
+}
+
+// GetStateUpdateByHash gets the information about the result of executing the requested block.
+func (sc *Client) GetStateUpdateByHash(ctx context.Context, blockHashOrTag string) (*GetStateUpdateOutput, error) {
+	var result GetStateUpdateOutput
+	err := sc.do(ctx, "starknet_getStateUpdateByHash", &result, blockHashOrTag)
+	return &result, err
+}
+
 // TransactionByHash gets the details and status of a submitted transaction.
 func (sc *Client) TransactionByHash(ctx context.Context, hash string) (*types.Transaction, error) {
 	var tx types.Transaction

--- a/rpc/api.go
+++ b/rpc/api.go
@@ -190,7 +190,7 @@ type GetStateUpdateOutput struct {
 }
 
 // GetStateUpdateByHash gets the information about the result of executing the requested block.
-func (sc *Client) GetStateUpdateByHash(ctx context.Context, blockHashOrTag string) (*GetStateUpdateOutput, error) {
+func (sc *Client) StateUpdateByHash(ctx context.Context, blockHashOrTag string) (*StateUpdateOutput, error) {
 	var result GetStateUpdateOutput
 	if err := sc.do(ctx, "starknet_getStateUpdateByHash", &result, blockHashOrTag); err != nil {
 		return nil, err

--- a/rpc/api.go
+++ b/rpc/api.go
@@ -141,7 +141,7 @@ func (sc *Client) StorageAt(ctx context.Context, contractAddress, key, blockHash
 // StorageDiff is a change in a single storage item
 type StorageDiff struct {
 	// ContractAddress is the contract address for which the state changed
-	ContractAddress string `json:"address"`
+	Address string `json:"address"`
 	// Key returns the key of the changed value
 	Key string `json:"key"`
 	// Value is the new value applied to the given address

--- a/rpc/api.go
+++ b/rpc/api.go
@@ -191,7 +191,7 @@ type StateUpdateOutput struct {
 
 // GetStateUpdateByHash gets the information about the result of executing the requested block.
 func (sc *Client) StateUpdateByHash(ctx context.Context, blockHashOrTag string) (*StateUpdateOutput, error) {
-	var result GetStateUpdateOutput
+	var result StateUpdateOutput
 	if err := sc.do(ctx, "starknet_getStateUpdateByHash", &result, blockHashOrTag); err != nil {
 		return nil, err
 	}

--- a/rpc/api.go
+++ b/rpc/api.go
@@ -175,7 +175,7 @@ type StateDiff struct {
 	Nonces []Nonce `json:"nonces"`
 }
 
-type GetStateUpdateOutput struct {
+type StateUpdateOutput struct {
 	// BlockHash is the block identifier,
 	BlockHash string `json:"block_hash"`
 	// NewRoot is the new global state root.

--- a/rpc/api.go
+++ b/rpc/api.go
@@ -192,8 +192,10 @@ type GetStateUpdateOutput struct {
 // GetStateUpdateByHash gets the information about the result of executing the requested block.
 func (sc *Client) GetStateUpdateByHash(ctx context.Context, blockHashOrTag string) (*GetStateUpdateOutput, error) {
 	var result GetStateUpdateOutput
-	err := sc.do(ctx, "starknet_getStateUpdateByHash", &result, blockHashOrTag)
-	return &result, err
+	if err := sc.do(ctx, "starknet_getStateUpdateByHash", &result, blockHashOrTag); err != nil {
+		return nil, err
+	}
+	return &result, nil
 }
 
 // TransactionByHash gets the details and status of a submitted transaction.

--- a/rpc/api_block_test.go
+++ b/rpc/api_block_test.go
@@ -179,7 +179,6 @@ func TestBlockByHash(t *testing.T) {
 // check when it is and test when it is the case.
 func TestGetStateUpdateByHash(t *testing.T) {
 	testConfig := beforeEach(t)
-	defer testConfig.client.Close()
 
 	type testSetType struct {
 		BlockHashOrTag string
@@ -196,7 +195,7 @@ func TestGetStateUpdateByHash(t *testing.T) {
 		t.Skip(fmt.Sprintf("not implemented on %s", testEnv))
 	}
 	for _, test := range testSet {
-		output, err := testConfig.client.GetStateUpdateByHash(context.Background(), test.BlockHashOrTag)
+		output, err := testConfig.client.StateUpdateByHash(context.Background(), test.BlockHashOrTag)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/rpc/api_block_test.go
+++ b/rpc/api_block_test.go
@@ -2,6 +2,7 @@ package rpc
 
 import (
 	"context"
+	"fmt"
 	"math/big"
 	"testing"
 )
@@ -168,6 +169,39 @@ func TestBlockByHash(t *testing.T) {
 			t.Fatalf("tx receipt mismatch, expect %s, got %s :",
 				test.ExpectedStatus,
 				block.Transactions[0].TransactionReceipt.Status)
+		}
+	}
+}
+
+// TestGetStateUpdateByHash tests GetStateUpdateByHash
+// TODO: this is not implemented yet with pathfinder as you can see from the
+// [code](https://github.com/eqlabs/pathfinder/blob/927183552dad6dcdfebac16c8c1d2baf019127b1/crates/pathfinder/rpc_examples.sh#L37)
+// check when it is and test when it is the case.
+func TestGetStateUpdateByHash(t *testing.T) {
+	testConfig := beforeEach(t)
+	defer testConfig.client.Close()
+
+	type testSetType struct {
+		BlockHashOrTag string
+	}
+	testSet := map[string][]testSetType{
+		"mock": {
+			{
+				BlockHashOrTag: "0xdeadbeef",
+			},
+		},
+	}[testEnv]
+
+	if len(testSet) == 0 {
+		t.Skip(fmt.Sprintf("not implemented on %s", testEnv))
+	}
+	for _, test := range testSet {
+		output, err := testConfig.client.GetStateUpdateByHash(context.Background(), test.BlockHashOrTag)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if output.BlockHash != test.BlockHashOrTag {
+			t.Fatalf("expecting block %s, got %s", test.BlockHashOrTag, output.BlockHash)
 		}
 	}
 }

--- a/rpc/mock_test.go
+++ b/rpc/mock_test.go
@@ -53,6 +53,8 @@ func (r *rpcMock) CallContext(ctx context.Context, result interface{}, method st
 		return mock_starknet_getEvents(result, method, args...)
 	case "starknet_getStorageAt":
 		return mock_starknet_getStorageAt(result, method, args...)
+	case "starknet_getStateUpdateByHash":
+		return mock_starknet_getStateUpdateByHash(result, method, args...)
 	case "starknet_call":
 		return mock_starknet_call(result, method, args...)
 	case "starknet_addDeployTransaction":
@@ -399,6 +401,28 @@ func mock_starknet_getStorageAt(result interface{}, method string, args ...inter
 		}
 	}
 	output := "0xdeadbeef"
+	outputContent, _ := json.Marshal(output)
+	json.Unmarshal(outputContent, r)
+	return nil
+}
+
+func mock_starknet_getStateUpdateByHash(result interface{}, method string, args ...interface{}) error {
+	r, ok := result.(*json.RawMessage)
+	if !ok {
+		return errWrongType
+	}
+	if len(args) != 1 {
+		fmt.Printf("args: %d\n", len(args))
+		return errWrongArgs
+	}
+	blockHash, ok := args[0].(string)
+	if !ok {
+		fmt.Printf("args[0] should be string, got %T\n", args[0])
+		return errWrongArgs
+	}
+	output := &GetStateUpdateOutput{
+		BlockHash: blockHash,
+	}
 	outputContent, _ := json.Marshal(output)
 	json.Unmarshal(outputContent, r)
 	return nil

--- a/rpc/mock_test.go
+++ b/rpc/mock_test.go
@@ -420,7 +420,7 @@ func mock_starknet_getStateUpdateByHash(result interface{}, method string, args 
 		fmt.Printf("args[0] should be string, got %T\n", args[0])
 		return errWrongArgs
 	}
-	output := &GetStateUpdateOutput{
+	output := &StateUpdateOutput{
 		BlockHash: blockHash,
 	}
 	outputContent, _ := json.Marshal(output)


### PR DESCRIPTION
`starknet_getstateupdatebyhash` is not yet implemented in pathfinder. I have coded the output as described in [starknet_api_openrpc.json](https://github.com/starkware-libs/starknet-specs/blob/master/api/starknet_api_openrpc.json) and created a mock with a test. I think we can push the PR as is and complete it once it can be fully implemented.