### PR TITLE
Implementation and tests for starknet_addInvokeTransaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Implementation status:
 | `starknet_chainId` | :heavy_check_mark: |
 | `starknet_syncing` | :heavy_check_mark: |
 | `starknet_getEvents` | :heavy_check_mark: |
-| `starknet_addInvokeTransaction` | :x: |
+| `starknet_addInvokeTransaction` | :heavy_check_mark: |
 | `starknet_addDeployTransaction` | :heavy_check_mark: |
 | `starknet_addDeclareTransaction` | :heavy_check_mark: |
 | `starknet_traceTransaction` | :x: (1) |

--- a/rpc/api_addtransaction_test.go
+++ b/rpc/api_addtransaction_test.go
@@ -121,3 +121,80 @@ func TestAddDeclareTransaction(t *testing.T) {
 		}
 	}
 }
+
+// TestAddInvokeTransaction tests AddInvokeTransaction
+func TestAddInvokeTransaction(t *testing.T) {
+	testConfig := beforeEach(t)
+
+	type testSetType struct {
+		FunctionCall            types.FunctionCall
+		Signature               []string
+		Version                 string
+		MaxFee                  string
+		ExpectedTransactionHash string
+	}
+	testSet := map[string][]testSetType{
+		"mock": {
+			{
+				FunctionCall: types.FunctionCall{
+					ContractAddress: "0x23371b227eaecd8e8920cd429d2cd0f3fee6abaacca08d3ab82a7cdd",
+					Calldata: []string{
+						"0x1",
+						"0x677bb1cdc050e8d63855e8743ab6e09179138def390676cc03c484daf112ba1",
+						"0x362398bec32bc0ebb411203221a35a0301193a96f317ebe5e40be9f60d15320",
+						"0x0",
+						"0x1",
+						"0x1",
+						"0x2b",
+						"0x0",
+					},
+					EntryPointSelector: "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
+				},
+				Signature: []string{
+					"3557065757165699682249469970267166698995647077461960906176449260016084767701",
+					"3202126414680946801789588986259466145787792017299869598314522555275920413944",
+				},
+				MaxFee:                  "0x4f388496839",
+				Version:                 "0x0",
+				ExpectedTransactionHash: "0xdeadbeef",
+			},
+		},
+		"testnet": {},
+		"mainnet": {
+			{
+				FunctionCall: types.FunctionCall{
+					ContractAddress: "0x23371b227eaecd8e8920cd429d2cd0f3fee6abaacca08d3ab82a7cdd",
+					Calldata: []string{
+						"0x1",
+						"0x677bb1cdc050e8d63855e8743ab6e09179138def390676cc03c484daf112ba1",
+						"0x362398bec32bc0ebb411203221a35a0301193a96f317ebe5e40be9f60d15320",
+						"0x0",
+						"0x1",
+						"0x1",
+						"0x2b",
+						"0x0",
+					},
+					EntryPointSelector: "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
+				},
+				Signature: []string{
+					"3557065757165699682249469970267166698995647077461960906176449260016084767701",
+					"3202126414680946801789588986259466145787792017299869598314522555275920413944",
+				},
+				MaxFee:                  "0x4f388496839",
+				Version:                 "0x0",
+				ExpectedTransactionHash: "0x1ce0d76c0c085306fd32679b75f9541fab71851da8d3e3898a691b49ed8175c",
+			},
+		},
+	}[testEnv]
+
+	for _, test := range testSet {
+		functionCall := test.FunctionCall
+		output, err := testConfig.client.AddInvokeTransaction(context.Background(), functionCall, test.Signature, test.MaxFee, test.Version)
+		if err != nil || output == nil {
+			t.Fatalf("output is nil, go err %v", err)
+		}
+		if output.TransactionHash != test.ExpectedTransactionHash {
+			t.Fatalf("tx expected %s, got %s", test.ExpectedTransactionHash, output.TransactionHash)
+		}
+	}
+}

--- a/rpc/api_test.go
+++ b/rpc/api_test.go
@@ -1,0 +1,44 @@
+package rpc
+
+import (
+	"context"
+	"testing"
+)
+
+// TestNotImplemented checks the method not yet implemented
+func TestNotImplemented(t *testing.T) {
+	testConfig := beforeEach(t)
+
+	type testSetType struct {
+		MissingMethod string
+	}
+	testSet := map[string][]testSetType{
+		"devnet": {},
+		"mainnet": {
+			{MissingMethod: "starknet_traceTransaction"},
+			{MissingMethod: "starknet_traceBlockTransactions"},
+			{MissingMethod: "starknet_getNonce"},
+			{MissingMethod: "starknet_protocolVersion"},
+			{MissingMethod: "starknet_pendingTransactions"},
+			{MissingMethod: "starknet_getStateUpdateByHash"},
+		},
+		"mock": {},
+		"testnet": {
+			{MissingMethod: "starknet_traceTransaction"},
+			{MissingMethod: "starknet_traceBlockTransactions"},
+			{MissingMethod: "starknet_getNonce"},
+			{MissingMethod: "starknet_protocolVersion"},
+			{MissingMethod: "starknet_pendingTransactions"},
+			{MissingMethod: "starknet_getStateUpdateByHash"},
+		},
+	}[testEnv]
+
+	for _, test := range testSet {
+		var out string
+		err := testConfig.client.do(context.Background(), test.MissingMethod, &out)
+
+		if err == nil || err.Error() != "Method not found" {
+			t.Fatalf("Method is now available, got %v\n", err)
+		}
+	}
+}

--- a/rpc/mock_test.go
+++ b/rpc/mock_test.go
@@ -73,6 +73,8 @@ func (r *rpcMock) CallContext(ctx context.Context, result interface{}, method st
 		return mock_starknet_addDeclareTransaction(result, method, args...)
 	case "starknet_addDeployTransaction":
 		return mock_starknet_addDeployTransaction(result, method, args...)
+	case "starknet_addInvokeTransaction":
+		return mock_starknet_addInvokeTransaction(result, method, args...)
 	case "starknet_estimateFee":
 		return mock_starknet_estimateFee(result, method, args...)
 	default:
@@ -508,6 +510,44 @@ func mock_starknet_estimateFee(result interface{}, method string, args ...interf
 		GasConsumed: "0xdeadbeef",
 		GasPrice:    "0xdeadbeef",
 		OverallFee:  "0xdeadbeef",
+	}
+	outputContent, _ := json.Marshal(output)
+	json.Unmarshal(outputContent, r)
+	return nil
+}
+
+func mock_starknet_addInvokeTransaction(result interface{}, method string, args ...interface{}) error {
+	r, ok := result.(*json.RawMessage)
+	if !ok {
+		return errWrongType
+	}
+	if len(args) != 4 {
+		fmt.Printf("args: %d\n", len(args))
+		return errWrongArgs
+	}
+	_, ok = args[0].(types.FunctionCall)
+	if !ok {
+		fmt.Printf("args[0] should be types.FunctionCall, got %T\n", args[0])
+		return errWrongArgs
+	}
+	_, ok = args[1].([]string)
+	if !ok {
+		fmt.Printf("args[1] should be []string, got %T\n", args[1])
+		return errWrongArgs
+	}
+	_, ok = args[2].(string)
+	if !ok {
+		fmt.Printf("args[2] should be []string, got %T\n", args[2])
+		return errWrongArgs
+	}
+	_, ok = args[3].(string)
+	if !ok {
+		fmt.Printf("args[3] should be []string, got %T\n", args[3])
+		return errWrongArgs
+	}
+
+	output := AddInvokeTransactionOutput{
+		TransactionHash: "0xdeadbeef",
 	}
 	outputContent, _ := json.Marshal(output)
 	json.Unmarshal(outputContent, r)

--- a/rpc/write.go
+++ b/rpc/write.go
@@ -22,8 +22,18 @@ type AddDeployTransactionOutput struct {
 	ContractAddress string `json:"contract_address"`
 }
 
-func (sc *Client) Invoke(context.Context, types.Transaction) (*types.AddTxResponse, error) {
-	panic("'starknet_addInvokeTransaction' not implemented")
+// AddInvokeTransactionOutput provides the output for AddInvokeTransaction.
+type AddInvokeTransactionOutput struct {
+	TransactionHash string `json:"transaction_hash"`
+}
+
+// AddInvokeTransaction estimates the fee for a given StarkNet transaction.
+func (sc *Client) AddInvokeTransaction(ctx context.Context, functionCall types.FunctionCall, signature []string, maxFee, version string) (*AddInvokeTransactionOutput, error) {
+	var output AddInvokeTransactionOutput
+	if err := sc.do(ctx, "starknet_addInvokeTransaction", &output, functionCall, signature, maxFee, version); err != nil {
+		return nil, err
+	}
+	return &output, nil
 }
 
 // AddDeclareTransaction submits a new class declaration transaction.
@@ -34,7 +44,7 @@ func (sc *Client) AddDeclareTransaction(ctx context.Context, contractDefinition 
 		if err != nil {
 			return nil, err
 		}
-		// TODO: change Program from contractDefinition to have a type that can handle 
+		// TODO: change Program from contractDefinition to have a type that can handle
 		// compressed and uncompressed data.
 		program, err = encodeProgram(data)
 		if err != nil {
@@ -62,7 +72,7 @@ func (sc *Client) AddDeployTransaction(ctx context.Context, contractAddressSalt 
 		if err != nil {
 			return nil, err
 		}
-		// TODO: change Program from contractDefinition to have a type that can handle 
+		// TODO: change Program from contractDefinition to have a type that can handle
 		// compressed and uncompressed data.
 		program, err = encodeProgram(data)
 		if err != nil {


### PR DESCRIPTION
starknet_addInvokeTransaction finishes the methods available with RPC. This PR provides the implementation as well as some tests with Mock and on Mainnet.