### PR TITLE
Move the interface to Felt

### DIFF
--- a/account.go
+++ b/account.go
@@ -16,7 +16,7 @@ const (
 
 type Account struct {
 	Provider types.Provider
-	Address  string
+	Address  *types.Felt
 	PublicX  *big.Int
 	PublicY  *big.Int
 	private  *big.Int
@@ -29,13 +29,13 @@ type ExecuteDetails struct {
 }
 
 /*
-	Instantiate a new StarkNet Account which includes structures for calling the network and signing transactions:
-	- private signing key
-	- stark curve definition
-	- full provider definition
-	- public key pair for signature verifications
+Instantiate a new StarkNet Account which includes structures for calling the network and signing transactions:
+- private signing key
+- stark curve definition
+- full provider definition
+- public key pair for signature verifications
 */
-func NewAccount(private, address string, provider types.Provider) (*Account, error) {
+func NewAccount(private string, address *types.Felt, provider types.Provider) (*Account, error) {
 	priv := SNValToBN(private)
 	x, y, err := Curve.PrivateToPoint(priv)
 	if err != nil {
@@ -56,9 +56,9 @@ func (account *Account) Sign(msgHash *big.Int) (*big.Int, *big.Int, error) {
 }
 
 /*
-	invocation wrapper for StarkNet account calls to '__execute__' contact calls through an account abstraction
-	- implementation has been tested against OpenZeppelin Account contract as of: https://github.com/OpenZeppelin/cairo-contracts/blob/4116c1ecbed9f821a2aa714c993a35c1682c946e/src/openzeppelin/account/Account.cairo
-	- accepts a multicall
+invocation wrapper for StarkNet account calls to '__execute__' contact calls through an account abstraction
+- implementation has been tested against OpenZeppelin Account contract as of: https://github.com/OpenZeppelin/cairo-contracts/blob/4116c1ecbed9f821a2aa714c993a35c1682c946e/src/openzeppelin/account/Account.cairo
+- accepts a multicall
 */
 func (account *Account) Execute(ctx context.Context, calls []types.Transaction, details ExecuteDetails) (*types.AddTxResponse, error) {
 	if details.Nonce == nil {
@@ -102,7 +102,7 @@ func (account *Account) HashMultiCall(fee *types.Felt, nonce *big.Int, calls []t
 	multiHashData := []*big.Int{
 		UTF8StrToBig(TRANSACTION_PREFIX),
 		big.NewInt(TRANSACTION_VERSION),
-		SNValToBN(account.Address),
+		SNValToBN(account.Address.String()),
 		GetSelectorFromName(EXECUTE_SELECTOR),
 		cdHash,
 		fee.Int,
@@ -137,7 +137,7 @@ func (account *Account) fmtExecute(ctx context.Context, calls []types.Transactio
 	req := types.FunctionInvoke{
 		FunctionCall: types.FunctionCall{
 			ContractAddress:    account.Address,
-			EntryPointSelector: EXECUTE_SELECTOR,
+			EntryPointSelector: types.StrToFelt(EXECUTE_SELECTOR),
 			Calldata:           fmtExecuteCalldataStrings(details.Nonce, calls),
 		},
 		MaxFee: details.MaxFee,
@@ -157,22 +157,22 @@ func (account *Account) fmtExecute(ctx context.Context, calls []types.Transactio
 	return &req, nil
 }
 
-func fmtExecuteCalldataStrings(nonce *big.Int, calls []types.Transaction) (calldataStrings []string) {
+func fmtExecuteCalldataStrings(nonce *big.Int, calls []types.Transaction) (calldataStrings []*types.Felt) {
 	callArray := fmtExecuteCalldata(nonce, calls)
 	for _, data := range callArray {
-		calldataStrings = append(calldataStrings, data.String())
+		calldataStrings = append(calldataStrings, types.BigToFelt(data))
 	}
 	return calldataStrings
 }
 
 /*
-	Formats the multicall transactions in a format which can be signed and verified by the network and OpenZeppelin account contracts
+Formats the multicall transactions in a format which can be signed and verified by the network and OpenZeppelin account contracts
 */
 func fmtExecuteCalldata(nonce *big.Int, calls []types.Transaction) (calldataArray []*big.Int) {
 	callArray := []*big.Int{big.NewInt(int64(len(calls)))}
 
 	for _, tx := range calls {
-		callArray = append(callArray, SNValToBN(tx.ContractAddress), GetSelectorFromName(tx.EntryPointSelector))
+		callArray = append(callArray, SNValToBN(tx.ContractAddress.String()), GetSelectorFromName(tx.EntryPointSelector.String()))
 
 		if len(tx.Calldata) == 0 {
 			callArray = append(callArray, big.NewInt(0), big.NewInt(0))
@@ -182,7 +182,7 @@ func fmtExecuteCalldata(nonce *big.Int, calls []types.Transaction) (calldataArra
 
 		callArray = append(callArray, big.NewInt(int64(len(calldataArray))), big.NewInt(int64(len(tx.Calldata))))
 		for _, cd := range tx.Calldata {
-			calldataArray = append(calldataArray, SNValToBN(cd))
+			calldataArray = append(calldataArray, SNValToBN(cd.String()))
 		}
 	}
 

--- a/curve.go
+++ b/curve.go
@@ -301,7 +301,7 @@ func (sc StarkCurve) HashTx(addr *big.Int, tx types.Transaction) (hash *big.Int,
 
 	txHashData := []*big.Int{
 		SNValToBN(tx.ContractAddress.String()),
-		GetSelectorFromName(tx.EntryPointSelector.String()),
+		GetSelectorFromName(tx.EntryPointSelector),
 		cdHash,
 	}
 
@@ -324,7 +324,7 @@ func (sc StarkCurve) HashMsg(addr *big.Int, tx types.Transaction) (hash *big.Int
 	txHashData := []*big.Int{
 		addr,
 		SNValToBN(tx.ContractAddress.String()),
-		GetSelectorFromName(tx.EntryPointSelector.String()),
+		GetSelectorFromName(tx.EntryPointSelector),
 		cdHash,
 		SNValToBN(tx.Nonce.String()),
 	}

--- a/curve.go
+++ b/curve.go
@@ -19,8 +19,8 @@ import (
 var Curve StarkCurve
 
 /*
-	Returned stark curve includes several values above and beyond
-	what the 'elliptic' interface calls for to facilitate common starkware functions
+Returned stark curve includes several values above and beyond
+what the 'elliptic' interface calls for to facilitate common starkware functions
 */
 type StarkCurve struct {
 	*elliptic.CurveParams
@@ -291,7 +291,7 @@ func DivMod(n, m, p *big.Int) *big.Int {
 func (sc StarkCurve) HashTx(addr *big.Int, tx types.Transaction) (hash *big.Int, err error) {
 	calldataArray := []*big.Int{big.NewInt(int64(len(tx.Calldata)))}
 	for _, cd := range tx.Calldata {
-		calldataArray = append(calldataArray, SNValToBN(cd))
+		calldataArray = append(calldataArray, SNValToBN(cd.String()))
 	}
 
 	cdHash, err := sc.HashElements(calldataArray)
@@ -300,8 +300,8 @@ func (sc StarkCurve) HashTx(addr *big.Int, tx types.Transaction) (hash *big.Int,
 	}
 
 	txHashData := []*big.Int{
-		SNValToBN(tx.ContractAddress),
-		GetSelectorFromName(tx.EntryPointSelector),
+		SNValToBN(tx.ContractAddress.String()),
+		GetSelectorFromName(tx.EntryPointSelector.String()),
 		cdHash,
 	}
 
@@ -313,7 +313,7 @@ func (sc StarkCurve) HashTx(addr *big.Int, tx types.Transaction) (hash *big.Int,
 func (sc StarkCurve) HashMsg(addr *big.Int, tx types.Transaction) (hash *big.Int, err error) {
 	calldataArray := []*big.Int{big.NewInt(int64(len(tx.Calldata)))}
 	for _, cd := range tx.Calldata {
-		calldataArray = append(calldataArray, HexToBN(cd))
+		calldataArray = append(calldataArray, HexToBN(cd.String()))
 	}
 
 	cdHash, err := sc.HashElements(calldataArray)
@@ -323,10 +323,10 @@ func (sc StarkCurve) HashMsg(addr *big.Int, tx types.Transaction) (hash *big.Int
 
 	txHashData := []*big.Int{
 		addr,
-		SNValToBN(tx.ContractAddress),
-		GetSelectorFromName(tx.EntryPointSelector),
+		SNValToBN(tx.ContractAddress.String()),
+		GetSelectorFromName(tx.EntryPointSelector.String()),
 		cdHash,
-		SNValToBN(tx.Nonce),
+		SNValToBN(tx.Nonce.String()),
 	}
 
 	hash, err = sc.ComputeHashOnElements(txHashData)

--- a/gateway/account.go
+++ b/gateway/account.go
@@ -11,10 +11,10 @@ import (
 	"github.com/dontpanicdao/caigo/types"
 )
 
-func (sg *Gateway) AccountNonce(ctx context.Context, address string) (*big.Int, error) {
+func (sg *Gateway) AccountNonce(ctx context.Context, address *types.Felt) (*big.Int, error) {
 	resp, err := sg.Call(ctx, types.FunctionCall{
 		ContractAddress:    address,
-		EntryPointSelector: "get_nonce",
+		EntryPointSelector: types.StrToFelt("get_nonce"),
 	}, "")
 	if err != nil {
 		return nil, err
@@ -27,8 +27,6 @@ func (sg *Gateway) AccountNonce(ctx context.Context, address string) (*big.Int, 
 }
 
 func (sg *Gateway) EstimateFee(ctx context.Context, call types.FunctionInvoke, hash string) (*types.FeeEstimate, error) {
-	call.EntryPointSelector = caigo.BigToHex(caigo.GetSelectorFromName(call.EntryPointSelector))
-
 	req, err := sg.newRequest(ctx, http.MethodPost, "/estimate_fee", call)
 	if err != nil {
 		return nil, err

--- a/gateway/block_test.go
+++ b/gateway/block_test.go
@@ -2,13 +2,18 @@ package gateway
 
 import (
 	"context"
+	"fmt"
+	"math/big"
 	"testing"
+
+	"github.com/dontpanicdao/caigo/types"
+	"github.com/google/go-querystring/query"
 )
 
 func Test_BlockIDByHash(t *testing.T) {
 	gw := NewClient()
 
-	id, err := gw.BlockIDByHash(context.Background(), "0x5239614da0a08b53fa8cbdbdcb2d852e153027ae26a2ae3d43f7ceceb28551e")
+	id, err := gw.BlockIDByHash(context.Background(), types.StrToFelt("0x5239614da0a08b53fa8cbdbdcb2d852e153027ae26a2ae3d43f7ceceb28551e"))
 	if err != nil || id == 0 {
 		t.Errorf("Getting Block ID by Hash: %v", err)
 	}
@@ -22,11 +27,64 @@ func Test_BlockHashByID(t *testing.T) {
 	gw := NewClient()
 
 	id, err := gw.BlockHashByID(context.Background(), 159179)
-	if err != nil || id == "" {
+	if err != nil {
 		t.Errorf("Getting Block ID by Hash: %v", err)
 	}
 
-	if id != "0x5239614da0a08b53fa8cbdbdcb2d852e153027ae26a2ae3d43f7ceceb28551e" {
+	if id.String() != "0x5239614da0a08b53fa8cbdbdcb2d852e153027ae26a2ae3d43f7ceceb28551e" {
 		t.Errorf("Wrong Block ID from Hash: %v", err)
+	}
+}
+
+func TestValueWithFeltWithPrepare(t *testing.T) {
+	v := &BlockOptions{
+		BlockNumber: 0,
+		BlockHash:   &types.Felt{Int: big.NewInt(1)},
+	}
+
+	type tempBlockOptions struct {
+		BlockNumber uint64 `url:"blockNumber,omitempty"`
+		BlockHash   string `url:"blockHash,omitempty"`
+	}
+	out := tempBlockOptions{
+		BlockNumber: v.BlockNumber,
+	}
+	if v.BlockHash != nil && v.BlockHash.Int != nil {
+		out.BlockHash = fmt.Sprintf("0x%s", v.BlockHash.Int.Text(16))
+	}
+	output, err := query.Values(out)
+	if err != nil {
+		t.Error(err)
+	}
+	x := output.Get("blockHash")
+	if x != "0x1" {
+		t.Errorf("Blockhash should be 1 (or 0x1), instead: \"%s\"", x)
+	}
+}
+
+// TestGateway checks the gateway can be accessed.
+func TestBlock(t *testing.T) {
+	testConfig := beforeEach(t)
+
+	type testSetType struct {
+		BlockHash *types.Felt
+	}
+	testSet := map[string][]testSetType{
+		"devnet":  {},
+		"mainnet": {{BlockHash: types.StrToFelt("0x4ee4c886d1767b7165a1e3a7c6ad145543988465f2bda680c16a79536f6d81f")}},
+		"mock":    {{BlockHash: types.StrToFelt("0xdeadbeef")}},
+		"testnet": {{BlockHash: types.StrToFelt("0x787af09f1cacdc5de1df83e8cdca3a48c1194171c742e78a9f684cb7aa4db")}},
+	}[testEnv]
+
+	for _, test := range testSet {
+		block, err := testConfig.client.Block(context.Background(), &BlockOptions{BlockHash: test.BlockHash})
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if block == nil || block.BlockHash == nil || block.BlockHash.Cmp(test.BlockHash.Int) != 0 {
+			t.Fatalf("expecting %v, instead: %v", test.BlockHash, block.BlockHash)
+		}
 	}
 }

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -67,29 +67,29 @@ func setupDevnet() {
 		{
 			PrivateKey: "0x28a778906e0b5f4d240ad25c5993422e06769eb799483ae602cc3830e3f538",
 			PublicKey:  "0x63f0f116c78146e1e4e193923fe3cad5f236c0ed61c2dc04487a733031359b8",
-			Address:    "0x0254cfb85c43dee6f410867b9795b5309beb4a2640211c8f5b2c7681a47e5f3c",
+			Address:    types.StrToFelt("10000"),
 			Transactions: []types.Transaction{
 				{
-					ContractAddress:    "0x22b0f298db2f1776f24cda70f431566d9ef1d0e54a52ee6d930b80ec8c55a62",
-					EntryPointSelector: "update_single_store",
-					Calldata:           []string{"3"},
+					ContractAddress:    types.StrToFelt("10000"),
+					EntryPointSelector: types.StrToFelt("update_single_store"),
+					Calldata:           []*types.Felt{types.StrToFelt("3")},
 				},
 			},
 		},
 		{
 			PrivateKey: "0x879d7dad7f9df54e1474ccf572266bba36d40e3202c799d6c477506647c126",
 			PublicKey:  "0xb95246e1caeaf34672906d7b74bd6968231a2130f41e85aebb62d43b88068",
-			Address:    "0x0126dd900b82c7fc95e8851f9c64d0600992e82657388a48d3c466553d4d9246",
+			Address:    types.StrToFelt("20000"),
 			Transactions: []types.Transaction{
 				{
-					ContractAddress:    "0x22b0f298db2f1776f24cda70f431566d9ef1d0e54a52ee6d930b80ec8c55a62",
-					EntryPointSelector: "update_multi_store",
-					Calldata:           []string{"4", "7"},
+					ContractAddress:    types.StrToFelt("20000"),
+					EntryPointSelector: types.StrToFelt("update_multi_store"),
+					Calldata:           []*types.Felt{types.StrToFelt("4"), types.StrToFelt("5")},
 				},
 				{
-					ContractAddress:    "0x22b0f298db2f1776f24cda70f431566d9ef1d0e54a52ee6d930b80ec8c55a62",
-					EntryPointSelector: "update_struct_store",
-					Calldata:           []string{"435921360636", "15000000000000000000", "0"},
+					ContractAddress:    types.StrToFelt("20000"),
+					EntryPointSelector: types.StrToFelt("update_struct_store"),
+					Calldata:           []*types.Felt{types.StrToFelt("435921360636"), types.StrToFelt("15000000000000000000"), types.StrToFelt("0")},
 				},
 			},
 		},
@@ -133,13 +133,13 @@ func TestGateway(t *testing.T) {
 	testConfig := beforeEach(t)
 
 	type testSetType struct {
-		BlockHash string
+		BlockHash *types.Felt
 	}
 	testSet := map[string][]testSetType{
 		"devnet":  {},
-		"mainnet": {{BlockHash: "0x4ee4c886d1767b7165a1e3a7c6ad145543988465f2bda680c16a79536f6d81f"}},
-		"mock":    {{BlockHash: "0xdeadbeef"}},
-		"testnet": {{BlockHash: "0x787af09f1cacdc5de1df83e8cdca3a48c1194171c742e78a9f684cb7aa4db"}},
+		"mainnet": {{BlockHash: types.StrToFelt("0x4ee4c886d1767b7165a1e3a7c6ad145543988465f2bda680c16a79536f6d81f")}},
+		"mock":    {{BlockHash: types.StrToFelt("0xdeadbeef")}},
+		"testnet": {{BlockHash: types.StrToFelt("0x787af09f1cacdc5de1df83e8cdca3a48c1194171c742e78a9f684cb7aa4db")}},
 	}[testEnv]
 
 	for _, test := range testSet {
@@ -148,8 +148,8 @@ func TestGateway(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if block.BlockHash != test.BlockHash {
-			t.Fatalf("expecting %s, instead: %s", "", block.BlockHash)
+		if block == nil || block.BlockHash == nil || block.BlockHash.Cmp(test.BlockHash.Int) != 0 {
+			t.Fatalf("expecting %v, instead: %v", test.BlockHash, block.BlockHash)
 		}
 	}
 }

--- a/gateway/mock_test.go
+++ b/gateway/mock_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 
 	"encoding/json"
+
+	"github.com/dontpanicdao/caigo/types"
 )
 
 // httpMock is a mock of the client.
@@ -37,7 +39,7 @@ func (r *httpMock) Do(req *http.Request) (*http.Response, error) {
 func get_block(req *http.Request) (*http.Response, error) {
 	blockHash := req.URL.Query().Get("blockHash")
 	block := Block{
-		BlockHash: blockHash,
+		BlockHash: types.StrToFelt(blockHash),
 	}
 	body, _ := json.Marshal(block)
 	return &http.Response{

--- a/gateway/provider.go
+++ b/gateway/provider.go
@@ -17,7 +17,7 @@ func NewProvider(opts ...Option) *GatewayProvider {
 	}
 }
 
-func (p *GatewayProvider) BlockByHash(ctx context.Context, hash, scope string) (*types.Block, error) {
+func (p *GatewayProvider) BlockByHash(ctx context.Context, hash *types.Felt, scope string) (*types.Block, error) {
 	b, err := p.Block(ctx, &BlockOptions{BlockHash: hash})
 	if err != nil {
 		return nil, err

--- a/gateway/starknet_test.go
+++ b/gateway/starknet_test.go
@@ -37,7 +37,7 @@ var (
 type TestAccountType struct {
 	PrivateKey   string              `json:"private_key"`
 	PublicKey    string              `json:"public_key"`
-	Address      string              `json:"address"`
+	Address      *types.Felt         `json:"address"`
 	Transactions []types.Transaction `json:"transactions,omitempty"`
 }
 
@@ -84,7 +84,7 @@ func TestExecuteGoerli(t *testing.T) {
 		fee := new(types.Felt)
 		fee.Int = new(big.Int).SetUint64(feeEstimate.OverallFee * FEE_MARGIN / 100)
 
-		_, err = account.Execute(context.Background(), testAccount.Transactions, 
+		_, err = account.Execute(context.Background(), testAccount.Transactions,
 			caigo.ExecuteDetails{
 				MaxFee: fee,
 			})
@@ -122,7 +122,7 @@ func TestCallGoerli(t *testing.T) {
 	for _, testAccount := range testnetAccounts {
 		call := types.FunctionCall{
 			ContractAddress:    testAccount.Address,
-			EntryPointSelector: "get_signer",
+			EntryPointSelector: types.StrToFelt("get_signer"),
 		}
 
 		resp, err := gw.Call(context.Background(), call, "")
@@ -174,8 +174,8 @@ func TestE2EDevnet(t *testing.T) {
 			tx := []types.Transaction{
 				{
 					ContractAddress:    txDetails.Transaction.ContractAddress,
-					EntryPointSelector: "set_rand",
-					Calldata:           []string{rand},
+					EntryPointSelector: types.StrToFelt("set_rand"),
+					Calldata:           []*types.Felt{types.StrToFelt(rand)},
 				},
 			}
 
@@ -199,7 +199,7 @@ func TestE2EDevnet(t *testing.T) {
 			execResp, err := account.Execute(context.Background(), tx,
 				caigo.ExecuteDetails{
 					MaxFee: fee,
-					Nonce: nonce,
+					Nonce:  nonce,
 				})
 			if err != nil {
 				t.Errorf("Could not execute test transaction: %v\n", err)
@@ -212,7 +212,7 @@ func TestE2EDevnet(t *testing.T) {
 
 			call := types.FunctionCall{
 				ContractAddress:    txDetails.Transaction.ContractAddress,
-				EntryPointSelector: "get_rand",
+				EntryPointSelector: types.StrToFelt("get_rand"),
 			}
 			callResp, err := gw.Call(context.Background(), call, "")
 			if err != nil {

--- a/gateway/transaction.go
+++ b/gateway/transaction.go
@@ -17,23 +17,23 @@ type StarknetTransaction struct {
 	TransactionIndex int         `json:"transaction_index"`
 	BlockNumber      int         `json:"block_number"`
 	Transaction      Transaction `json:"transaction"`
-	BlockHash        string      `json:"block_hash"`
+	BlockHash        *types.Felt `json:"block_hash"`
 	Status           string      `json:"status"`
 }
 
 type Transaction struct {
-	TransactionHash    string   `json:"transaction_hash,omitempty"`
-	ClassHash          string   `json:"class_hash,omitempty"`
-	ContractAddress    string   `json:"contract_address,omitempty"`
-	SenderAddress      string   `json:"sender_address,omitempty"`
-	EntryPointSelector string   `json:"entry_point_selector"`
-	Calldata           []string `json:"calldata"`
-	Signature          []string `json:"signature"`
-	EntryPointType     string   `json:"entry_point_type,omitempty"`
-	MaxFee             string   `json:"max_fee,omitempty"`
-	Nonce              string   `json:"nonce,omitempty"`
-	Version            string   `json:"version,omitempty"`
-	Type               string   `json:"type,omitempty"`
+	TransactionHash    *types.Felt   `json:"transaction_hash,omitempty"`
+	ClassHash          *types.Felt   `json:"class_hash,omitempty"`
+	ContractAddress    *types.Felt   `json:"contract_address,omitempty"`
+	SenderAddress      *types.Felt   `json:"sender_address,omitempty"`
+	EntryPointSelector *types.Felt   `json:"entry_point_selector"`
+	Calldata           []*types.Felt `json:"calldata"`
+	Signature          []*types.Felt `json:"signature"`
+	EntryPointType     *types.Felt   `json:"entry_point_type,omitempty"`
+	MaxFee             *types.Felt   `json:"max_fee,omitempty"`
+	Nonce              *types.Felt   `json:"nonce,omitempty"`
+	Version            string        `json:"version,omitempty"`
+	Type               string        `json:"type,omitempty"`
 }
 
 func (t Transaction) Normalize() *types.Transaction {

--- a/rpc/api.go
+++ b/rpc/api.go
@@ -41,7 +41,7 @@ type FunctionCallAdapter struct {
 func (sc *Client) Call(ctx context.Context, call types.FunctionCall, hash string) ([]string, error) {
 	callAdapter := FunctionCallAdapter{
 		ContractAddress:    call.ContractAddress.String(),
-		EntryPointSelector: caigo.BigToHex(caigo.GetSelectorFromName(call.EntryPointSelector.ShortString())),
+		EntryPointSelector: caigo.BigToHex(caigo.GetSelectorFromName(call.EntryPointSelector)),
 	}
 
 	if len(call.Calldata) == 0 {
@@ -334,10 +334,10 @@ func (sc *Client) EstimateFee(ctx context.Context, call types.FunctionInvoke, bl
 }
 
 // AccountNonce gets the latest nonce associated with the given address
-func (sc *Client) AccountNonce(ctx context.Context, contractAddress *types.Felt) (*big.Int, error) {
-	var nonce big.Int
+func (sc *Client) AccountNonce(ctx context.Context, contractAddress *types.Felt) (*types.Felt, error) {
+	var nonce *types.Felt
 	err := sc.do(ctx, "starknet_getNonce", &nonce, contractAddress.String())
-	return &nonce, err
+	return nonce, err
 }
 
 func toBlockNumArg(number *big.Int) interface{} {

--- a/rpc/api_addtransaction_test.go
+++ b/rpc/api_addtransaction_test.go
@@ -137,18 +137,18 @@ func TestAddInvokeTransaction(t *testing.T) {
 		"mock": {
 			{
 				FunctionCall: types.FunctionCall{
-					ContractAddress: "0x23371b227eaecd8e8920cd429d2cd0f3fee6abaacca08d3ab82a7cdd",
-					Calldata: []string{
-						"0x1",
-						"0x677bb1cdc050e8d63855e8743ab6e09179138def390676cc03c484daf112ba1",
-						"0x362398bec32bc0ebb411203221a35a0301193a96f317ebe5e40be9f60d15320",
-						"0x0",
-						"0x1",
-						"0x1",
-						"0x2b",
-						"0x0",
+					ContractAddress: types.StrToFelt("10000"),
+					Calldata: []*types.Felt{
+						types.StrToFelt("0x1"),
+						types.StrToFelt("0x677bb1cdc050e8d63855e8743ab6e09179138def390676cc03c484daf112ba1"),
+						types.StrToFelt("0x362398bec32bc0ebb411203221a35a0301193a96f317ebe5e40be9f60d15320"),
+						types.StrToFelt("0x0"),
+						types.StrToFelt("0x1"),
+						types.StrToFelt("0x1"),
+						types.StrToFelt("0x2b"),
+						types.StrToFelt("0x0"),
 					},
-					EntryPointSelector: "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
+					EntryPointSelector: types.StrToFelt("0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad"),
 				},
 				Signature: []string{
 					"3557065757165699682249469970267166698995647077461960906176449260016084767701",
@@ -163,18 +163,18 @@ func TestAddInvokeTransaction(t *testing.T) {
 		"mainnet": {
 			{
 				FunctionCall: types.FunctionCall{
-					ContractAddress: "0x23371b227eaecd8e8920cd429d2cd0f3fee6abaacca08d3ab82a7cdd",
-					Calldata: []string{
-						"0x1",
-						"0x677bb1cdc050e8d63855e8743ab6e09179138def390676cc03c484daf112ba1",
-						"0x362398bec32bc0ebb411203221a35a0301193a96f317ebe5e40be9f60d15320",
-						"0x0",
-						"0x1",
-						"0x1",
-						"0x2b",
-						"0x0",
+					ContractAddress: types.StrToFelt("10000"),
+					Calldata: []*types.Felt{
+						types.StrToFelt("0x1"),
+						types.StrToFelt("0x677bb1cdc050e8d63855e8743ab6e09179138def390676cc03c484daf112ba1"),
+						types.StrToFelt("0x362398bec32bc0ebb411203221a35a0301193a96f317ebe5e40be9f60d15320"),
+						types.StrToFelt("0x0"),
+						types.StrToFelt("0x1"),
+						types.StrToFelt("0x1"),
+						types.StrToFelt("0x2b"),
+						types.StrToFelt("0x0"),
 					},
-					EntryPointSelector: "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
+					EntryPointSelector: types.StrToFelt("0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad"),
 				},
 				Signature: []string{
 					"3557065757165699682249469970267166698995647077461960906176449260016084767701",

--- a/rpc/api_addtransaction_test.go
+++ b/rpc/api_addtransaction_test.go
@@ -148,7 +148,7 @@ func TestAddInvokeTransaction(t *testing.T) {
 						types.StrToFelt("0x2b"),
 						types.StrToFelt("0x0"),
 					},
-					EntryPointSelector: types.StrToFelt("0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad"),
+					EntryPointSelector: "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
 				},
 				Signature: []string{
 					"3557065757165699682249469970267166698995647077461960906176449260016084767701",
@@ -174,7 +174,7 @@ func TestAddInvokeTransaction(t *testing.T) {
 						types.StrToFelt("0x2b"),
 						types.StrToFelt("0x0"),
 					},
-					EntryPointSelector: types.StrToFelt("0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad"),
+					EntryPointSelector: "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
 				},
 				Signature: []string{
 					"3557065757165699682249469970267166698995647077461960906176449260016084767701",

--- a/rpc/api_block_test.go
+++ b/rpc/api_block_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"math/big"
 	"testing"
+
+	"github.com/dontpanicdao/caigo/types"
 )
 
 // TestBlockNumber tests BlockNumber and check the returned value is strictly positive
@@ -39,7 +41,7 @@ func TestBlockByNumber(t *testing.T) {
 	type testSetType struct {
 		BlockNumber       *big.Int
 		BlockScope        string
-		ExpectedBlockHash string
+		ExpectedBlockHash *types.Felt
 		ExpectedStatus    string
 		ExpectedTx0Hash   string
 	}
@@ -48,14 +50,14 @@ func TestBlockByNumber(t *testing.T) {
 			{
 				BlockNumber:       big.NewInt(1000),
 				BlockScope:        "FULL_TXN_AND_RECEIPTS",
-				ExpectedBlockHash: "0xdeadbeef",
+				ExpectedBlockHash: types.StrToFelt("0xdeadbeef"),
 				ExpectedStatus:    "ACCEPTED_ON_L1",
 				ExpectedTx0Hash:   "0xdeadbeef",
 			},
 			{
 				BlockNumber:       big.NewInt(1000),
 				BlockScope:        "FULL_TXNS",
-				ExpectedBlockHash: "0xdeadbeef",
+				ExpectedBlockHash: types.StrToFelt("0xdeadbeef"),
 				ExpectedStatus:    "",
 				ExpectedTx0Hash:   "0xdeadbeef",
 			},
@@ -64,14 +66,14 @@ func TestBlockByNumber(t *testing.T) {
 			{
 				BlockNumber:       big.NewInt(242060),
 				BlockScope:        "FULL_TXN_AND_RECEIPTS",
-				ExpectedBlockHash: "0x115aa451e374dbfdeb6f8d4c70133a39c6bb7b2948a4a3f0c9d5dda30f94044",
+				ExpectedBlockHash: types.StrToFelt("0x115aa451e374dbfdeb6f8d4c70133a39c6bb7b2948a4a3f0c9d5dda30f94044"),
 				ExpectedStatus:    "ACCEPTED_ON_L1",
 				ExpectedTx0Hash:   "0x705547f8f2f8fdfb10ed533d909f76482bb293c5a32648d476774516a0bebd0",
 			},
 			{
 				BlockNumber:       big.NewInt(242060),
 				BlockScope:        "FULL_TXNS",
-				ExpectedBlockHash: "0x115aa451e374dbfdeb6f8d4c70133a39c6bb7b2948a4a3f0c9d5dda30f94044",
+				ExpectedBlockHash: types.StrToFelt("0x115aa451e374dbfdeb6f8d4c70133a39c6bb7b2948a4a3f0c9d5dda30f94044"),
 				ExpectedStatus:    "",
 				ExpectedTx0Hash:   "0x705547f8f2f8fdfb10ed533d909f76482bb293c5a32648d476774516a0bebd0",
 			},
@@ -79,7 +81,7 @@ func TestBlockByNumber(t *testing.T) {
 		"mainnet": {{
 			BlockNumber:       big.NewInt(1500),
 			BlockScope:        "FULL_TXN_AND_RECEIPTS",
-			ExpectedBlockHash: "0x6f8e6413281c43bfcb9f96e315a08c57c619c9da4b10e2cb7d33369f3fb75a0",
+			ExpectedBlockHash: types.StrToFelt("0x6f8e6413281c43bfcb9f96e315a08c57c619c9da4b10e2cb7d33369f3fb75a0"),
 			ExpectedStatus:    "ACCEPTED_ON_L1",
 			ExpectedTx0Hash:   "0x5f904b9185d4ed442846ac7e26bc4c60249a2a7f0bb85376c0bc7459665bae6",
 		}},
@@ -90,12 +92,12 @@ func TestBlockByNumber(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if block.BlockHash != test.ExpectedBlockHash {
-			t.Fatalf("blockhash mismatch, expect %s, got %s :",
+		if block.BlockHash.String() != test.ExpectedBlockHash.String() {
+			t.Fatalf("blockhash mismatch, expect %v, got %v :",
 				test.ExpectedBlockHash,
 				block.BlockHash)
 		}
-		if block.Transactions[0].TransactionHash != test.ExpectedTx0Hash {
+		if block.Transactions[0].TransactionHash.String() != test.ExpectedTx0Hash {
 			t.Fatalf("tx[0] mismatch, expect %s, got %s :",
 				test.ExpectedTx0Hash,
 				block.Transactions[0].TransactionHash)
@@ -113,7 +115,7 @@ func TestBlockByHash(t *testing.T) {
 	testConfig := beforeEach(t)
 
 	type testSetType struct {
-		BlockHash           string
+		BlockHash           *types.Felt
 		BlockScope          string
 		ExpectedBlockNumber int
 		ExpectedTx0Hash     string
@@ -122,14 +124,14 @@ func TestBlockByHash(t *testing.T) {
 	testSet := map[string][]testSetType{
 		"mock": {
 			{
-				BlockHash:           "0xdeadbeef",
+				BlockHash:           types.StrToFelt("0xdeadbeef"),
 				BlockScope:          "FULL_TXN_AND_RECEIPTS",
 				ExpectedBlockNumber: 1000,
 				ExpectedTx0Hash:     "0xdeadbeef",
 				ExpectedStatus:      "ACCEPTED_ON_L1",
 			},
 			{
-				BlockHash:           "0xdeadbeef",
+				BlockHash:           types.StrToFelt("0xdeadbeef"),
 				BlockScope:          "FULL_TXNS",
 				ExpectedBlockNumber: 1000,
 				ExpectedTx0Hash:     "0xdeadbeef",
@@ -138,14 +140,14 @@ func TestBlockByHash(t *testing.T) {
 		},
 		"testnet": {
 			{
-				BlockHash:           "0x115aa451e374dbfdeb6f8d4c70133a39c6bb7b2948a4a3f0c9d5dda30f94044",
+				BlockHash:           types.StrToFelt("0x115aa451e374dbfdeb6f8d4c70133a39c6bb7b2948a4a3f0c9d5dda30f94044"),
 				BlockScope:          "FULL_TXN_AND_RECEIPTS",
 				ExpectedBlockNumber: 242060,
 				ExpectedTx0Hash:     "0x705547f8f2f8fdfb10ed533d909f76482bb293c5a32648d476774516a0bebd0",
 				ExpectedStatus:      "ACCEPTED_ON_L1",
 			},
 			{
-				BlockHash:           "0x115aa451e374dbfdeb6f8d4c70133a39c6bb7b2948a4a3f0c9d5dda30f94044",
+				BlockHash:           types.StrToFelt("0x115aa451e374dbfdeb6f8d4c70133a39c6bb7b2948a4a3f0c9d5dda30f94044"),
 				BlockScope:          "FULL_TXNS",
 				ExpectedBlockNumber: 242060,
 				ExpectedTx0Hash:     "0x705547f8f2f8fdfb10ed533d909f76482bb293c5a32648d476774516a0bebd0",
@@ -153,7 +155,7 @@ func TestBlockByHash(t *testing.T) {
 			},
 		},
 		"mainnet": {{
-			BlockHash:           "0x6f8e6413281c43bfcb9f96e315a08c57c619c9da4b10e2cb7d33369f3fb75a0",
+			BlockHash:           types.StrToFelt("0x6f8e6413281c43bfcb9f96e315a08c57c619c9da4b10e2cb7d33369f3fb75a0"),
 			BlockScope:          "FULL_TXN_AND_RECEIPTS",
 			ExpectedBlockNumber: 1500,
 			ExpectedTx0Hash:     "0x5f904b9185d4ed442846ac7e26bc4c60249a2a7f0bb85376c0bc7459665bae6",
@@ -171,7 +173,7 @@ func TestBlockByHash(t *testing.T) {
 				test.ExpectedBlockNumber,
 				block.BlockNumber)
 		}
-		if block.Transactions[0].TransactionHash != test.ExpectedTx0Hash {
+		if block.Transactions[0].TransactionHash.String() != test.ExpectedTx0Hash {
 			t.Fatalf("tx[0] mismatch, expect %s, got %s :",
 				test.ExpectedTx0Hash,
 				block.Transactions[0].TransactionHash)

--- a/rpc/api_call_test.go
+++ b/rpc/api_call_test.go
@@ -15,7 +15,7 @@ func TestCall(t *testing.T) {
 
 	type testSetType struct {
 		ContractAddress    *types.Felt
-		EntrypointSelector *types.Felt
+		EntrypointSelector string
 		Calldata           []*types.Felt
 		ExpectedResult     string
 	}
@@ -23,7 +23,7 @@ func TestCall(t *testing.T) {
 		"mock": {
 			{
 				ContractAddress:    types.StrToFelt("0xdeadbeef"),
-				EntrypointSelector: types.StrToFelt("decimals"),
+				EntrypointSelector: "decimals",
 				Calldata:           []*types.Felt{types.StrToFelt("1234"), types.StrToFelt("5678")},
 				ExpectedResult:     "0x12",
 			},
@@ -31,7 +31,7 @@ func TestCall(t *testing.T) {
 		"testnet": {
 			{
 				ContractAddress:    types.StrToFelt("0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7"),
-				EntrypointSelector: types.StrToFelt("decimals"),
+				EntrypointSelector: "decimals",
 				Calldata:           []*types.Felt{types.StrToFelt("78910"), types.StrToFelt("111213")},
 				ExpectedResult:     "0x12",
 			},
@@ -39,7 +39,7 @@ func TestCall(t *testing.T) {
 		"mainnet": {
 			{
 				ContractAddress:    types.StrToFelt("0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7"),
-				EntrypointSelector: types.StrToFelt("decimals"),
+				EntrypointSelector: "decimals",
 				Calldata:           []*types.Felt{types.StrToFelt("141516"), types.StrToFelt("17181920")},
 				ExpectedResult:     "0x12",
 			},
@@ -91,7 +91,7 @@ func TestEstimateFee(t *testing.T) {
 							types.StrToFelt("0x0000000000000000000000000000000000000000000000000000000000000003"),
 							types.StrToFelt("0x0000000000000000000000000000000000000000000000000000000000000001"),
 						},
-						EntryPointSelector: types.StrToFelt("0x015d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad"),
+						EntryPointSelector: "0x015d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
 					},
 					Signature: []*types.Felt{
 						types.StrToFelt("0x010e400d046147777c2ac5645024e1ee81c86d90b52d76ab8a8125e5f49612f9"),
@@ -124,7 +124,7 @@ func TestEstimateFee(t *testing.T) {
 							types.StrToFelt("0x0000000000000000000000000000000000000000000000000000000000000000"),
 							types.StrToFelt("0x0000000000000000000000000000000000000000000000000000000000000001"),
 						},
-						EntryPointSelector: types.StrToFelt("0x015d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad"),
+						EntryPointSelector: "0x015d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
 					},
 					Signature: []*types.Felt{
 						types.StrToFelt("0x010e400d046147777c2ac5645024e1ee81c86d90b52d76ab8a8125e5f49612f9"),

--- a/rpc/api_call_test.go
+++ b/rpc/api_call_test.go
@@ -3,6 +3,7 @@ package rpc
 import (
 	"context"
 	"fmt"
+	"math/big"
 	"testing"
 
 	"github.com/dontpanicdao/caigo/types"
@@ -13,29 +14,33 @@ func TestCall(t *testing.T) {
 	testConfig := beforeEach(t)
 
 	type testSetType struct {
-		ContractAddress    string
-		EntrypointSelector string
+		ContractAddress    *types.Felt
+		EntrypointSelector *types.Felt
+		Calldata           []*types.Felt
 		ExpectedResult     string
 	}
 	testSet := map[string][]testSetType{
 		"mock": {
 			{
-				ContractAddress:    "0xdeadbeef",
-				EntrypointSelector: "decimals",
+				ContractAddress:    types.StrToFelt("0xdeadbeef"),
+				EntrypointSelector: types.StrToFelt("decimals"),
+				Calldata:           []*types.Felt{types.StrToFelt("1234"), types.StrToFelt("5678")},
 				ExpectedResult:     "0x12",
 			},
 		},
 		"testnet": {
 			{
-				ContractAddress:    "0x029260ce936efafa6d0042bc59757a653e3f992b97960c1c4f8ccd63b7a90136",
-				EntrypointSelector: "decimals",
+				ContractAddress:    types.StrToFelt("0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7"),
+				EntrypointSelector: types.StrToFelt("decimals"),
+				Calldata:           []*types.Felt{types.StrToFelt("78910"), types.StrToFelt("111213")},
 				ExpectedResult:     "0x12",
 			},
 		},
 		"mainnet": {
 			{
-				ContractAddress:    "0x06a09ccb1caaecf3d9683efe335a667b2169a409d19c589ba1eb771cd210af75",
-				EntrypointSelector: "decimals",
+				ContractAddress:    types.StrToFelt("0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7"),
+				EntrypointSelector: types.StrToFelt("decimals"),
+				Calldata:           []*types.Felt{types.StrToFelt("141516"), types.StrToFelt("17181920")},
 				ExpectedResult:     "0x12",
 			},
 		},
@@ -46,6 +51,7 @@ func TestCall(t *testing.T) {
 			ContractAddress:    test.ContractAddress,
 			EntryPointSelector: test.EntrypointSelector,
 		}
+
 		output, err := testConfig.client.Call(context.Background(), function, "latest")
 		if err != nil {
 			t.Fatal(err)
@@ -75,20 +81,17 @@ func TestEstimateFee(t *testing.T) {
 			{
 				call: types.FunctionInvoke{
 					FunctionCall: types.FunctionCall{
-						ContractAddress: "0x0019fcae2482de8fb3afaf8d4b219449bec93a5928f02f58eef645cc071767f4",
-						Calldata: []string{
-							"0x0000000000000000000000000000000000000000000000000000000000000001",
-							"0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
-							"0x0083afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
-							"0x0000000000000000000000000000000000000000000000000000000000000000",
-							"0x0000000000000000000000000000000000000000000000000000000000000003",
-							"0x0000000000000000000000000000000000000000000000000000000000000003",
-							"0x04681402a7ab16c41f7e5d091f32fe9b78de096e0bd5962ce5bd7aaa4a441f64",
-							"0x000000000000000000000000000000000000000000000000001d41f6331e6800",
-							"0x0000000000000000000000000000000000000000000000000000000000000000",
-							"0x0000000000000000000000000000000000000000000000000000000000000001",
+						ContractAddress: &types.Felt{Int: big.NewInt(10000)},
+						Calldata: []*types.Felt{
+							types.StrToFelt("0x0000000000000000000000000000000000000000000000000000000000000001"),
+							types.StrToFelt("0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7"),
+							types.StrToFelt("0x0083afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e"),
+							types.StrToFelt("0x0000000000000000000000000000000000000000000000000000000000000000"),
+							types.StrToFelt("0x0000000000000000000000000000000000000000000000000000000000000003"),
+							types.StrToFelt("0x0000000000000000000000000000000000000000000000000000000000000003"),
+							types.StrToFelt("0x0000000000000000000000000000000000000000000000000000000000000001"),
 						},
-						EntryPointSelector: "0x015d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
+						EntryPointSelector: types.StrToFelt("0x015d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad"),
 					},
 					Signature: []*types.Felt{
 						types.StrToFelt("0x010e400d046147777c2ac5645024e1ee81c86d90b52d76ab8a8125e5f49612f9"),
@@ -108,20 +111,20 @@ func TestEstimateFee(t *testing.T) {
 			{
 				call: types.FunctionInvoke{
 					FunctionCall: types.FunctionCall{
-						ContractAddress: "0x0019fcae2482de8fb3afaf8d4b219449bec93a5928f02f58eef645cc071767f4",
-						Calldata: []string{
-							"0x0000000000000000000000000000000000000000000000000000000000000001",
-							"0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
-							"0x0083afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
-							"0x0000000000000000000000000000000000000000000000000000000000000000",
-							"0x0000000000000000000000000000000000000000000000000000000000000003",
-							"0x0000000000000000000000000000000000000000000000000000000000000003",
-							"0x04681402a7ab16c41f7e5d091f32fe9b78de096e0bd5962ce5bd7aaa4a441f64",
-							"0x000000000000000000000000000000000000000000000000001d41f6331e6800",
-							"0x0000000000000000000000000000000000000000000000000000000000000000",
-							"0x0000000000000000000000000000000000000000000000000000000000000001",
+						ContractAddress: types.StrToFelt("0xdeadbeef"),
+						Calldata: []*types.Felt{
+							types.StrToFelt("0x0000000000000000000000000000000000000000000000000000000000000001"),
+							types.StrToFelt("0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7"),
+							types.StrToFelt("0x0083afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e"),
+							types.StrToFelt("0x0000000000000000000000000000000000000000000000000000000000000000"),
+							types.StrToFelt("0x0000000000000000000000000000000000000000000000000000000000000003"),
+							types.StrToFelt("0x0000000000000000000000000000000000000000000000000000000000000003"),
+							types.StrToFelt("0x04681402a7ab16c41f7e5d091f32fe9b78de096e0bd5962ce5bd7aaa4a441f64"),
+							types.StrToFelt("0x000000000000000000000000000000000000000000000000001d41f6331e6800"),
+							types.StrToFelt("0x0000000000000000000000000000000000000000000000000000000000000000"),
+							types.StrToFelt("0x0000000000000000000000000000000000000000000000000000000000000001"),
 						},
-						EntryPointSelector: "0x015d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
+						EntryPointSelector: types.StrToFelt("0x015d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad"),
 					},
 					Signature: []*types.Felt{
 						types.StrToFelt("0x010e400d046147777c2ac5645024e1ee81c86d90b52d76ab8a8125e5f49612f9"),

--- a/rpc/api_contract_test.go
+++ b/rpc/api_contract_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"testing"
+
+	"github.com/dontpanicdao/caigo/types"
 )
 
 // TestCodeAt tests code for a contract instance. This will be deprecated.
@@ -236,13 +238,13 @@ func TestAccountNonce(t *testing.T) {
 	testConfig := beforeEach(t)
 
 	type testSetType struct {
-		ContractAddress string
+		ContractAddress *types.Felt
 		ExpectedNonce   string
 	}
 	testSet := map[string][]testSetType{
 		"mock": {
 			{
-				ContractAddress: "0xdeadbeef",
+				ContractAddress: types.StrToFelt("0xdeadbeef"),
 				ExpectedNonce:   "10",
 			},
 		},

--- a/rpc/api_transaction_test.go
+++ b/rpc/api_transaction_test.go
@@ -59,7 +59,7 @@ func TestTransactionByBlockHashAndIndex(t *testing.T) {
 		if tx.ContractAddress.String() != test.ExpectedContractAddress.String() {
 			t.Fatalf("expecting contract %s, got %s", test.ExpectedContractAddress, tx.ContractAddress)
 		}
-		if tx.EntryPointSelector.String() != test.ExpectedEntrypointSelector {
+		if tx.EntryPointSelector != test.ExpectedEntrypointSelector {
 			t.Fatalf("expecting entrypoint %s, got %s", test.ExpectedEntrypointSelector, tx.EntryPointSelector)
 		}
 	}
@@ -117,7 +117,7 @@ func TestTransactionByBlockNumberAndIndex(t *testing.T) {
 		if tx.ContractAddress.String() != test.ExpectedContractAddress.String() {
 			t.Fatalf("expecting contract %s, got %s", test.ExpectedContractAddress, tx.ContractAddress)
 		}
-		if tx.EntryPointSelector.String() != test.ExpectedEntrypointSelector {
+		if tx.EntryPointSelector != test.ExpectedEntrypointSelector {
 			t.Fatalf("expecting entrypoint %s, got %s", test.ExpectedEntrypointSelector, tx.EntryPointSelector)
 		}
 	}
@@ -167,7 +167,7 @@ func TestTransactionByHash(t *testing.T) {
 		if tx.ContractAddress.String() != test.ExpectedContractAddress.String() {
 			t.Fatalf("expecting contract %s, got %s", test.ExpectedContractAddress, tx.ContractAddress)
 		}
-		if tx.EntryPointSelector.String() != test.ExpectedEntrypointSelector {
+		if tx.EntryPointSelector != test.ExpectedEntrypointSelector {
 			t.Fatalf("expecting entrypoint %s, got %s", test.ExpectedEntrypointSelector, tx.EntryPointSelector)
 		}
 	}

--- a/rpc/api_transaction_test.go
+++ b/rpc/api_transaction_test.go
@@ -3,6 +3,8 @@ package rpc
 import (
 	"context"
 	"testing"
+
+	"github.com/dontpanicdao/caigo/types"
 )
 
 // TestTransactionByBlockHashAndIndex tests transaction by blockHash and txIndex
@@ -13,7 +15,7 @@ func TestTransactionByBlockHashAndIndex(t *testing.T) {
 		BlockHash                  string
 		TxIndex                    int
 		ExpectedTxHash             string
-		ExpectedContractAddress    string
+		ExpectedContractAddress    *types.Felt
 		ExpectedEntrypointSelector string
 	}
 	testSet := map[string][]testSetType{
@@ -22,7 +24,7 @@ func TestTransactionByBlockHashAndIndex(t *testing.T) {
 				BlockHash:                  "0xdeadbeef",
 				TxIndex:                    7,
 				ExpectedTxHash:             "0xdeadbeef",
-				ExpectedContractAddress:    "0xdeadbeef",
+				ExpectedContractAddress:    types.StrToFelt("0xdeadbeef"),
 				ExpectedEntrypointSelector: "0xdeadbeef",
 			},
 		},
@@ -31,7 +33,7 @@ func TestTransactionByBlockHashAndIndex(t *testing.T) {
 				BlockHash:                  "0x115aa451e374dbfdeb6f8d4c70133a39c6bb7b2948a4a3f0c9d5dda30f94044",
 				TxIndex:                    3,
 				ExpectedTxHash:             "0x179124db5707ea54a44c7e9cc2e654a0160a0f6fa9a3ef8f3f062a659224da1",
-				ExpectedContractAddress:    "0x6bc8601525b88448ecc22de7ce94caa4cd7b3d594ad5c8360f21c7d6bfa5085",
+				ExpectedContractAddress:    types.StrToFelt("0x6bc8601525b88448ecc22de7ce94caa4cd7b3d594ad5c8360f21c7d6bfa5085"),
 				ExpectedEntrypointSelector: "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
 			},
 		},
@@ -40,7 +42,7 @@ func TestTransactionByBlockHashAndIndex(t *testing.T) {
 				BlockHash:                  "0x6f8e6413281c43bfcb9f96e315a08c57c619c9da4b10e2cb7d33369f3fb75a0",
 				TxIndex:                    1,
 				ExpectedTxHash:             "0x2b8ff0898ab240a45082fa2d2e0118bfc2a30959a2d898bf3668d8c453963cb",
-				ExpectedContractAddress:    "0x443df1c1f5b55878b44c623557dc0bf7bee18c01813fe09fc6e47811a467976",
+				ExpectedContractAddress:    types.StrToFelt("0xdeadbeef"),
 				ExpectedEntrypointSelector: "0x12ead94ae9d3f9d2bdb6b847cf255f1f398193a1f88884a0ae8e18f24a037b6",
 			},
 		},
@@ -51,13 +53,13 @@ func TestTransactionByBlockHashAndIndex(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if tx == nil || tx.TransactionHash != test.ExpectedTxHash {
+		if tx == nil || tx.TransactionHash.String() != test.ExpectedTxHash {
 			t.Fatal("transaction should exist and match the tx hash")
 		}
-		if tx.ContractAddress != test.ExpectedContractAddress {
+		if tx.ContractAddress.String() != test.ExpectedContractAddress.String() {
 			t.Fatalf("expecting contract %s, got %s", test.ExpectedContractAddress, tx.ContractAddress)
 		}
-		if tx.EntryPointSelector != test.ExpectedEntrypointSelector {
+		if tx.EntryPointSelector.String() != test.ExpectedEntrypointSelector {
 			t.Fatalf("expecting entrypoint %s, got %s", test.ExpectedEntrypointSelector, tx.EntryPointSelector)
 		}
 	}
@@ -71,7 +73,7 @@ func TestTransactionByBlockNumberAndIndex(t *testing.T) {
 		BlockNumberOrTag           interface{}
 		TxIndex                    int
 		ExpectedTxHash             string
-		ExpectedContractAddress    string
+		ExpectedContractAddress    *types.Felt
 		ExpectedEntrypointSelector string
 	}
 	testSet := map[string][]testSetType{
@@ -80,7 +82,7 @@ func TestTransactionByBlockNumberAndIndex(t *testing.T) {
 				BlockNumberOrTag:           7,
 				TxIndex:                    7,
 				ExpectedTxHash:             "0xdeadbeef",
-				ExpectedContractAddress:    "0xdeadbeef",
+				ExpectedContractAddress:    types.StrToFelt("0xdeadbeef"),
 				ExpectedEntrypointSelector: "0xdeadbeef",
 			},
 		},
@@ -89,7 +91,7 @@ func TestTransactionByBlockNumberAndIndex(t *testing.T) {
 				BlockNumberOrTag:           242060,
 				TxIndex:                    3,
 				ExpectedTxHash:             "0x179124db5707ea54a44c7e9cc2e654a0160a0f6fa9a3ef8f3f062a659224da1",
-				ExpectedContractAddress:    "0x6bc8601525b88448ecc22de7ce94caa4cd7b3d594ad5c8360f21c7d6bfa5085",
+				ExpectedContractAddress:    types.StrToFelt("0x6bc8601525b88448ecc22de7ce94caa4cd7b3d594ad5c8360f21c7d6bfa5085"),
 				ExpectedEntrypointSelector: "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
 			},
 		},
@@ -98,7 +100,7 @@ func TestTransactionByBlockNumberAndIndex(t *testing.T) {
 				BlockNumberOrTag:           1500,
 				TxIndex:                    1,
 				ExpectedTxHash:             "0x2b8ff0898ab240a45082fa2d2e0118bfc2a30959a2d898bf3668d8c453963cb",
-				ExpectedContractAddress:    "0x443df1c1f5b55878b44c623557dc0bf7bee18c01813fe09fc6e47811a467976",
+				ExpectedContractAddress:    types.StrToFelt("0xdeadbeef"),
 				ExpectedEntrypointSelector: "0x12ead94ae9d3f9d2bdb6b847cf255f1f398193a1f88884a0ae8e18f24a037b6",
 			},
 		},
@@ -109,13 +111,13 @@ func TestTransactionByBlockNumberAndIndex(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if tx == nil || tx.TransactionHash != test.ExpectedTxHash {
+		if tx == nil || tx.TransactionHash.String() != test.ExpectedTxHash {
 			t.Fatal("transaction should exist and match the tx hash")
 		}
-		if tx.ContractAddress != test.ExpectedContractAddress {
+		if tx.ContractAddress.String() != test.ExpectedContractAddress.String() {
 			t.Fatalf("expecting contract %s, got %s", test.ExpectedContractAddress, tx.ContractAddress)
 		}
-		if tx.EntryPointSelector != test.ExpectedEntrypointSelector {
+		if tx.EntryPointSelector.String() != test.ExpectedEntrypointSelector {
 			t.Fatalf("expecting entrypoint %s, got %s", test.ExpectedEntrypointSelector, tx.EntryPointSelector)
 		}
 	}
@@ -127,28 +129,28 @@ func TestTransactionByHash(t *testing.T) {
 
 	type testSetType struct {
 		TxHash                     string
-		ExpectedContractAddress    string
+		ExpectedContractAddress    *types.Felt
 		ExpectedEntrypointSelector string
 	}
 	testSet := map[string][]testSetType{
 		"mock": {
 			{
 				TxHash:                     "0xdeadbeef",
-				ExpectedContractAddress:    "0xdeadbeef",
+				ExpectedContractAddress:    types.StrToFelt("0xdeadbeef"),
 				ExpectedEntrypointSelector: "0xdeadbeef",
 			},
 		},
 		"testnet": {
 			{
 				TxHash:                     "0x705547f8f2f8fdfb10ed533d909f76482bb293c5a32648d476774516a0bebd0",
-				ExpectedContractAddress:    "0x315e364b162653e5c7b23efd34f8da27ba9c069b68e3042b7d76ce1df890313",
+				ExpectedContractAddress:    types.StrToFelt("0x315e364b162653e5c7b23efd34f8da27ba9c069b68e3042b7d76ce1df890313"),
 				ExpectedEntrypointSelector: "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
 			},
 		},
 		"mainnet": {
 			{
 				TxHash:                     "0x5f904b9185d4ed442846ac7e26bc4c60249a2a7f0bb85376c0bc7459665bae6",
-				ExpectedContractAddress:    "0x3b4be7def2fc08589348966255e101824928659ebb724855223ff3a8c831efa",
+				ExpectedContractAddress:    types.StrToFelt("0xdeadbeef"),
 				ExpectedEntrypointSelector: "0x2913ee03e5e3308c41e308bd391ea4faac9b9cb5062c76a6b3ab4f65397e106",
 			},
 		},
@@ -159,13 +161,13 @@ func TestTransactionByHash(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if tx == nil || tx.TransactionHash != test.TxHash {
+		if tx == nil || tx.TransactionHash.String() != test.TxHash {
 			t.Fatal("transaction should exist and match the tx hash")
 		}
-		if tx.ContractAddress != test.ExpectedContractAddress {
+		if tx.ContractAddress.String() != test.ExpectedContractAddress.String() {
 			t.Fatalf("expecting contract %s, got %s", test.ExpectedContractAddress, tx.ContractAddress)
 		}
-		if tx.EntryPointSelector != test.ExpectedEntrypointSelector {
+		if tx.EntryPointSelector.String() != test.ExpectedEntrypointSelector {
 			t.Fatalf("expecting entrypoint %s, got %s", test.ExpectedEntrypointSelector, tx.EntryPointSelector)
 		}
 	}

--- a/rpc/mock_test.go
+++ b/rpc/mock_test.go
@@ -212,7 +212,7 @@ func mock_starknet_getTransactionByHash(result interface{}, method string, args 
 	transaction := types.Transaction{
 		TransactionHash:    types.StrToFelt(txHash),
 		ContractAddress:    types.StrToFelt("0xdeadbeef"),
-		EntryPointSelector: types.StrToFelt("0xdeadbeef"),
+		EntryPointSelector: "0xdeadbeef",
 	}
 	outputContent, _ := json.Marshal(transaction)
 	json.Unmarshal(outputContent, r)
@@ -239,7 +239,7 @@ func mock_starknet_getTransactionByBlockHashAndIndex(result interface{}, method 
 	transaction := types.Transaction{
 		TransactionHash:    types.StrToFelt("0xdeadbeef"),
 		ContractAddress:    types.StrToFelt("0xdeadbeef"),
-		EntryPointSelector: types.StrToFelt("0xdeadbeef"),
+		EntryPointSelector: "0xdeadbeef",
 	}
 	outputContent, _ := json.Marshal(transaction)
 	json.Unmarshal(outputContent, r)
@@ -268,7 +268,7 @@ func mock_starknet_getTransactionByBlockNumberAndIndex(result interface{}, metho
 	transaction := types.Transaction{
 		TransactionHash:    types.StrToFelt("0xdeadbeef"),
 		ContractAddress:    types.StrToFelt("0xdeadbeef"),
-		EntryPointSelector: types.StrToFelt("0xdeadbeef"),
+		EntryPointSelector: "0xdeadbeef",
 	}
 	outputContent, _ := json.Marshal(transaction)
 	json.Unmarshal(outputContent, r)

--- a/rpc/mock_test.go
+++ b/rpc/mock_test.go
@@ -11,8 +11,9 @@ import (
 )
 
 var (
-	errWrongType = fmt.Errorf("wrong type")
-	errWrongArgs = fmt.Errorf("wrong number of args")
+	errWrongType  = fmt.Errorf("wrong type")
+	errWrongArgs  = fmt.Errorf("wrong number of args")
+	errWrongValue = fmt.Errorf("wrong value")
 )
 
 // rpcMock is a mock of the go-ethereum Client that can be used for local tests
@@ -119,11 +120,11 @@ func mock_starknet_getBlockByHash(result interface{}, method string, args ...int
 	}
 	transaction := types.Transaction{
 		TransactionReceipt: transactionReceipt,
-		TransactionHash:    "0xdeadbeef",
+		TransactionHash:    types.StrToFelt("0xdeadbeef"),
 	}
 	output := types.Block{
 		BlockNumber:  1000,
-		BlockHash:    "0xdeadbeef",
+		BlockHash:    types.StrToFelt("0xdeadbeef"),
 		Transactions: []*types.Transaction{&transaction},
 	}
 	outputContent, _ := json.Marshal(output)
@@ -155,10 +156,10 @@ func mock_starknet_getBlockByNumber(result interface{}, method string, args ...i
 	}
 	transaction := types.Transaction{
 		TransactionReceipt: transactionReceipt,
-		TransactionHash:    "0xdeadbeef",
+		TransactionHash:    types.StrToFelt("0xdeadbeef"),
 	}
 	output := types.Block{
-		BlockHash:    "0xdeadbeef",
+		BlockHash:    types.StrToFelt("0xdeadbeef"),
 		Transactions: []*types.Transaction{&transaction},
 	}
 	outputContent, _ := json.Marshal(output)
@@ -209,9 +210,9 @@ func mock_starknet_getTransactionByHash(result interface{}, method string, args 
 		return errWrongArgs
 	}
 	transaction := types.Transaction{
-		TransactionHash:    txHash,
-		ContractAddress:    "0xdeadbeef",
-		EntryPointSelector: "0xdeadbeef",
+		TransactionHash:    types.StrToFelt(txHash),
+		ContractAddress:    types.StrToFelt("0xdeadbeef"),
+		EntryPointSelector: types.StrToFelt("0xdeadbeef"),
 	}
 	outputContent, _ := json.Marshal(transaction)
 	json.Unmarshal(outputContent, r)
@@ -236,9 +237,9 @@ func mock_starknet_getTransactionByBlockHashAndIndex(result interface{}, method 
 		return errWrongArgs
 	}
 	transaction := types.Transaction{
-		TransactionHash:    "0xdeadbeef",
-		ContractAddress:    "0xdeadbeef",
-		EntryPointSelector: "0xdeadbeef",
+		TransactionHash:    types.StrToFelt("0xdeadbeef"),
+		ContractAddress:    types.StrToFelt("0xdeadbeef"),
+		EntryPointSelector: types.StrToFelt("0xdeadbeef"),
 	}
 	outputContent, _ := json.Marshal(transaction)
 	json.Unmarshal(outputContent, r)
@@ -265,9 +266,9 @@ func mock_starknet_getTransactionByBlockNumberAndIndex(result interface{}, metho
 		return errWrongArgs
 	}
 	transaction := types.Transaction{
-		TransactionHash:    "0xdeadbeef",
-		ContractAddress:    "0xdeadbeef",
-		EntryPointSelector: "0xdeadbeef",
+		TransactionHash:    types.StrToFelt("0xdeadbeef"),
+		ContractAddress:    types.StrToFelt("0xdeadbeef"),
+		EntryPointSelector: types.StrToFelt("0xdeadbeef"),
 	}
 	outputContent, _ := json.Marshal(transaction)
 	json.Unmarshal(outputContent, r)
@@ -413,9 +414,11 @@ func mock_starknet_call(result interface{}, method string, args ...interface{}) 
 		fmt.Printf("args: %d\n", len(args))
 		return errWrongArgs
 	}
-	function, ok := args[0].(types.FunctionCall)
-	if !ok || function.ContractAddress != "0xdeadbeef" {
-		return errWrongArgs
+
+	function, ok := args[0].(FunctionCallAdapter)
+	if !ok || function.ContractAddress != types.StrToFelt("0xdeadbeef").String() {
+		fmt.Println(function.ContractAddress)
+		return errWrongValue
 	}
 	output := []string{"0x12"}
 	outputContent, _ := json.Marshal(output)

--- a/types/felt_test.go
+++ b/types/felt_test.go
@@ -1,9 +1,9 @@
 package types
 
 import (
-	"fmt"
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"math/big"
 	"strconv"
 	"testing"
@@ -26,9 +26,9 @@ var (
 var feltTest FeltTest
 
 type FeltTest struct {
-	MaxFelt *big.Int    `json:"max_felt"`
-	LongString string `json:"long_string"`
-	Felts   []FeltValue `json:"felts"`
+	MaxFelt    *big.Int    `json:"max_felt"`
+	LongString string      `json:"long_string"`
+	Felts      []FeltValue `json:"felts"`
 }
 
 type FeltValue struct {

--- a/types/provider.go
+++ b/types/provider.go
@@ -6,7 +6,7 @@ import (
 )
 
 type Provider interface {
-	AccountNonce(context.Context, *Felt) (*big.Int, error)
+	AccountNonce(context.Context, *Felt) (*Felt, error)
 	BlockByHash(context.Context, *Felt, string) (*Block, error)
 	BlockByNumber(context.Context, *big.Int, string) (*Block, error)
 	Call(context.Context, FunctionCall, string) ([]string, error)

--- a/types/provider.go
+++ b/types/provider.go
@@ -6,8 +6,8 @@ import (
 )
 
 type Provider interface {
-	AccountNonce(context.Context, string) (*big.Int, error)
-	BlockByHash(context.Context, string, string) (*Block, error)
+	AccountNonce(context.Context, *Felt) (*big.Int, error)
+	BlockByHash(context.Context, *Felt, string) (*Block, error)
 	BlockByNumber(context.Context, *big.Int, string) (*Block, error)
 	Call(context.Context, FunctionCall, string) ([]string, error)
 	ChainID(context.Context) (string, error)

--- a/types/transaction.go
+++ b/types/transaction.go
@@ -4,38 +4,38 @@ type StarknetTransaction struct {
 	TransactionIndex int         `json:"transaction_index"`
 	BlockNumber      int         `json:"block_number"`
 	Transaction      Transaction `json:"transaction"`
-	BlockHash        string      `json:"block_hash"`
+	BlockHash        *Felt       `json:"block_hash"`
 	Status           string      `json:"status"`
 }
 
 type Transaction struct {
 	TransactionReceipt
-	TransactionHash    string   `json:"txn_hash,omitempty"`
-	ClassHash          string   `json:"class_hash,omitempty"`
-	ContractAddress    string   `json:"contract_address,omitempty"`
-	SenderAddress      string   `json:"sender_address,omitempty"`
-	EntryPointSelector string   `json:"entry_point_selector,omitempty"`
-	Calldata           []string `json:"calldata"`
-	Signature          []string `json:"signature"`
-	MaxFee             string   `json:"max_fee,omitempty"`
-	Nonce              string   `json:"nonce,omitempty"`
-	Version            string   `json:"version,omitempty"`
-	Type               string   `json:"type,omitempty"`
+	TransactionHash    *Felt   `json:"txn_hash,omitempty"`
+	ClassHash          *Felt   `json:"class_hash,omitempty"`
+	ContractAddress    *Felt   `json:"contract_address,omitempty"`
+	SenderAddress      *Felt   `json:"sender_address,omitempty"`
+	EntryPointSelector *Felt   `json:"entry_point_selector,omitempty"`
+	Calldata           []*Felt `json:"calldata"`
+	Signature          []*Felt `json:"signature"`
+	MaxFee             *Felt   `json:"max_fee,omitempty"`
+	Nonce              *Felt   `json:"nonce,omitempty"`
+	Version            string  `json:"version,omitempty"`
+	Type               string  `json:"type,omitempty"`
 }
 
 type L1Message struct {
-	ToAddress string  `json:"to_address,omitempty"`
+	ToAddress *Felt   `json:"to_address,omitempty"`
 	Payload   []*Felt `json:"payload,omitempty"`
 }
 
 type L2Message struct {
-	FromAddress string  `json:"from_address,omitempty"`
+	FromAddress *Felt   `json:"from_address,omitempty"`
 	Payload     []*Felt `json:"payload,omitempty"`
 }
 
 type Event struct {
 	Order       int     `json:"order,omitempty"`
-	FromAddress string  `json:"from_address,omitempty"`
+	FromAddress *Felt   `json:"from_address,omitempty"`
 	Keys        []*Felt `json:"keys,omitempty"`
 	Data        []*Felt `json:"data,omitempty"`
 }
@@ -68,12 +68,12 @@ type TransactionTrace struct {
 }
 
 type FunctionInvocation struct {
-	CallerAddress      string               `json:"caller_address"`
-	ContractAddress    string               `json:"contract_address"`
-	Calldata           []string             `json:"calldata"`
+	CallerAddress      *Felt                `json:"caller_address"`
+	ContractAddress    *Felt                `json:"contract_address"`
+	Calldata           []*Felt              `json:"calldata"`
 	CallType           string               `json:"call_type"`
-	ClassHash          string               `json:"class_hash"`
-	Selector           string               `json:"selector"`
+	ClassHash          *Felt                `json:"class_hash"`
+	Selector           *Felt                `json:"selector"`
 	EntryPointType     string               `json:"entry_point_type"`
 	Result             []string             `json:"result"`
 	ExecutionResources ExecutionResources   `json:"execution_resources"`

--- a/types/transaction.go
+++ b/types/transaction.go
@@ -14,7 +14,7 @@ type Transaction struct {
 	ClassHash          *Felt   `json:"class_hash,omitempty"`
 	ContractAddress    *Felt   `json:"contract_address,omitempty"`
 	SenderAddress      *Felt   `json:"sender_address,omitempty"`
-	EntryPointSelector *Felt   `json:"entry_point_selector,omitempty"`
+	EntryPointSelector string  `json:"entry_point_selector,omitempty"`
 	Calldata           []*Felt `json:"calldata"`
 	Signature          []*Felt `json:"signature"`
 	MaxFee             *Felt   `json:"max_fee,omitempty"`

--- a/types/types.go
+++ b/types/types.go
@@ -3,7 +3,7 @@ package types
 type Bytecode []string
 
 type Block struct {
-	BlockHash       string         `json:"block_hash"`
+	BlockHash       *Felt          `json:"block_hash"`
 	ParentBlockHash string         `json:"parent_hash"`
 	BlockNumber     int            `json:"block_number"`
 	NewRoot         string         `json:"new_root"`
@@ -20,7 +20,7 @@ type Code struct {
 }
 
 /*
-	StarkNet transaction states
+StarkNet transaction states
 */
 const (
 	NOT_RECIEVED = TxStatus(iota)
@@ -41,7 +41,7 @@ func (s TxStatus) String() string {
 
 type TransactionStatus struct {
 	TxStatus        string `json:"tx_status"`
-	BlockHash       string `json:"block_hash,omitempty"`
+	BlockHash       *Felt  `json:"block_hash,omitempty"`
 	TxFailureReason struct {
 		ErrorMessage string `json:"error_message,omitempty"`
 	} `json:"tx_failure_reason,omitempty"`
@@ -103,9 +103,9 @@ type EntryPointList struct {
 }
 
 type FunctionCall struct {
-	ContractAddress    string   `json:"contract_address"`
-	EntryPointSelector string   `json:"entry_point_selector"`
-	Calldata           []string `json:"calldata"`
+	ContractAddress    *Felt   `json:"contract_address"`
+	EntryPointSelector *Felt   `json:"entry_point_selector"`
+	Calldata           []*Felt `json:"calldata"`
 }
 
 type Signature []*Felt

--- a/types/types.go
+++ b/types/types.go
@@ -104,7 +104,7 @@ type EntryPointList struct {
 
 type FunctionCall struct {
 	ContractAddress    *Felt   `json:"contract_address"`
-	EntryPointSelector *Felt   `json:"entry_point_selector"`
+	EntryPointSelector string  `json:"entry_point_selector"`
 	Calldata           []*Felt `json:"calldata"`
 }
 


### PR DESCRIPTION
I am handling over that PR that @internnos has written. Thank to him! I will detail the content of what I am changing here. It seems we are stuck on a test but since there is also an issue with Pathfinder 0.3.0-alpha breaking the interface it might also come from there. Below are the list of my findings:

There are a **LOT** of breaking changes. btw, @drspacemn I would not go for 1.0 before the protocol ossifies. Right now we have seen they continue to introduce breaking changes in the payload and also it the api. For instance Pathfinder has removed `get_code`.

- `Transaction` is used to get data in and out. We used to rely on that fact to enter the entrypoint as a string (i.e. the name of the function) and return in the same data the `keccak256 & (252-1)` of the function. We cannot do that anymore. What I have done is turn it into a Felt we will have to inject the entrypoint. The reason I did that it that I understand the entrypoint will be removed when calling an account because it will call both `__execute__` and `__validate__` and whatever the name of the function will be to handle the commit to pay.
- `BlockNumber` where not consistent accross the stack. I moved them to `uint64`, not that I am proud of it but at least to have something consistent
- Thinking about it: (1) the curve implementation should be with the Felt implementation and (2) the account should not have a `private` field but a signer attached to it because it could very well be that the signer authentication does rely on a key that has a different scheme than secp256k1. For now I will leave it that way