### PR TITLE
add a test to detect when methods are implemented

### DIFF
--- a/rpc/api_test.go
+++ b/rpc/api_test.go
@@ -1,0 +1,44 @@
+package rpc
+
+import (
+	"context"
+	"testing"
+)
+
+// TestNotImplemented checks the method not yet implemented
+func TestNotImplemented(t *testing.T) {
+	testConfig := beforeEach(t)
+
+	type testSetType struct {
+		MissingMethod string
+	}
+	testSet := map[string][]testSetType{
+		"devnet": {},
+		"mainnet": {
+			{MissingMethod: "starknet_traceTransaction"},
+			{MissingMethod: "starknet_traceBlockTransactions"},
+			{MissingMethod: "starknet_getNonce"},
+			{MissingMethod: "starknet_protocolVersion"},
+			{MissingMethod: "starknet_pendingTransactions"},
+			{MissingMethod: "starknet_getStateUpdateByHash"},
+		},
+		"mock": {},
+		"testnet": {
+			{MissingMethod: "starknet_traceTransaction"},
+			{MissingMethod: "starknet_traceBlockTransactions"},
+			{MissingMethod: "starknet_getNonce"},
+			{MissingMethod: "starknet_protocolVersion"},
+			{MissingMethod: "starknet_pendingTransactions"},
+			{MissingMethod: "starknet_getStateUpdateByHash"},
+		},
+	}[testEnv]
+
+	for _, test := range testSet {
+		var out string
+		err := testConfig.client.do(context.Background(), test.MissingMethod, &out)
+
+		if err == nil || err.Error() != "Method not found" {
+			t.Fatalf("Method is now available, got %v\n", err)
+		}
+	}
+}


### PR DESCRIPTION
`TestNotImplemented` is a test that succeed while the method listed remain unimplemented. This test will, once we setup a nightly run help with detecting a new implementation of a method with pathfinder.