### PR TITLE
fix: chainId overflow fix

### DIFF
--- a/typed.go
+++ b/typed.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"fmt"
 	"math/big"
+
+	"github.com/dontpanicdao/caigo/types"
 )
 
 type TypedData struct {
@@ -16,7 +18,7 @@ type TypedData struct {
 type Domain struct {
 	Name    string
 	Version string
-	ChainId int
+	ChainId string
 }
 
 type TypeDef struct {
@@ -39,11 +41,11 @@ type TypedMessage interface {
 func (dm Domain) FmtDefinitionEncoding(field string) (fmtEnc []*big.Int) {
 	switch field {
 	case "name":
-		fmtEnc = append(fmtEnc, UTF8StrToBig(dm.Name))
+		fmtEnc = append(fmtEnc, types.StrToFelt(dm.Name).Big())
 	case "version":
-		fmtEnc = append(fmtEnc, StrToBig(dm.Version))
+		fmtEnc = append(fmtEnc, types.StrToFelt(dm.Version).Big())
 	case "chainId":
-		fmtEnc = append(fmtEnc, big.NewInt(int64(dm.ChainId)))
+		fmtEnc = append(fmtEnc, types.StrToFelt(dm.ChainId).Big())
 	}
 	return fmtEnc
 }

--- a/typed_test.go
+++ b/typed_test.go
@@ -42,7 +42,7 @@ func MockTypedData() (ttd TypedData) {
 	dm := Domain{
 		Name:    "StarkNet Mail",
 		Version: "1",
-		ChainId: 1,
+		ChainId: "1",
 	}
 
 	ttd, _ = NewTypedData(exampleTypes, "Mail", dm)


### PR DESCRIPTION
StarkNet testnet chainId will overflow the `Domain.ChainId` int type(#97  ): 

- Convert string SN_GOERLI to byte array: [83,78,95,71,79,69,82,76,73]
- Convert byte array to int: 1536727068981429685321 (decimal) / 0x534e5f474f45524c49  (hex)

Changed type to `string`