### PR TITLE
Implement and test additional RPC verbs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-<h1 align="center">Golang Library for StarkNet</h1>
+<
+1 align="center">Golang Library for StarkNet</h1>
 
 <p align="center">
     <a href="https://pkg.go.dev/github.com/dontpanicdao/caigo">
@@ -50,9 +51,9 @@ Implementation status:
 | `starknet_addDeclareTransaction` | :x: |
 | `starknet_traceTransaction` | :x: |
 | `starknet_traceBlockTransactions` | :x: |
-| `starknet_getNonce` | :x: |
+| `starknet_getNonce` (1) | :x: |
 | `starknet_protocolVersion` (1) | :x: |
-| `starknet_pendingTransactions` | :x: |
+| `starknet_pendingTransactions` (1) | :x: |
 | `starknet_estimateFee` | :x: |
 | `starknet_getBlockTransactionCountByHash` | :heavy_check_mark: |
 | `starknet_getBlockTransactionCountByNumber` | :heavy_check_mark: |

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Implementation status:
 | `starknet_traceTransaction` | :x: |
 | `starknet_traceBlockTransactions` | :x: |
 | `starknet_getNonce` | :x: |
-| `starknet_protocolVersion` | :x: |
+| `starknet_protocolVersion` (1) | :x: |
 | `starknet_pendingTransactions` | :x: |
 | `starknet_estimateFee` | :x: |
 | `starknet_getBlockTransactionCountByHash` | :heavy_check_mark: |
@@ -59,7 +59,9 @@ Implementation status:
 | `starknet_getTransactionByBlockNumberAndIndex` | :heavy_check_mark: |
 | `starknet_getTransactionByBlockHashAndIndex` | :heavy_check_mark: |
 | `starknet_getStorageAt` | :heavy_check_mark: |
-| `starknet_getStateUpdateByHash` | :x: |
+| `starknet_getStateUpdateByHash` (1) | :x: |
+
+(1) verbs that are not yet implemented by Pathfinder.
 
 ### Run Examples
 

--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ Implementation status:
 | `starknet_estimateFee` | :x: |
 | `starknet_getBlockTransactionCountByHash` | :x: |
 | `starknet_getBlockTransactionCountByNumber` | :x: |
-| `starknet_getTransactionByBlockNumberAndIndex` | :x: |
-| `starknet_getTransactionByBlockHashAndIndex` | :x: |
+| `starknet_getTransactionByBlockNumberAndIndex` | :heavy_check_mark: |
+| `starknet_getTransactionByBlockHashAndIndex` | :heavy_check_mark: |
 | `starknet_getStorageAt` | :heavy_check_mark: |
 | `starknet_getStateUpdateByHash` | :x: |
 

--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ Implementation status:
 | `starknet_protocolVersion` | :x: |
 | `starknet_pendingTransactions` | :x: |
 | `starknet_estimateFee` | :x: |
-| `starknet_getBlockTransactionCountByHash` | :x: |
-| `starknet_getBlockTransactionCountByNumber` | :x: |
+| `starknet_getBlockTransactionCountByHash` | :heavy_check_mark: |
+| `starknet_getBlockTransactionCountByNumber` | :heavy_check_mark: |
 | `starknet_getTransactionByBlockNumberAndIndex` | :heavy_check_mark: |
 | `starknet_getTransactionByBlockHashAndIndex` | :heavy_check_mark: |
 | `starknet_getStorageAt` | :heavy_check_mark: |

--- a/rpc/api.go
+++ b/rpc/api.go
@@ -127,7 +127,7 @@ func (sc *Client) ClassHashAt(ctx context.Context, address string) (string, erro
 	return *result, nil
 }
 
-// GetStorageAt gets the value of the storage at the given address and key.
+// StorageAt gets the value of the storage at the given address and key.
 func (sc *Client) StorageAt(ctx context.Context, contractAddress, key, blockHashOrTag string) (string, error) {
 	var value string
 	hashKey := fmt.Sprintf("0x%s", caigo.GetSelectorFromName(key).Text(16))
@@ -189,7 +189,7 @@ type StateUpdateOutput struct {
 	StateDiff StateDiff `json:"state_diff"`
 }
 
-// GetStateUpdateByHash gets the information about the result of executing the requested block.
+// StateUpdateByHash gets the information about the result of executing the requested block.
 func (sc *Client) StateUpdateByHash(ctx context.Context, blockHashOrTag string) (*StateUpdateOutput, error) {
 	var result StateUpdateOutput
 	if err := sc.do(ctx, "starknet_getStateUpdateByHash", &result, blockHashOrTag); err != nil {
@@ -211,8 +211,8 @@ func (sc *Client) TransactionByHash(ctx context.Context, hash string) (*types.Tr
 	return &tx, nil
 }
 
-// GetTransactionByBlockNumberAndIndex get the details of a transaction by a given block number and index.
-func (sc *Client) GetTransactionByBlockNumberAndIndex(ctx context.Context, blockNumberOrTag interface{}, txIndex int) (*types.Transaction, error) {
+// TransactionByBlockNumberAndIndex get the details of a transaction by a given block number and index.
+func (sc *Client) TransactionByBlockNumberAndIndex(ctx context.Context, blockNumberOrTag interface{}, txIndex int) (*types.Transaction, error) {
 	var tx types.Transaction
 	if err := sc.do(ctx, "starknet_getTransactionByBlockNumberAndIndex", &tx, blockNumberOrTag, txIndex); err != nil {
 		return nil, err
@@ -223,8 +223,8 @@ func (sc *Client) GetTransactionByBlockNumberAndIndex(ctx context.Context, block
 	return &tx, nil
 }
 
-// GetTransactionByBlockHashAndIndex get the details of a transaction by a given block hash and index.
-func (sc *Client) GetTransactionByBlockHashAndIndex(ctx context.Context, blockHash string, txIndex int) (*types.Transaction, error) {
+// TransactionByBlockHashAndIndex get the details of a transaction by a given block hash and index.
+func (sc *Client) TransactionByBlockHashAndIndex(ctx context.Context, blockHash string, txIndex int) (*types.Transaction, error) {
 	var tx types.Transaction
 	if err := sc.do(ctx, "starknet_getTransactionByBlockHashAndIndex", &tx, blockHash, txIndex); err != nil {
 		return nil, err
@@ -235,8 +235,8 @@ func (sc *Client) GetTransactionByBlockHashAndIndex(ctx context.Context, blockHa
 	return &tx, nil
 }
 
-// GetBlockTransactionCountByNumber gets the number of transactions in a block given a block number (height).
-func (sc *Client) GetBlockTransactionCountByNumber(ctx context.Context, blockNumberOrTag interface{}) (int, error) {
+// BlockTransactionCountByNumber gets the number of transactions in a block given a block number (height).
+func (sc *Client) BlockTransactionCountByNumber(ctx context.Context, blockNumberOrTag interface{}) (int, error) {
 	var count int
 	if err := sc.do(ctx, "starknet_getBlockTransactionCountByNumber", &count, blockNumberOrTag); err != nil {
 		return 0, err
@@ -248,8 +248,8 @@ func (sc *Client) GetBlockTransactionCountByNumber(ctx context.Context, blockNum
 	return count, nil
 }
 
-// GetBlockTransactionCountByHash gets the number of transactions in a block given a block hash.
-func (sc *Client) GetBlockTransactionCountByHash(ctx context.Context, blockHashOrTag string) (int, error) {
+// BlockTransactionCountByHash gets the number of transactions in a block given a block hash.
+func (sc *Client) BlockTransactionCountByHash(ctx context.Context, blockHashOrTag string) (int, error) {
 	var count int
 	if err := sc.do(ctx, "starknet_getBlockTransactionCountByHash", &count, blockHashOrTag); err != nil {
 		return 0, err

--- a/rpc/api.go
+++ b/rpc/api.go
@@ -235,6 +235,32 @@ func (sc *Client) GetTransactionByBlockHashAndIndex(ctx context.Context, blockHa
 	return &tx, nil
 }
 
+// GetBlockTransactionCountByNumber gets the number of transactions in a block given a block number (height).
+func (sc *Client) GetBlockTransactionCountByNumber(ctx context.Context, blockNumberOrTag interface{}) (int, error) {
+	var count int
+	if err := sc.do(ctx, "starknet_getBlockTransactionCountByNumber", &count, blockNumberOrTag); err != nil {
+		return 0, err
+	}
+	if count == 0 {
+		return 0, ErrNotFound
+	}
+
+	return count, nil
+}
+
+// GetBlockTransactionCountByHash gets the number of transactions in a block given a block hash.
+func (sc *Client) GetBlockTransactionCountByHash(ctx context.Context, blockHashOrTag string) (int, error) {
+	var count int
+	if err := sc.do(ctx, "starknet_getBlockTransactionCountByHash", &count, blockHashOrTag); err != nil {
+		return 0, err
+	}
+	if count == 0 {
+		return 0, ErrNotFound
+	}
+
+	return count, nil
+}
+
 // TransactionReceipt gets the transaction receipt by the transaction hash.
 func (sc *Client) TransactionReceipt(ctx context.Context, hash string) (*types.TransactionReceipt, error) {
 	var receipt types.TransactionReceipt

--- a/rpc/api.go
+++ b/rpc/api.go
@@ -293,8 +293,10 @@ func (sc *Client) EstimateFee(context.Context, types.Transaction) (*types.FeeEst
 }
 
 // AccountNonce gets the latest nonce associated with the given address
-func (sc *Client) AccountNonce(context.Context, string) (*big.Int, error) {
-	panic("not implemented")
+func (sc *Client) AccountNonce(ctx context.Context, contractAddress string) (*big.Int, error) {
+	var nonce big.Int
+	err := sc.do(ctx, "starknet_getNonce", &nonce, contractAddress)
+	return &nonce, err
 }
 
 func toBlockNumArg(number *big.Int) interface{} {

--- a/rpc/api.go
+++ b/rpc/api.go
@@ -211,6 +211,30 @@ func (sc *Client) TransactionByHash(ctx context.Context, hash string) (*types.Tr
 	return &tx, nil
 }
 
+// GetTransactionByBlockNumberAndIndex get the details of a transaction by a given block number and index.
+func (sc *Client) GetTransactionByBlockNumberAndIndex(ctx context.Context, blockNumberOrTag interface{}, txIndex int) (*types.Transaction, error) {
+	var tx types.Transaction
+	if err := sc.do(ctx, "starknet_getTransactionByBlockNumberAndIndex", &tx, blockNumberOrTag, txIndex); err != nil {
+		return nil, err
+	} else if tx.TransactionHash == "" {
+		return nil, ErrNotFound
+	}
+
+	return &tx, nil
+}
+
+// GetTransactionByBlockHashAndIndex get the details of a transaction by a given block hash and index.
+func (sc *Client) GetTransactionByBlockHashAndIndex(ctx context.Context, blockHash string, txIndex int) (*types.Transaction, error) {
+	var tx types.Transaction
+	if err := sc.do(ctx, "starknet_getTransactionByBlockHashAndIndex", &tx, blockHash, txIndex); err != nil {
+		return nil, err
+	} else if tx.TransactionHash == "" {
+		return nil, ErrNotFound
+	}
+
+	return &tx, nil
+}
+
 // TransactionReceipt gets the transaction receipt by the transaction hash.
 func (sc *Client) TransactionReceipt(ctx context.Context, hash string) (*types.TransactionReceipt, error) {
 	var receipt types.TransactionReceipt

--- a/rpc/api_block_test.go
+++ b/rpc/api_block_test.go
@@ -173,11 +173,11 @@ func TestBlockByHash(t *testing.T) {
 	}
 }
 
-// TestGetStateUpdateByHash tests GetStateUpdateByHash
+// TestStateUpdateByHash tests StateUpdateByHash
 // TODO: this is not implemented yet with pathfinder as you can see from the
 // [code](https://github.com/eqlabs/pathfinder/blob/927183552dad6dcdfebac16c8c1d2baf019127b1/crates/pathfinder/rpc_examples.sh#L37)
 // check when it is and test when it is the case.
-func TestGetStateUpdateByHash(t *testing.T) {
+func TestStateUpdateByHash(t *testing.T) {
 	testConfig := beforeEach(t)
 
 	type testSetType struct {
@@ -205,10 +205,9 @@ func TestGetStateUpdateByHash(t *testing.T) {
 	}
 }
 
-// TestGetBlockTransactionCountByHash tests GetBlockTransactionCountByHash
-func TestGetBlockTransactionCountByHash(t *testing.T) {
+// TestBlockTransactionCountByHash tests BlockTransactionCountByHash
+func TestBlockTransactionCountByHash(t *testing.T) {
 	testConfig := beforeEach(t)
-	defer testConfig.client.Close()
 
 	type testSetType struct {
 		BlockHash       string
@@ -234,7 +233,7 @@ func TestGetBlockTransactionCountByHash(t *testing.T) {
 	}[testEnv]
 
 	for _, test := range testSet {
-		txCount, err := testConfig.client.GetBlockTransactionCountByHash(context.Background(), test.BlockHash)
+		txCount, err := testConfig.client.BlockTransactionCountByHash(context.Background(), test.BlockHash)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -246,10 +245,9 @@ func TestGetBlockTransactionCountByHash(t *testing.T) {
 	}
 }
 
-// TestGetBlockTransactionCountByHash tests GetBlockTransactionCountByHash
-func TestGetBlockTransactionCountByNumber(t *testing.T) {
+// TestBlockTransactionCountByHash tests BlockTransactionCountByHash
+func TestBlockTransactionCountByNumber(t *testing.T) {
 	testConfig := beforeEach(t)
-	defer testConfig.client.Close()
 
 	type testSetType struct {
 		BlockNumberOrTag interface{}
@@ -275,7 +273,7 @@ func TestGetBlockTransactionCountByNumber(t *testing.T) {
 	}[testEnv]
 
 	for _, test := range testSet {
-		txCount, err := testConfig.client.GetBlockTransactionCountByNumber(context.Background(), test.BlockNumberOrTag)
+		txCount, err := testConfig.client.BlockTransactionCountByNumber(context.Background(), test.BlockNumberOrTag)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/rpc/api_block_test.go
+++ b/rpc/api_block_test.go
@@ -204,3 +204,85 @@ func TestGetStateUpdateByHash(t *testing.T) {
 		}
 	}
 }
+
+// TestGetBlockTransactionCountByHash tests GetBlockTransactionCountByHash
+func TestGetBlockTransactionCountByHash(t *testing.T) {
+	testConfig := beforeEach(t)
+	defer testConfig.client.Close()
+
+	type testSetType struct {
+		BlockHash       string
+		ExpectedTxCount int
+	}
+	testSet := map[string][]testSetType{
+		"mock": {
+			{
+				BlockHash:       "0xdeadbeef",
+				ExpectedTxCount: 7,
+			},
+		},
+		"testnet": {
+			{
+				BlockHash:       "0x115aa451e374dbfdeb6f8d4c70133a39c6bb7b2948a4a3f0c9d5dda30f94044",
+				ExpectedTxCount: 31,
+			},
+		},
+		"mainnet": {{
+			BlockHash:       "0x6f8e6413281c43bfcb9f96e315a08c57c619c9da4b10e2cb7d33369f3fb75a0",
+			ExpectedTxCount: 31,
+		}},
+	}[testEnv]
+
+	for _, test := range testSet {
+		txCount, err := testConfig.client.GetBlockTransactionCountByHash(context.Background(), test.BlockHash)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if txCount != test.ExpectedTxCount {
+			t.Fatalf("txCount mismatch, expect %d, got %d :",
+				test.ExpectedTxCount,
+				txCount)
+		}
+	}
+}
+
+// TestGetBlockTransactionCountByHash tests GetBlockTransactionCountByHash
+func TestGetBlockTransactionCountByNumber(t *testing.T) {
+	testConfig := beforeEach(t)
+	defer testConfig.client.Close()
+
+	type testSetType struct {
+		BlockNumberOrTag interface{}
+		ExpectedTxCount  int
+	}
+	testSet := map[string][]testSetType{
+		"mock": {
+			{
+				BlockNumberOrTag: 666,
+				ExpectedTxCount:  7,
+			},
+		},
+		"testnet": {
+			{
+				BlockNumberOrTag: 242060,
+				ExpectedTxCount:  31,
+			},
+		},
+		"mainnet": {{
+			BlockNumberOrTag: 1500,
+			ExpectedTxCount:  31,
+		}},
+	}[testEnv]
+
+	for _, test := range testSet {
+		txCount, err := testConfig.client.GetBlockTransactionCountByNumber(context.Background(), test.BlockNumberOrTag)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if txCount != test.ExpectedTxCount {
+			t.Fatalf("txCount mismatch, expect %d, got %d :",
+				test.ExpectedTxCount,
+				txCount)
+		}
+	}
+}

--- a/rpc/api_contract_test.go
+++ b/rpc/api_contract_test.go
@@ -100,7 +100,7 @@ func TestClassAt(t *testing.T) {
 	}
 }
 
-// TestClassHashAt tests code for a getClassHashAt.
+// TestClassHashAt tests code for a ClassHashAt.
 func TestClassHashAt(t *testing.T) {
 	testConfig := beforeEach(t)
 
@@ -191,8 +191,8 @@ func TestClass(t *testing.T) {
 	}
 }
 
-// TestGetStorageAt tests GetStorageAt
-func TestGetStorageAt(t *testing.T) {
+// TestStorageAt tests StorageAt
+func TestStorageAt(t *testing.T) {
 	testConfig := beforeEach(t)
 
 	type testSetType struct {
@@ -242,7 +242,6 @@ func TestGetStorageAt(t *testing.T) {
 // TestAccountNonce test AccountNonce
 func TestAccountNonce(t *testing.T) {
 	testConfig := beforeEach(t)
-	defer testConfig.client.Close()
 
 	type testSetType struct {
 		ContractAddress string

--- a/rpc/api_contract_test.go
+++ b/rpc/api_contract_test.go
@@ -2,6 +2,7 @@ package rpc
 
 import (
 	"context"
+	"fmt"
 	"testing"
 )
 
@@ -234,6 +235,42 @@ func TestGetStorageAt(t *testing.T) {
 		}
 		if value != test.ExpectedValue {
 			t.Fatalf("expecting value %s, got %s", test.ExpectedValue, value)
+		}
+	}
+}
+
+// TestAccountNonce test AccountNonce
+func TestAccountNonce(t *testing.T) {
+	testConfig := beforeEach(t)
+	defer testConfig.client.Close()
+
+	type testSetType struct {
+		ContractAddress string
+		ExpectedNonce   string
+	}
+	testSet := map[string][]testSetType{
+		"mock": {
+			{
+				ContractAddress: "0xdeadbeef",
+				ExpectedNonce:   "10",
+			},
+		},
+		"testnet": {},
+		"mainnet": {},
+	}[testEnv]
+
+	if len(testSet) == 0 {
+		t.Skip(fmt.Sprintf("not implemented on %s", testEnv))
+	}
+
+	for _, test := range testSet {
+		nonce, err := testConfig.client.AccountNonce(context.Background(), test.ContractAddress)
+
+		if err != nil || nonce == nil {
+			t.Fatal(err)
+		}
+		if nonce.Text(10) != test.ExpectedNonce {
+			t.Fatalf("nonce %s expected, got %s", test.ExpectedNonce, nonce.Text(10))
 		}
 	}
 }

--- a/rpc/api_transaction_test.go
+++ b/rpc/api_transaction_test.go
@@ -5,6 +5,124 @@ import (
 	"testing"
 )
 
+// TestGetTransactionByBlockHashAndIndex tests transaction by blockHash and txIndex
+func TestGetTransactionByBlockHashAndIndex(t *testing.T) {
+	testConfig := beforeEach(t)
+	defer testConfig.client.Close()
+
+	type testSetType struct {
+		BlockHash                  string
+		TxIndex                    int
+		ExpectedTxHash             string
+		ExpectedContractAddress    string
+		ExpectedEntrypointSelector string
+	}
+	testSet := map[string][]testSetType{
+		"mock": {
+			{
+				BlockHash:                  "0xdeadbeef",
+				TxIndex:                    7,
+				ExpectedTxHash:             "0xdeadbeef",
+				ExpectedContractAddress:    "0xdeadbeef",
+				ExpectedEntrypointSelector: "0xdeadbeef",
+			},
+		},
+		"testnet": {
+			{
+				BlockHash:                  "0x115aa451e374dbfdeb6f8d4c70133a39c6bb7b2948a4a3f0c9d5dda30f94044",
+				TxIndex:                    3,
+				ExpectedTxHash:             "0x179124db5707ea54a44c7e9cc2e654a0160a0f6fa9a3ef8f3f062a659224da1",
+				ExpectedContractAddress:    "0x6bc8601525b88448ecc22de7ce94caa4cd7b3d594ad5c8360f21c7d6bfa5085",
+				ExpectedEntrypointSelector: "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
+			},
+		},
+		"mainnet": {
+			{
+				BlockHash:                  "0x6f8e6413281c43bfcb9f96e315a08c57c619c9da4b10e2cb7d33369f3fb75a0",
+				TxIndex:                    1,
+				ExpectedTxHash:             "0x2b8ff0898ab240a45082fa2d2e0118bfc2a30959a2d898bf3668d8c453963cb",
+				ExpectedContractAddress:    "0x443df1c1f5b55878b44c623557dc0bf7bee18c01813fe09fc6e47811a467976",
+				ExpectedEntrypointSelector: "0x12ead94ae9d3f9d2bdb6b847cf255f1f398193a1f88884a0ae8e18f24a037b6",
+			},
+		},
+	}[testEnv]
+
+	for _, test := range testSet {
+		tx, err := testConfig.client.GetTransactionByBlockHashAndIndex(context.Background(), test.BlockHash, test.TxIndex)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if tx == nil || tx.TransactionHash != test.ExpectedTxHash {
+			t.Fatal("transaction should exist and match the tx hash")
+		}
+		if tx.ContractAddress != test.ExpectedContractAddress {
+			t.Fatalf("expecting contract %s, got %s", test.ExpectedContractAddress, tx.ContractAddress)
+		}
+		if tx.EntryPointSelector != test.ExpectedEntrypointSelector {
+			t.Fatalf("expecting entrypoint %s, got %s", test.ExpectedEntrypointSelector, tx.EntryPointSelector)
+		}
+	}
+}
+
+// TestGetTransactionByBlockNumberAndIndex tests transaction by blockHash and txIndex
+func TestGetTransactionByBlockNumberAndIndex(t *testing.T) {
+	testConfig := beforeEach(t)
+	defer testConfig.client.Close()
+
+	type testSetType struct {
+		BlockNumberOrTag           interface{}
+		TxIndex                    int
+		ExpectedTxHash             string
+		ExpectedContractAddress    string
+		ExpectedEntrypointSelector string
+	}
+	testSet := map[string][]testSetType{
+		"mock": {
+			{
+				BlockNumberOrTag:           7,
+				TxIndex:                    7,
+				ExpectedTxHash:             "0xdeadbeef",
+				ExpectedContractAddress:    "0xdeadbeef",
+				ExpectedEntrypointSelector: "0xdeadbeef",
+			},
+		},
+		"testnet": {
+			{
+				BlockNumberOrTag:           242060,
+				TxIndex:                    3,
+				ExpectedTxHash:             "0x179124db5707ea54a44c7e9cc2e654a0160a0f6fa9a3ef8f3f062a659224da1",
+				ExpectedContractAddress:    "0x6bc8601525b88448ecc22de7ce94caa4cd7b3d594ad5c8360f21c7d6bfa5085",
+				ExpectedEntrypointSelector: "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
+			},
+		},
+		"mainnet": {
+			{
+				BlockNumberOrTag:           1500,
+				TxIndex:                    1,
+				ExpectedTxHash:             "0x2b8ff0898ab240a45082fa2d2e0118bfc2a30959a2d898bf3668d8c453963cb",
+				ExpectedContractAddress:    "0x443df1c1f5b55878b44c623557dc0bf7bee18c01813fe09fc6e47811a467976",
+				ExpectedEntrypointSelector: "0x12ead94ae9d3f9d2bdb6b847cf255f1f398193a1f88884a0ae8e18f24a037b6",
+			},
+		},
+	}[testEnv]
+
+	for _, test := range testSet {
+		tx, err := testConfig.client.GetTransactionByBlockNumberAndIndex(context.Background(), test.BlockNumberOrTag, test.TxIndex)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if tx == nil || tx.TransactionHash != test.ExpectedTxHash {
+			t.Fatal("transaction should exist and match the tx hash")
+		}
+		if tx.ContractAddress != test.ExpectedContractAddress {
+			t.Fatalf("expecting contract %s, got %s", test.ExpectedContractAddress, tx.ContractAddress)
+		}
+		if tx.EntryPointSelector != test.ExpectedEntrypointSelector {
+			t.Fatalf("expecting entrypoint %s, got %s", test.ExpectedEntrypointSelector, tx.EntryPointSelector)
+		}
+	}
+}
+
 // TestTransactionByHash tests transaction by hash
 func TestTransactionByHash(t *testing.T) {
 	testConfig := beforeEach(t)

--- a/rpc/api_transaction_test.go
+++ b/rpc/api_transaction_test.go
@@ -5,10 +5,9 @@ import (
 	"testing"
 )
 
-// TestGetTransactionByBlockHashAndIndex tests transaction by blockHash and txIndex
-func TestGetTransactionByBlockHashAndIndex(t *testing.T) {
+// TestTransactionByBlockHashAndIndex tests transaction by blockHash and txIndex
+func TestTransactionByBlockHashAndIndex(t *testing.T) {
 	testConfig := beforeEach(t)
-	defer testConfig.client.Close()
 
 	type testSetType struct {
 		BlockHash                  string
@@ -48,7 +47,7 @@ func TestGetTransactionByBlockHashAndIndex(t *testing.T) {
 	}[testEnv]
 
 	for _, test := range testSet {
-		tx, err := testConfig.client.GetTransactionByBlockHashAndIndex(context.Background(), test.BlockHash, test.TxIndex)
+		tx, err := testConfig.client.TransactionByBlockHashAndIndex(context.Background(), test.BlockHash, test.TxIndex)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -64,10 +63,9 @@ func TestGetTransactionByBlockHashAndIndex(t *testing.T) {
 	}
 }
 
-// TestGetTransactionByBlockNumberAndIndex tests transaction by blockHash and txIndex
-func TestGetTransactionByBlockNumberAndIndex(t *testing.T) {
+// TestTransactionByBlockNumberAndIndex tests transaction by blockHash and txIndex
+func TestTransactionByBlockNumberAndIndex(t *testing.T) {
 	testConfig := beforeEach(t)
-	defer testConfig.client.Close()
 
 	type testSetType struct {
 		BlockNumberOrTag           interface{}
@@ -107,7 +105,7 @@ func TestGetTransactionByBlockNumberAndIndex(t *testing.T) {
 	}[testEnv]
 
 	for _, test := range testSet {
-		tx, err := testConfig.client.GetTransactionByBlockNumberAndIndex(context.Background(), test.BlockNumberOrTag, test.TxIndex)
+		tx, err := testConfig.client.TransactionByBlockNumberAndIndex(context.Background(), test.BlockNumberOrTag, test.TxIndex)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -75,16 +75,11 @@ func (sc *Client) Syncing(ctx context.Context) (*SyncResponse, error) {
 	return &result, nil
 }
 
-// ProtocolVersionOutput provides the output for ProtocolVersion.
-type ProtocolVersionOutput struct {
-	ProtocolVersion string `json:"protocolVersion"`
-}
-
 // ProtocolVersion returns the current starknet protocol version identifier, as supported by this sequencer.
-func (sc *Client) ProtocolVersion(ctx context.Context) (*ProtocolVersionOutput, error) {
-	var protocol ProtocolVersionOutput
+func (sc *Client) ProtocolVersion(ctx context.Context) (string, error) {
+	var protocol string
 	err := sc.do(ctx, "starknet_protocolVersion", &protocol)
-	return &protocol, err
+	return protocol, err
 }
 
 func (sc *Client) do(ctx context.Context, method string, data interface{}, args ...interface{}) error {

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -75,6 +75,18 @@ func (sc *Client) Syncing(ctx context.Context) (*SyncResponse, error) {
 	return &result, nil
 }
 
+// ProtocolVersionOutput provides the output for ProtocolVersion.
+type ProtocolVersionOutput struct {
+	ProtocolVersion string `json:"protocolVersion"`
+}
+
+// ProtocolVersion returns the current starknet protocol version identifier, as supported by this sequencer.
+func (sc *Client) ProtocolVersion(ctx context.Context) (*ProtocolVersionOutput, error) {
+	var protocol ProtocolVersionOutput
+	err := sc.do(ctx, "starknet_protocolVersion", &protocol)
+	return &protocol, err
+}
+
 func (sc *Client) do(ctx context.Context, method string, data interface{}, args ...interface{}) error {
 	var raw json.RawMessage
 	err := sc.c.CallContext(ctx, &raw, method, args...)

--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -168,11 +168,11 @@ func TestProtocolVersion(t *testing.T) {
 
 		protocol, err := testConfig.client.ProtocolVersion(context.Background())
 
-		if err != nil || protocol == nil {
+		if err != nil || protocol == "" {
 			t.Fatal(err)
 		}
-		if protocol.ProtocolVersion != test.ProtocolVersion {
-			t.Fatal("protocol should not be empty")
+		if protocol != test.ProtocolVersion {
+			t.Fatalf("protocol %s expected, got %s", test.ProtocolVersion, protocol)
 		}
 	}
 }

--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -143,6 +143,40 @@ func TestSyncing(t *testing.T) {
 	}
 }
 
+// TestProtocolVersion test ProtocolVersion
+func TestProtocolVersion(t *testing.T) {
+	testConfig := beforeEach(t)
+	defer testConfig.client.Close()
+
+	type testSetType struct {
+		ProtocolVersion string
+	}
+	testSet := map[string][]testSetType{
+		"mock": {
+			{
+				ProtocolVersion: "0x312e30",
+			},
+		},
+		"testnet": {},
+		"mainnet": {},
+	}[testEnv]
+
+	if len(testSet) == 0 {
+		t.Skip(fmt.Sprintf("not implemented on %s", testEnv))
+	}
+	for _, test := range testSet {
+
+		protocol, err := testConfig.client.ProtocolVersion(context.Background())
+
+		if err != nil || protocol == nil {
+			t.Fatal(err)
+		}
+		if protocol.ProtocolVersion != test.ProtocolVersion {
+			t.Fatal("protocol should not be empty")
+		}
+	}
+}
+
 // TestClose checks the function is called
 func TestClose(t *testing.T) {
 	testConfig := beforeEach(t)

--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -146,7 +146,6 @@ func TestSyncing(t *testing.T) {
 // TestProtocolVersion test ProtocolVersion
 func TestProtocolVersion(t *testing.T) {
 	testConfig := beforeEach(t)
-	defer testConfig.client.Close()
 
 	type testSetType struct {
 		ProtocolVersion string

--- a/rpc/mock_test.go
+++ b/rpc/mock_test.go
@@ -37,6 +37,10 @@ func (r *rpcMock) CallContext(ctx context.Context, result interface{}, method st
 		return mock_starknet_getBlockByHash(result, method, args...)
 	case "starknet_getBlockByNumber":
 		return mock_starknet_getBlockByNumber(result, method, args...)
+	case "starknet_getTransactionByBlockHashAndIndex":
+		return mock_starknet_getTransactionByBlockHashAndIndex(result, method, args...)
+	case "starknet_getTransactionByBlockNumberAndIndex":
+		return mock_starknet_getTransactionByBlockNumberAndIndex(result, method, args...)
 	case "starknet_getTransactionByHash":
 		return mock_starknet_getTransactionByHash(result, method, args...)
 	case "starknet_getTransactionReceipt":
@@ -192,6 +196,62 @@ func mock_starknet_getTransactionByHash(result interface{}, method string, args 
 	}
 	transaction := types.Transaction{
 		TransactionHash:    txHash,
+		ContractAddress:    "0xdeadbeef",
+		EntryPointSelector: "0xdeadbeef",
+	}
+	outputContent, _ := json.Marshal(transaction)
+	json.Unmarshal(outputContent, r)
+	return nil
+}
+
+func mock_starknet_getTransactionByBlockHashAndIndex(result interface{}, method string, args ...interface{}) error {
+	r, ok := result.(*json.RawMessage)
+	if !ok || r == nil {
+		return errWrongType
+	}
+	if len(args) != 2 {
+		return errWrongArgs
+	}
+	blockHash, ok := args[0].(string)
+	if !ok || !strings.HasPrefix(blockHash, "0x") {
+		return errWrongArgs
+	}
+	_, ok = args[1].(int)
+	if !ok {
+		fmt.Printf("args[1] expecting int, got %T\n", args[1])
+		return errWrongArgs
+	}
+	transaction := types.Transaction{
+		TransactionHash:    "0xdeadbeef",
+		ContractAddress:    "0xdeadbeef",
+		EntryPointSelector: "0xdeadbeef",
+	}
+	outputContent, _ := json.Marshal(transaction)
+	json.Unmarshal(outputContent, r)
+	return nil
+}
+
+func mock_starknet_getTransactionByBlockNumberAndIndex(result interface{}, method string, args ...interface{}) error {
+	r, ok := result.(*json.RawMessage)
+	if !ok || r == nil {
+		return errWrongType
+	}
+	if len(args) != 2 {
+		return errWrongArgs
+	}
+	_, ok1 := args[0].(int)
+	_, ok2 := args[0].(string)
+	if !ok1 && !ok2 {
+		fmt.Printf("args[0] expecting int or string, got %T\n", args[0])
+		return errWrongArgs
+	}
+	_, ok = args[1].(int)
+	if !ok {
+		fmt.Printf("args[1] expecting int, got %T\n", args[1])
+		return errWrongArgs
+	}
+	transaction := types.Transaction{
+		TransactionHash:    "0xdeadbeef",
 		ContractAddress:    "0xdeadbeef",
 		EntryPointSelector: "0xdeadbeef",
 	}

--- a/rpc/mock_test.go
+++ b/rpc/mock_test.go
@@ -41,6 +41,10 @@ func (r *rpcMock) CallContext(ctx context.Context, result interface{}, method st
 		return mock_starknet_getTransactionByBlockHashAndIndex(result, method, args...)
 	case "starknet_getTransactionByBlockNumberAndIndex":
 		return mock_starknet_getTransactionByBlockNumberAndIndex(result, method, args...)
+	case "starknet_getBlockTransactionCountByNumber":
+		return mock_starknet_getBlockTransactionCountByNumber(result, method, args...)
+	case "starknet_getBlockTransactionCountByHash":
+		return mock_starknet_getBlockTransactionCountByHash(result, method, args...)
 	case "starknet_getTransactionByHash":
 		return mock_starknet_getTransactionByHash(result, method, args...)
 	case "starknet_getTransactionReceipt":
@@ -483,6 +487,47 @@ func mock_starknet_getStateUpdateByHash(result interface{}, method string, args 
 	output := &StateUpdateOutput{
 		BlockHash: blockHash,
 	}
+	outputContent, _ := json.Marshal(output)
+	json.Unmarshal(outputContent, r)
+	return nil
+}
+
+func mock_starknet_getBlockTransactionCountByHash(result interface{}, method string, args ...interface{}) error {
+	r, ok := result.(*json.RawMessage)
+	if !ok {
+		return errWrongType
+	}
+	if len(args) != 1 {
+		fmt.Printf("args: %d\n", len(args))
+		return errWrongArgs
+	}
+	_, ok = args[0].(string)
+	if !ok {
+		fmt.Printf("args[0] should be string, got %T\n", args[0])
+		return errWrongArgs
+	}
+	output := 7
+	outputContent, _ := json.Marshal(output)
+	json.Unmarshal(outputContent, r)
+	return nil
+}
+
+func mock_starknet_getBlockTransactionCountByNumber(result interface{}, method string, args ...interface{}) error {
+	r, ok := result.(*json.RawMessage)
+	if !ok {
+		return errWrongType
+	}
+	if len(args) != 1 {
+		fmt.Printf("args: %d\n", len(args))
+		return errWrongArgs
+	}
+	_, ok1 := args[0].(string)
+	_, ok2 := args[0].(int)
+	if !ok1 && !ok2 {
+		fmt.Printf("args[0] should be int or string, got %T\n", args[0])
+		return errWrongArgs
+	}
+	output := 7
 	outputContent, _ := json.Marshal(output)
 	json.Unmarshal(outputContent, r)
 	return nil

--- a/rpc/mock_test.go
+++ b/rpc/mock_test.go
@@ -63,6 +63,8 @@ func (r *rpcMock) CallContext(ctx context.Context, result interface{}, method st
 		return mock_starknet_getStorageAt(result, method, args...)
 	case "starknet_getStateUpdateByHash":
 		return mock_starknet_getStateUpdateByHash(result, method, args...)
+	case "starknet_protocolVersion":
+		return mock_starknet_protocolVersion(result, method, args...)
 	case "starknet_call":
 		return mock_starknet_call(result, method, args...)
 	case "starknet_addDeployTransaction":
@@ -528,6 +530,23 @@ func mock_starknet_getBlockTransactionCountByNumber(result interface{}, method s
 		return errWrongArgs
 	}
 	output := 7
+	outputContent, _ := json.Marshal(output)
+	json.Unmarshal(outputContent, r)
+	return nil
+}
+
+func mock_starknet_protocolVersion(result interface{}, method string, args ...interface{}) error {
+	r, ok := result.(*json.RawMessage)
+	if !ok {
+		return errWrongType
+	}
+	if len(args) != 0 {
+		fmt.Printf("args: %d\n", len(args))
+		return errWrongArgs
+	}
+	output := ProtocolVersionOutput{
+		ProtocolVersion: "0x312e30",
+	}
 	outputContent, _ := json.Marshal(output)
 	json.Unmarshal(outputContent, r)
 	return nil

--- a/rpc/mock_test.go
+++ b/rpc/mock_test.go
@@ -59,6 +59,8 @@ func (r *rpcMock) CallContext(ctx context.Context, result interface{}, method st
 		return mock_starknet_getClass(result, method, args...)
 	case "starknet_getEvents":
 		return mock_starknet_getEvents(result, method, args...)
+	case "starknet_getNonce":
+		return mock_starknet_getNonce(result, method, args...)
 	case "starknet_getStorageAt":
 		return mock_starknet_getStorageAt(result, method, args...)
 	case "starknet_getStateUpdateByHash":
@@ -544,9 +546,26 @@ func mock_starknet_protocolVersion(result interface{}, method string, args ...in
 		fmt.Printf("args: %d\n", len(args))
 		return errWrongArgs
 	}
-	output := ProtocolVersionOutput{
-		ProtocolVersion: "0x312e30",
+	output := "0x312e30"
+	outputContent, _ := json.Marshal(output)
+	json.Unmarshal(outputContent, r)
+	return nil
+}
+
+func mock_starknet_getNonce(result interface{}, method string, args ...interface{}) error {
+	r, ok := result.(*json.RawMessage)
+	if !ok {
+		return errWrongType
 	}
+	if len(args) != 1 {
+		fmt.Printf("args: %d\n", len(args))
+		return errWrongArgs
+	}
+	if _, ok := args[0].(string); !ok {
+		fmt.Printf("args[0] should be string, got %T\n", args[0])
+		return errWrongArgs
+	}
+	output := big.NewInt(10)
 	outputContent, _ := json.Marshal(output)
 	json.Unmarshal(outputContent, r)
 	return nil


### PR DESCRIPTION
This PR creates the implementation and tests for 
- `starknet_getTransactionByBlockNumberAndIndex` 
- `starknet_getTransactionByBlockHashAndIndex`
- `starknet_getBlockTransactionCountByHash`
- `starknet_getBlockTransactionCountByNumber`

In addition, the 2 following verbs are not available from PathFinder. As a result, I have only developped the mock:

- `starknet_protocolVersion`
- `starknet_getNonce`