### PR TITLE
feat: embed pedersen params

### DIFF
--- a/caigo_test.go
+++ b/caigo_test.go
@@ -7,38 +7,28 @@ import (
 	"testing"
 )
 
-var caigoCurve StarkCurve
-
-func init() {
-	var err error
-	caigoCurve, err = SC(WithConstants("./pedersen_params.json"))
-	if err != nil {
-		panic(err.Error())
-	}
-}
-
 func BenchmarkSignatureVerify(b *testing.B) {
-	private, _ := caigoCurve.GetRandomPrivateKey()
-	x, y, _ := caigoCurve.PrivateToPoint(private)
+	private, _ := Curve.GetRandomPrivateKey()
+	x, y, _ := Curve.PrivateToPoint(private)
 
-	hash, _ := caigoCurve.PedersenHash(
+	hash, _ := Curve.PedersenHash(
 		[]*big.Int{
 			HexToBN("0x7f15c38ea577a26f4f553282fcfe4f1feeb8ecfaad8f221ae41abf8224cbddd"),
 			HexToBN("0x7f15c38ea577a26f4f553282fcfe4f1feeb8ecfaad8f221ae41abf8224cbdde"),
 		})
 
-	r, s, _ := caigoCurve.Sign(hash, private)
+	r, s, _ := Curve.Sign(hash, private)
 
 	b.Run(fmt.Sprintf("sign_input_size_%d", hash.BitLen()), func(b *testing.B) {
-		caigoCurve.Sign(hash, private)
+		Curve.Sign(hash, private)
 	})
 	b.Run(fmt.Sprintf("verify_input_size_%d", hash.BitLen()), func(b *testing.B) {
-		caigoCurve.Verify(hash, r, s, x, y)
+		Curve.Verify(hash, r, s, x, y)
 	})
 }
 
 func TestHashAndSign(t *testing.T) {
-	hashy, err := caigoCurve.HashElements([]*big.Int{
+	hashy, err := Curve.HashElements([]*big.Int{
 		big.NewInt(1953658213),
 		big.NewInt(126947999705460),
 		big.NewInt(1953658213),
@@ -47,37 +37,37 @@ func TestHashAndSign(t *testing.T) {
 		t.Errorf("Hasing elements: %v\n", err)
 	}
 
-	priv, _ := caigoCurve.GetRandomPrivateKey()
-	x, y, err := caigoCurve.PrivateToPoint(priv)
+	priv, _ := Curve.GetRandomPrivateKey()
+	x, y, err := Curve.PrivateToPoint(priv)
 	if err != nil {
 		t.Errorf("Could not convert random private key to point: %v\n", err)
 	}
 
-	r, s, err := caigoCurve.Sign(hashy, priv)
+	r, s, err := Curve.Sign(hashy, priv)
 	if err != nil {
 		t.Errorf("Could not convert gen signature: %v\n", err)
 	}
 
-	if !caigoCurve.Verify(hashy, r, s, x, y) {
+	if !Curve.Verify(hashy, r, s, x, y) {
 		t.Errorf("Verified bad signature %v %v\n", r, s)
 	}
 }
 
 func TestComputeFact(t *testing.T) {
 	testFacts := []struct {
-		programHash			*big.Int
-		programOutput		[]*big.Int
-		expected			*big.Int
+		programHash   *big.Int
+		programOutput []*big.Int
+		expected      *big.Int
 	}{
 		{
-			programHash: HexToBN("0x114952172aed91e59f870a314e75de0a437ff550e4618068cec2d832e48b0c7"),
+			programHash:   HexToBN("0x114952172aed91e59f870a314e75de0a437ff550e4618068cec2d832e48b0c7"),
 			programOutput: []*big.Int{big.NewInt(289)},
-			expected: HexToBN("0xe6168c0a865aa80d724ad05627fa65fbcfe4b1d66a586e9f348f461b076072c4"),
+			expected:      HexToBN("0xe6168c0a865aa80d724ad05627fa65fbcfe4b1d66a586e9f348f461b076072c4"),
 		},
 		{
-			programHash: HexToBN("0x79920d895101ad1fbdea9adf141d8f362fdea9ee35f33dfcd07f38e4a589bab"),
+			programHash:   HexToBN("0x79920d895101ad1fbdea9adf141d8f362fdea9ee35f33dfcd07f38e4a589bab"),
 			programOutput: []*big.Int{StrToBig("2754806153357301156380357983574496185342034785016738734224771556919270737441")},
-			expected: HexToBN("0x1d174fa1443deea9aab54bbca8d9be308dd14a0323dd827556c173bd132098db"),
+			expected:      HexToBN("0x1d174fa1443deea9aab54bbca8d9be308dd14a0323dd827556c173bd132098db"),
 		},
 	}
 
@@ -90,67 +80,67 @@ func TestComputeFact(t *testing.T) {
 }
 
 func TestBadSignature(t *testing.T) {
-	hash, err := caigoCurve.PedersenHash([]*big.Int{HexToBN("0x12773"), HexToBN("0x872362")})
+	hash, err := Curve.PedersenHash([]*big.Int{HexToBN("0x12773"), HexToBN("0x872362")})
 	if err != nil {
 		t.Errorf("Hashing err: %v\n", err)
 	}
 
-	priv, _ := caigoCurve.GetRandomPrivateKey()
-	x, y, err := caigoCurve.PrivateToPoint(priv)
+	priv, _ := Curve.GetRandomPrivateKey()
+	x, y, err := Curve.PrivateToPoint(priv)
 	if err != nil {
 		t.Errorf("Could not convert random private key to point: %v\n", err)
 	}
 
-	r, s, err := caigoCurve.Sign(hash, priv)
+	r, s, err := Curve.Sign(hash, priv)
 	if err != nil {
 		t.Errorf("Could not convert gen signature: %v\n", err)
 	}
 
 	badR := new(big.Int).Add(r, big.NewInt(1))
-	if caigoCurve.Verify(hash, badR, s, x, y) {
+	if Curve.Verify(hash, badR, s, x, y) {
 		t.Errorf("Verified bad signature %v %v\n", r, s)
 	}
 
 	badS := new(big.Int).Add(s, big.NewInt(1))
-	if caigoCurve.Verify(hash, r, badS, x, y) {
+	if Curve.Verify(hash, r, badS, x, y) {
 		t.Errorf("Verified bad signature %v %v\n", r, s)
 	}
 
 	badHash := new(big.Int).Add(hash, big.NewInt(1))
-	if caigoCurve.Verify(badHash, r, s, x, y) {
+	if Curve.Verify(badHash, r, s, x, y) {
 		t.Errorf("Verified bad signature %v %v\n", r, s)
 	}
 }
 
 func TestSignature(t *testing.T) {
 	testSignature := []struct {
-		private			*big.Int
-		publicX			*big.Int
-		publicY			*big.Int
-		hash			*big.Int
-		rIn				*big.Int
-		sIn				*big.Int
-		raw				string
+		private *big.Int
+		publicX *big.Int
+		publicY *big.Int
+		hash    *big.Int
+		rIn     *big.Int
+		sIn     *big.Int
+		raw     string
 	}{
 		{
 			private: StrToBig("104397037759416840641267745129360920341912682966983343798870479003077644689"),
 			publicX: StrToBig("1913222325711601599563860015182907040361852177892954047964358042507353067365"),
 			publicY: StrToBig("798905265292544287704154888908626830160713383708400542998012716235575472365"),
-			hash: StrToBig("2680576269831035412725132645807649347045997097070150916157159360688041452746"),
-			rIn: StrToBig("607684330780324271206686790958794501662789535258258105407533051445036595885"),
-			sIn: StrToBig("453590782387078613313238308551260565642934039343903827708036287031471258875"),
+			hash:    StrToBig("2680576269831035412725132645807649347045997097070150916157159360688041452746"),
+			rIn:     StrToBig("607684330780324271206686790958794501662789535258258105407533051445036595885"),
+			sIn:     StrToBig("453590782387078613313238308551260565642934039343903827708036287031471258875"),
 		},
 		{
 			hash: HexToBN("0x7f15c38ea577a26f4f553282fcfe4f1feeb8ecfaad8f221ae41abf8224cbddd"),
-			rIn: StrToBig("2458502865976494910213617956670505342647705497324144349552978333078363662855"),
-			sIn: StrToBig("3439514492576562277095748549117516048613512930236865921315982886313695689433"),
-			raw: "04033f45f07e1bd1a51b45fc24ec8c8c9908db9e42191be9e169bfcac0c0d997450319d0f53f6ca077c4fa5207819144a2a4165daef6ee47a7c1d06c0dcaa3e456",
+			rIn:  StrToBig("2458502865976494910213617956670505342647705497324144349552978333078363662855"),
+			sIn:  StrToBig("3439514492576562277095748549117516048613512930236865921315982886313695689433"),
+			raw:  "04033f45f07e1bd1a51b45fc24ec8c8c9908db9e42191be9e169bfcac0c0d997450319d0f53f6ca077c4fa5207819144a2a4165daef6ee47a7c1d06c0dcaa3e456",
 		},
 		{
-			hash: HexToBN("0x324df642fcc7d98b1d9941250840704f35b9ac2e3e2b58b6a034cc09adac54c"),
+			hash:    HexToBN("0x324df642fcc7d98b1d9941250840704f35b9ac2e3e2b58b6a034cc09adac54c"),
 			publicX: HexToBN("0x4e52f2f40700e9cdd0f386c31a1f160d0f310504fc508a1051b747a26070d10"),
-			rIn: StrToBig("2849277527182985104629156126825776904262411756563556603659114084811678482647"),
-			sIn: StrToBig("3156340738553451171391693475354397094160428600037567299774561739201502791079"),
+			rIn:     StrToBig("2849277527182985104629156126825776904262411756563556603659114084811678482647"),
+			sIn:     StrToBig("3156340738553451171391693475354397094160428600037567299774561739201502791079"),
 		},
 	}
 
@@ -158,24 +148,24 @@ func TestSignature(t *testing.T) {
 	for _, tt := range testSignature {
 		if tt.raw != "" {
 			h, _ := HexToBytes(tt.raw)
-			tt.publicX, tt.publicY = elliptic.Unmarshal(curve, h)
+			tt.publicX, tt.publicY = elliptic.Unmarshal(Curve, h)
 		} else if tt.private != nil {
-			tt.publicX, tt.publicY, err = caigoCurve.PrivateToPoint(tt.private)
+			tt.publicX, tt.publicY, err = Curve.PrivateToPoint(tt.private)
 			if err != nil {
 				t.Errorf("Could not convert random private key to point: %v\n", err)
 			}
 		} else if tt.publicX != nil {
-			tt.publicY = caigoCurve.GetYCoordinate(tt.publicX)
+			tt.publicY = Curve.GetYCoordinate(tt.publicX)
 		}
 
-		if tt.rIn == nil  && tt.private != nil {
-			tt.rIn, tt.sIn, err = caigoCurve.Sign(tt.hash, tt.private)
+		if tt.rIn == nil && tt.private != nil {
+			tt.rIn, tt.sIn, err = Curve.Sign(tt.hash, tt.private)
 			if err != nil {
 				t.Errorf("Could not sign good hash: %v\n", err)
 			}
 		}
-		
-		if !caigoCurve.Verify(tt.hash, tt.rIn, tt.sIn, tt.publicX, tt.publicY) {
+
+		if !Curve.Verify(tt.hash, tt.rIn, tt.sIn, tt.publicX, tt.publicY) {
 			t.Errorf("successful signature did not verify\n")
 		}
 	}

--- a/curve_test.go
+++ b/curve_test.go
@@ -6,16 +6,6 @@ import (
 	"testing"
 )
 
-var curve StarkCurve
-
-func init() {
-	var err error
-	curve, err = SC(WithConstants("./pedersen_params.json"))
-	if err != nil {
-		panic(err.Error())
-	}
-}
-
 func BenchmarkPedersenHash(b *testing.B) {
 	suite := [][]*big.Int{
 		[]*big.Int{HexToBN("0x12773"), HexToBN("0x872362")},
@@ -29,15 +19,15 @@ func BenchmarkPedersenHash(b *testing.B) {
 
 	for _, test := range suite {
 		b.Run(fmt.Sprintf("input_size_%d_%d", test[0].BitLen(), test[1].BitLen()), func(b *testing.B) {
-			curve.PedersenHash(test)
+			Curve.PedersenHash(test)
 		})
 	}
 }
 
 func TestPedersenHash(t *testing.T) {
 	testPedersen := []struct {
-		elements		[]*big.Int
-		expected		*big.Int
+		elements []*big.Int
+		expected *big.Int
 	}{
 		{
 			elements: []*big.Int{HexToBN("0x12773"), HexToBN("0x872362")},
@@ -54,7 +44,7 @@ func TestPedersenHash(t *testing.T) {
 	}
 
 	for _, tt := range testPedersen {
-		hash, err := curve.PedersenHash(tt.elements)
+		hash, err := Curve.PedersenHash(tt.elements)
 		if err != nil {
 			t.Errorf("Hashing err: %v\n", err)
 		}
@@ -66,25 +56,25 @@ func TestPedersenHash(t *testing.T) {
 
 func TestDivMod(t *testing.T) {
 	testDivmod := []struct {
-		x *big.Int
-		y *big.Int
-		expected		*big.Int
+		x        *big.Int
+		y        *big.Int
+		expected *big.Int
 	}{
 		{
-			x: StrToBig("311379432064974854430469844112069886938521247361583891764940938105250923060"),
-			y: StrToBig("621253665351494585790174448601059271924288186997865022894315848222045687999"),
+			x:        StrToBig("311379432064974854430469844112069886938521247361583891764940938105250923060"),
+			y:        StrToBig("621253665351494585790174448601059271924288186997865022894315848222045687999"),
 			expected: StrToBig("2577265149861519081806762825827825639379641276854712526969977081060187505740"),
 		},
 		{
-			x: big.NewInt(1),
-			y: big.NewInt(2),
+			x:        big.NewInt(1),
+			y:        big.NewInt(2),
 			expected: HexToBN("0x0400000000000008800000000000000000000000000000000000000000000001"),
 		},
 	}
 
-	for _, tt := range testDivmod{
-		divR := DivMod(tt.x, tt.y, curve.P)
-		
+	for _, tt := range testDivmod {
+		divR := DivMod(tt.x, tt.y, Curve.P)
+
 		if divR.Cmp(tt.expected) != 0 {
 			t.Errorf("DivMod Res %v does not == expected %v\n", divR, tt.expected)
 		}
@@ -93,30 +83,30 @@ func TestDivMod(t *testing.T) {
 
 func TestAdd(t *testing.T) {
 	testAdd := []struct {
-		x *big.Int
-		y *big.Int
-		expectedX		*big.Int
-		expectedY		*big.Int
+		x         *big.Int
+		y         *big.Int
+		expectedX *big.Int
+		expectedY *big.Int
 	}{
 		{
-			x: StrToBig("1468732614996758835380505372879805860898778283940581072611506469031548393285"),
-			y: StrToBig("1402551897475685522592936265087340527872184619899218186422141407423956771926"),
+			x:         StrToBig("1468732614996758835380505372879805860898778283940581072611506469031548393285"),
+			y:         StrToBig("1402551897475685522592936265087340527872184619899218186422141407423956771926"),
 			expectedX: StrToBig("2573054162739002771275146649287762003525422629677678278801887452213127777391"),
 			expectedY: StrToBig("3086444303034188041185211625370405120551769541291810669307042006593736192813"),
 		},
 		{
-			x: big.NewInt(1),
-			y: big.NewInt(2),
+			x:         big.NewInt(1),
+			y:         big.NewInt(2),
 			expectedX: StrToBig("225199957243206662471193729647752088571005624230831233470296838210993906468"),
 			expectedY: StrToBig("190092378222341939862849656213289777723812734888226565973306202593691957981"),
 		},
 	}
 
 	for _, tt := range testAdd {
-		resX, resY := curve.Add(curve.Gx, curve.Gy, tt.x, tt.y)
+		resX, resY := Curve.Add(Curve.Gx, Curve.Gy, tt.x, tt.y)
 		if resX.Cmp(tt.expectedX) != 0 {
 			t.Errorf("ResX %v does not == expected %v\n", resX, tt.expectedX)
-	
+
 		}
 		if resY.Cmp(tt.expectedY) != 0 {
 			t.Errorf("ResY %v does not == expected %v\n", resY, tt.expectedY)
@@ -126,30 +116,30 @@ func TestAdd(t *testing.T) {
 
 func TestMultAir(t *testing.T) {
 	testMult := []struct {
-		r *big.Int
-		x *big.Int
-		y *big.Int
-		expectedX		*big.Int
-		expectedY		*big.Int
+		r         *big.Int
+		x         *big.Int
+		y         *big.Int
+		expectedX *big.Int
+		expectedY *big.Int
 	}{
 		{
-			r: StrToBig("2458502865976494910213617956670505342647705497324144349552978333078363662855"),
-			x: StrToBig("1468732614996758835380505372879805860898778283940581072611506469031548393285"),
-			y: StrToBig("1402551897475685522592936265087340527872184619899218186422141407423956771926"),
+			r:         StrToBig("2458502865976494910213617956670505342647705497324144349552978333078363662855"),
+			x:         StrToBig("1468732614996758835380505372879805860898778283940581072611506469031548393285"),
+			y:         StrToBig("1402551897475685522592936265087340527872184619899218186422141407423956771926"),
 			expectedX: StrToBig("182543067952221301675635959482860590467161609552169396182763685292434699999"),
 			expectedY: StrToBig("3154881600662997558972388646773898448430820936643060392452233533274798056266"),
 		},
 	}
 
 	for _, tt := range testMult {
-		x, y, err := curve.MimicEcMultAir(tt.r, tt.x, tt.y, curve.Gx, curve.Gy)
+		x, y, err := Curve.MimicEcMultAir(tt.r, tt.x, tt.y, Curve.Gx, Curve.Gy)
 		if err != nil {
 			t.Errorf("MultAirERR %v\n", err)
 		}
-	
+
 		if x.Cmp(tt.expectedX) != 0 {
 			t.Errorf("ResX %v does not == expected %v\n", x, tt.expectedX)
-	
+
 		}
 		if y.Cmp(tt.expectedY) != 0 {
 			t.Errorf("ResY %v does not == expected %v\n", y, tt.expectedY)

--- a/examples/account/main.go
+++ b/examples/account/main.go
@@ -21,13 +21,6 @@ var (
 )
 
 func main() {
-	// init the stark curve with constants
-	// 'WithConstants()' will pull the StarkNet 'pedersen_params.json' file if you don't have it locally
-	curve, err := caigo.SC(caigo.WithConstants())
-	if err != nil {
-		panic(err.Error())
-	}
-
 	// init starknet gateway client
 	gw := gateway.NewProvider(gateway.WithChain(name))
 
@@ -42,7 +35,7 @@ func main() {
 	fmt.Println("Counter is currently at: ", callResp[0])
 
 	// init account handler
-	account, err := caigo.NewAccount(&curve, privakeKey, address, gw)
+	account, err := caigo.NewAccount(privakeKey, address, gw)
 	if err != nil {
 		panic(err.Error())
 	}

--- a/examples/curve/main.go
+++ b/examples/curve/main.go
@@ -14,29 +14,24 @@ func main() {
 		It is recommended to use in the same way(i.e. `curve.Sign` and not `ecdsa.Sign`).
 		NOTE: when not given local file path this pulls the curve data from Starkware github repo
 	*/
-	curve, err := caigo.SC(caigo.WithConstants())
+	hash, err := caigo.Curve.PedersenHash([]*big.Int{caigo.HexToBN("0x12773"), caigo.HexToBN("0x872362")})
 	if err != nil {
 		panic(err.Error())
 	}
 
-	hash, err := curve.PedersenHash([]*big.Int{caigo.HexToBN("0x12773"), caigo.HexToBN("0x872362")})
+	priv, _ := caigo.Curve.GetRandomPrivateKey()
+
+	x, y, err := caigo.Curve.PrivateToPoint(priv)
 	if err != nil {
 		panic(err.Error())
 	}
 
-	priv, _ := curve.GetRandomPrivateKey()
-
-	x, y, err := curve.PrivateToPoint(priv)
+	r, s, err := caigo.Curve.Sign(hash, priv)
 	if err != nil {
 		panic(err.Error())
 	}
 
-	r, s, err := curve.Sign(hash, priv)
-	if err != nil {
-		panic(err.Error())
-	}
-
-	if curve.Verify(hash, r, s, x, y) {
+	if caigo.Curve.Verify(hash, r, s, x, y) {
 		fmt.Println("signature is valid")
 	} else {
 		fmt.Println("signature is invalid")

--- a/gateway/starknet_test.go
+++ b/gateway/starknet_test.go
@@ -122,12 +122,7 @@ func TestDeclare(t *testing.T) {
 
 func TestExecuteGoerli(t *testing.T) {
 	for _, testAccount := range testnetAccounts {
-		curve, err := caigo.SC(caigo.WithConstants(projectRoot + "pedersen_params.json"))
-		if err != nil {
-			t.Errorf("testnet: could not init with constant points: %v\n", err)
-		}
-
-		account, err := caigo.NewAccount(&curve, testAccount.PrivateKey, testAccount.Address, NewProvider())
+		account, err := caigo.NewAccount(testAccount.PrivateKey, testAccount.Address, NewProvider())
 		if err != nil {
 			t.Errorf("testnet: could not create account: %v\n", err)
 		}
@@ -205,6 +200,9 @@ func TestE2EDevnet(t *testing.T) {
 	}
 
 	txDetails, err := gw.Transaction(context.Background(), TransactionOptions{TransactionHash: deployTx.TransactionHash})
+	if err != nil {
+		t.Errorf("fetching transaction: %v", err)
+	}
 
 	for i := 0; i < 3; i++ {
 		rand := fmt.Sprintf("0x%x", rand.New(rand.NewSource(time.Now().UnixNano())).Intn(SEED))
@@ -216,12 +214,8 @@ func TestE2EDevnet(t *testing.T) {
 				Calldata:           []string{rand},
 			},
 		}
-		curve, err := caigo.SC(caigo.WithConstants(projectRoot + "pedersen_params.json"))
-		if err != nil {
-			t.Errorf("testnet: could not init with constant points: %v\n", err)
-		}
 
-		account, err := caigo.NewAccount(&curve, devnetAccounts[i].PrivateKey, devnetAccounts[i].Address, gw)
+		account, err := caigo.NewAccount(devnetAccounts[i].PrivateKey, devnetAccounts[i].Address, gw)
 		if err != nil {
 			t.Errorf("testnet: could not create account: %v\n", err)
 		}

--- a/typed_test.go
+++ b/typed_test.go
@@ -52,11 +52,6 @@ func MockTypedData() (ttd TypedData) {
 func TestGetMessageHash(t *testing.T) {
 	ttd := MockTypedData()
 
-	curve, err := SC(WithConstants("./pedersen_params.json"))
-	if err != nil {
-		t.Errorf("Could not init with constant points: %v\n", err)
-	}
-
 	mail := Mail{
 		From: Person{
 			Name:   "Cow",
@@ -69,7 +64,7 @@ func TestGetMessageHash(t *testing.T) {
 		Contents: "Hello, Bob!",
 	}
 
-	hash, err := ttd.GetMessageHash(HexToBN("0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826"), mail, curve)
+	hash, err := ttd.GetMessageHash(HexToBN("0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826"), mail, Curve)
 	if err != nil {
 		t.Errorf("Could not hash message: %v\n", err)
 	}
@@ -82,8 +77,6 @@ func TestGetMessageHash(t *testing.T) {
 
 func BenchmarkGetMessageHash(b *testing.B) {
 	ttd := MockTypedData()
-
-	curve, _ := SC(WithConstants("./pedersen_params.json"))
 
 	mail := Mail{
 		From: Person{
@@ -98,19 +91,14 @@ func BenchmarkGetMessageHash(b *testing.B) {
 	}
 	addr := HexToBN("0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826")
 	b.Run(fmt.Sprintf("input_size_%d", addr.BitLen()), func(b *testing.B) {
-		ttd.GetMessageHash(addr, mail, curve)
+		ttd.GetMessageHash(addr, mail, Curve)
 	})
 }
 
 func TestGetDomainHash(t *testing.T) {
 	ttd := MockTypedData()
 
-	curve, err := SC(WithConstants("./pedersen_params.json"))
-	if err != nil {
-		t.Errorf("Could not init with constant points: %v\n", err)
-	}
-
-	hash, err := ttd.GetTypedMessageHash("StarkNetDomain", ttd.Domain, curve)
+	hash, err := ttd.GetTypedMessageHash("StarkNetDomain", ttd.Domain, Curve)
 	if err != nil {
 		t.Errorf("Could not hash message: %v\n", err)
 	}
@@ -137,12 +125,7 @@ func TestGetTypedMessageHash(t *testing.T) {
 		Contents: "Hello, Bob!",
 	}
 
-	curve, err := SC(WithConstants("./pedersen_params.json"))
-	if err != nil {
-		t.Errorf("Could not init with constant points: %v\n", err)
-	}
-
-	hash, err := ttd.GetTypedMessageHash("Mail", mail, curve)
+	hash, err := ttd.GetTypedMessageHash("Mail", mail, Curve)
 	if err != nil {
 		t.Errorf("Could get typed message hash: %v\n", err)
 	}


### PR DESCRIPTION
uses go:embed to embed the pedersen params and improves the ergonomics of the library. we might consider moving `Curve` to a `curve` package so the api can be e.g. `curve.Sign(...)`