### PR TITLE
fix declare transaction and add test

### DIFF
--- a/rpc/contracts/counter.cairo
+++ b/rpc/contracts/counter.cairo
@@ -4,90 +4,84 @@ from starkware.cairo.common.cairo_builtins import HashBuiltin, SignatureBuiltin
 from starkware.cairo.common.math import assert_not_zero
 from starkware.starknet.common.syscalls import get_tx_info, get_caller_address
 
-####################
-# STORAGE VARIABLES
-####################
+//###################
+// STORAGE VARIABLES
+//###################
 @storage_var
-func counter() -> (count : felt):
-end
+func counter() -> (count: felt) {
+}
 
 @storage_var
-func rand() -> (val : felt):
-end
+func rand() -> (val: felt) {
+}
 
-####################
-# CONSTRUCTOR
-####################
+//###################
+// CONSTRUCTOR
+//###################
 @constructor
-func constructor{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}():
-    counter.write(0)
+func constructor{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+    counter.write(0);
 
-    return ()
-end
+    return ();
+}
 
-####################
-# GETTERS FUNCTION
-####################
+//###################
+// GETTERS FUNCTION
+//###################
 @view
-func get_count{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (
-    count : felt
-):
-    let (count) = counter.read()
+func get_count{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (count: felt) {
+    let (count) = counter.read();
 
-    return (count)
-end
+    return (count,);
+}
 
 @view
-func get_rand{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (val : felt):
-    let (val) = rand.read()
+func get_rand{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (val: felt) {
+    let (val) = rand.read();
 
-    return (val)
-end
+    return (val,);
+}
 
-####################
-# EXTERNAL FUNCTIONS
-####################
+//###################
+// EXTERNAL FUNCTIONS
+//###################
 @external
-func set_rand{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(val : felt):
-    rand.write(val)
+func set_rand{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(val: felt) {
+    rand.write(val);
 
-    return ()
-end
-
-@external
-func set_rand_signed{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(val : felt):
-    let (caller) = get_caller_address()
-    let (tx_info) = get_tx_info()
-
-    assert_not_zero(tx_info.signature_len)
-
-    rand.write(val)
-
-    return ()
-end
+    return ();
+}
 
 @external
-func increment{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (
-    count : felt
-):
-    let (count) = counter.read()
-    counter.write(count + 1)
+func set_rand_signed{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(val: felt) {
+    let (caller) = get_caller_address();
+    let (tx_info) = get_tx_info();
 
-    let (new_count) = counter.read()
+    assert_not_zero(tx_info.signature_len);
 
-    return (count=new_count)
-end
+    rand.write(val);
+
+    return ();
+}
 
 @external
-func decrement{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (
-    count : felt
-):
-    let (count) = counter.read()
-    assert_not_zero(count)
+func increment{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (count: felt) {
+    let (count) = counter.read();
+    counter.write(count + 1);
 
-    counter.write(count - 1)
+    let (new_count) = counter.read();
 
-    let (new_count) = counter.read()
+    return (count=new_count);
+}
 
-    return (count=new_count)
-end
+@external
+func decrement{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (count: felt) {
+    let (count) = counter.read();
+    assert_not_zero(count);
+
+    counter.write(count - 1);
+
+    let (new_count) = counter.read();
+
+    return (count=new_count);
+}

--- a/rpc/tests/counter.json
+++ b/rpc/tests/counter.json
@@ -116,6 +116,7 @@
             "pedersen",
             "range_check"
         ],
+        "compiler_version": "0.10.0",
         "data": [
             "0x20780017fff7ffd",
             "0x4",
@@ -437,54 +438,54 @@
         ],
         "debug_info": {
             "file_contents": {
-                "autogen/starknet/arg_processor/0e9d4c974a6b6ace74b8b3274b87fad1f5800d4af46cff21a4b9883e1a1b0574.cairo": "assert [__return_value_ptr] = ret_value.count\nlet __return_value_ptr = __return_value_ptr + 1\n",
-                "autogen/starknet/arg_processor/1b562308a65653425ce06491fa4b4539466f3251a07e73e099d0afe86a48900e.cairo": "assert [cast(fp + (-4), felt*)] = __calldata_actual_size\n",
-                "autogen/starknet/arg_processor/5e1cc73f0b484f90bb02da164d88332b40c6f698801aa4d3c603dab22157e902.cairo": "let __calldata_actual_size =  __calldata_ptr - cast([cast(fp + (-3), felt**)], felt*)\n",
-                "autogen/starknet/arg_processor/a9266930b90536cd6d9acab036ca1b6f8ca9fd5be109686bde4c26dae53e3682.cairo": "let __calldata_arg_val = [__calldata_ptr]\nlet __calldata_ptr = __calldata_ptr + 1\n",
-                "autogen/starknet/arg_processor/c11cfe8d534f163fffd92734efaf54f4ba09cfa5ec207c5020b2eed1ea236bf6.cairo": "assert [__return_value_ptr] = ret_value.val\nlet __return_value_ptr = __return_value_ptr + 1\n",
-                "autogen/starknet/external/constructor/424b26e79f70343cc02557f1fbd25745138efb26a3dc5c8b593ca765b73138b7.cairo": "let pedersen_ptr = [cast([cast(fp + (-5), felt**)] + 1, starkware.cairo.common.cairo_builtins.HashBuiltin**)]\n",
-                "autogen/starknet/external/constructor/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo": "return (syscall_ptr,pedersen_ptr,range_check_ptr,retdata_size,retdata)\n",
-                "autogen/starknet/external/constructor/c7060df96cb0acca1380ae43bf758cab727bfdf73cb5d34a93e24a9742817fda.cairo": "let syscall_ptr = [cast([cast(fp + (-5), felt**)] + 0, felt**)]\n",
-                "autogen/starknet/external/constructor/e651458745e7cd218121c342e0915890767e2f59ddc2e315b8844ad0f47d582e.cairo": "let range_check_ptr = [cast([cast(fp + (-5), felt**)] + 2, felt*)]\n",
-                "autogen/starknet/external/constructor/ef3a79c18d46a9fa62dfdc7620278a45e5a135102b4efbfbcf08b5b08cd0430f.cairo": "let ret_value = __wrapped_func{syscall_ptr=syscall_ptr, pedersen_ptr=pedersen_ptr, range_check_ptr=range_check_ptr}()\n%{ memory[ap] = segments.add() %}        # Allocate memory for return value.\ntempvar retdata : felt*\nlet retdata_size = 0\n",
-                "autogen/starknet/external/decrement/424b26e79f70343cc02557f1fbd25745138efb26a3dc5c8b593ca765b73138b7.cairo": "let pedersen_ptr = [cast([cast(fp + (-5), felt**)] + 1, starkware.cairo.common.cairo_builtins.HashBuiltin**)]\n",
-                "autogen/starknet/external/decrement/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo": "return (syscall_ptr,pedersen_ptr,range_check_ptr,retdata_size,retdata)\n",
-                "autogen/starknet/external/decrement/58b175dbe66406ba3118784bf312a6131e4de96f0bac6e7c3bd3a7617ae5dc2f.cairo": "let ret_value = __wrapped_func{syscall_ptr=syscall_ptr, pedersen_ptr=pedersen_ptr, range_check_ptr=range_check_ptr}()\nlet (range_check_ptr, retdata_size, retdata) = decrement_encode_return(ret_value, range_check_ptr)\n",
-                "autogen/starknet/external/decrement/c7060df96cb0acca1380ae43bf758cab727bfdf73cb5d34a93e24a9742817fda.cairo": "let syscall_ptr = [cast([cast(fp + (-5), felt**)] + 0, felt**)]\n",
-                "autogen/starknet/external/decrement/e651458745e7cd218121c342e0915890767e2f59ddc2e315b8844ad0f47d582e.cairo": "let range_check_ptr = [cast([cast(fp + (-5), felt**)] + 2, felt*)]\n",
-                "autogen/starknet/external/get_count/424b26e79f70343cc02557f1fbd25745138efb26a3dc5c8b593ca765b73138b7.cairo": "let pedersen_ptr = [cast([cast(fp + (-5), felt**)] + 1, starkware.cairo.common.cairo_builtins.HashBuiltin**)]\n",
-                "autogen/starknet/external/get_count/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo": "return (syscall_ptr,pedersen_ptr,range_check_ptr,retdata_size,retdata)\n",
-                "autogen/starknet/external/get_count/c7060df96cb0acca1380ae43bf758cab727bfdf73cb5d34a93e24a9742817fda.cairo": "let syscall_ptr = [cast([cast(fp + (-5), felt**)] + 0, felt**)]\n",
-                "autogen/starknet/external/get_count/e651458745e7cd218121c342e0915890767e2f59ddc2e315b8844ad0f47d582e.cairo": "let range_check_ptr = [cast([cast(fp + (-5), felt**)] + 2, felt*)]\n",
-                "autogen/starknet/external/get_count/f8bf6f462c384fec4c4809e698679b696d8dda6a3d3aa885d7e695c195989fd2.cairo": "let ret_value = __wrapped_func{syscall_ptr=syscall_ptr, pedersen_ptr=pedersen_ptr, range_check_ptr=range_check_ptr}()\nlet (range_check_ptr, retdata_size, retdata) = get_count_encode_return(ret_value, range_check_ptr)\n",
-                "autogen/starknet/external/get_rand/424b26e79f70343cc02557f1fbd25745138efb26a3dc5c8b593ca765b73138b7.cairo": "let pedersen_ptr = [cast([cast(fp + (-5), felt**)] + 1, starkware.cairo.common.cairo_builtins.HashBuiltin**)]\n",
-                "autogen/starknet/external/get_rand/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo": "return (syscall_ptr,pedersen_ptr,range_check_ptr,retdata_size,retdata)\n",
-                "autogen/starknet/external/get_rand/c7060df96cb0acca1380ae43bf758cab727bfdf73cb5d34a93e24a9742817fda.cairo": "let syscall_ptr = [cast([cast(fp + (-5), felt**)] + 0, felt**)]\n",
-                "autogen/starknet/external/get_rand/d48875e526340a1dcff06e3bc494c0ada98a469fc60e878ec3084da28e6dc8ba.cairo": "let ret_value = __wrapped_func{syscall_ptr=syscall_ptr, pedersen_ptr=pedersen_ptr, range_check_ptr=range_check_ptr}()\nlet (range_check_ptr, retdata_size, retdata) = get_rand_encode_return(ret_value, range_check_ptr)\n",
-                "autogen/starknet/external/get_rand/e651458745e7cd218121c342e0915890767e2f59ddc2e315b8844ad0f47d582e.cairo": "let range_check_ptr = [cast([cast(fp + (-5), felt**)] + 2, felt*)]\n",
-                "autogen/starknet/external/increment/424b26e79f70343cc02557f1fbd25745138efb26a3dc5c8b593ca765b73138b7.cairo": "let pedersen_ptr = [cast([cast(fp + (-5), felt**)] + 1, starkware.cairo.common.cairo_builtins.HashBuiltin**)]\n",
-                "autogen/starknet/external/increment/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo": "return (syscall_ptr,pedersen_ptr,range_check_ptr,retdata_size,retdata)\n",
-                "autogen/starknet/external/increment/c7060df96cb0acca1380ae43bf758cab727bfdf73cb5d34a93e24a9742817fda.cairo": "let syscall_ptr = [cast([cast(fp + (-5), felt**)] + 0, felt**)]\n",
-                "autogen/starknet/external/increment/e651458745e7cd218121c342e0915890767e2f59ddc2e315b8844ad0f47d582e.cairo": "let range_check_ptr = [cast([cast(fp + (-5), felt**)] + 2, felt*)]\n",
-                "autogen/starknet/external/increment/fbeebf7e6c5edbed844bfa3456de063adfe5b9764cf84d51277f2022272aca40.cairo": "let ret_value = __wrapped_func{syscall_ptr=syscall_ptr, pedersen_ptr=pedersen_ptr, range_check_ptr=range_check_ptr}()\nlet (range_check_ptr, retdata_size, retdata) = increment_encode_return(ret_value, range_check_ptr)\n",
-                "autogen/starknet/external/return/decrement/90f94e6e93a262d25fecd194da011329bc24f5eabb48944f4db091a13c4e5366.cairo": "func decrement_encode_return(ret_value : (count : felt), range_check_ptr) -> (\n        range_check_ptr, data_len : felt, data : felt*):\n    %{ memory[ap] = segments.add() %}\n    alloc_locals\n    local __return_value_ptr_start : felt*\n    let __return_value_ptr = __return_value_ptr_start\n    with range_check_ptr:\n    end\n    return (\n        range_check_ptr=range_check_ptr,\n        data_len=__return_value_ptr - __return_value_ptr_start,\n        data=__return_value_ptr_start)\nend\n",
-                "autogen/starknet/external/return/get_count/d04953fbc799b56c10331939a73220559ea6fa67ac77f91ebc8738661fcc1714.cairo": "func get_count_encode_return(ret_value : (count : felt), range_check_ptr) -> (\n        range_check_ptr, data_len : felt, data : felt*):\n    %{ memory[ap] = segments.add() %}\n    alloc_locals\n    local __return_value_ptr_start : felt*\n    let __return_value_ptr = __return_value_ptr_start\n    with range_check_ptr:\n    end\n    return (\n        range_check_ptr=range_check_ptr,\n        data_len=__return_value_ptr - __return_value_ptr_start,\n        data=__return_value_ptr_start)\nend\n",
-                "autogen/starknet/external/return/get_rand/fe4c96e3c91b4c042788f080214cea51dee669de3a1544eba01eaa4b1d50b306.cairo": "func get_rand_encode_return(ret_value : (val : felt), range_check_ptr) -> (\n        range_check_ptr, data_len : felt, data : felt*):\n    %{ memory[ap] = segments.add() %}\n    alloc_locals\n    local __return_value_ptr_start : felt*\n    let __return_value_ptr = __return_value_ptr_start\n    with range_check_ptr:\n    end\n    return (\n        range_check_ptr=range_check_ptr,\n        data_len=__return_value_ptr - __return_value_ptr_start,\n        data=__return_value_ptr_start)\nend\n",
-                "autogen/starknet/external/return/increment/adb54f6bab72175c1c54ee4b1895325ce3bf4b9032bc5a52084ebf756d63d09a.cairo": "func increment_encode_return(ret_value : (count : felt), range_check_ptr) -> (\n        range_check_ptr, data_len : felt, data : felt*):\n    %{ memory[ap] = segments.add() %}\n    alloc_locals\n    local __return_value_ptr_start : felt*\n    let __return_value_ptr = __return_value_ptr_start\n    with range_check_ptr:\n    end\n    return (\n        range_check_ptr=range_check_ptr,\n        data_len=__return_value_ptr - __return_value_ptr_start,\n        data=__return_value_ptr_start)\nend\n",
-                "autogen/starknet/external/set_rand/2c999e3fe134bd4d5d23d149df69642a5e99354b178e46fc4ed43cd0ed6de4bd.cairo": "let ret_value = __wrapped_func{syscall_ptr=syscall_ptr, pedersen_ptr=pedersen_ptr, range_check_ptr=range_check_ptr}(val=__calldata_arg_val,)\n%{ memory[ap] = segments.add() %}        # Allocate memory for return value.\ntempvar retdata : felt*\nlet retdata_size = 0\n",
-                "autogen/starknet/external/set_rand/424b26e79f70343cc02557f1fbd25745138efb26a3dc5c8b593ca765b73138b7.cairo": "let pedersen_ptr = [cast([cast(fp + (-5), felt**)] + 1, starkware.cairo.common.cairo_builtins.HashBuiltin**)]\n",
-                "autogen/starknet/external/set_rand/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo": "return (syscall_ptr,pedersen_ptr,range_check_ptr,retdata_size,retdata)\n",
-                "autogen/starknet/external/set_rand/c7060df96cb0acca1380ae43bf758cab727bfdf73cb5d34a93e24a9742817fda.cairo": "let syscall_ptr = [cast([cast(fp + (-5), felt**)] + 0, felt**)]\n",
-                "autogen/starknet/external/set_rand/e651458745e7cd218121c342e0915890767e2f59ddc2e315b8844ad0f47d582e.cairo": "let range_check_ptr = [cast([cast(fp + (-5), felt**)] + 2, felt*)]\n",
-                "autogen/starknet/external/set_rand_signed/2c999e3fe134bd4d5d23d149df69642a5e99354b178e46fc4ed43cd0ed6de4bd.cairo": "let ret_value = __wrapped_func{syscall_ptr=syscall_ptr, pedersen_ptr=pedersen_ptr, range_check_ptr=range_check_ptr}(val=__calldata_arg_val,)\n%{ memory[ap] = segments.add() %}        # Allocate memory for return value.\ntempvar retdata : felt*\nlet retdata_size = 0\n",
-                "autogen/starknet/external/set_rand_signed/424b26e79f70343cc02557f1fbd25745138efb26a3dc5c8b593ca765b73138b7.cairo": "let pedersen_ptr = [cast([cast(fp + (-5), felt**)] + 1, starkware.cairo.common.cairo_builtins.HashBuiltin**)]\n",
-                "autogen/starknet/external/set_rand_signed/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo": "return (syscall_ptr,pedersen_ptr,range_check_ptr,retdata_size,retdata)\n",
-                "autogen/starknet/external/set_rand_signed/c7060df96cb0acca1380ae43bf758cab727bfdf73cb5d34a93e24a9742817fda.cairo": "let syscall_ptr = [cast([cast(fp + (-5), felt**)] + 0, felt**)]\n",
-                "autogen/starknet/external/set_rand_signed/e651458745e7cd218121c342e0915890767e2f59ddc2e315b8844ad0f47d582e.cairo": "let range_check_ptr = [cast([cast(fp + (-5), felt**)] + 2, felt*)]\n",
-                "autogen/starknet/storage_var/counter/decl.cairo": "namespace counter:\n    from starkware.starknet.common.storage import normalize_address\n    from starkware.starknet.common.syscalls import storage_read, storage_write\n    from starkware.cairo.common.cairo_builtins import HashBuiltin\n    from starkware.cairo.common.hash import hash2\n\n    func addr{pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (res : felt):\n        let res = 0\n        call hash2\n        call normalize_address\n    end\n\n    func read{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (\n        count : felt\n    ):\n        let storage_addr = 0\n        call addr\n        call storage_read\n    end\n\n    func write{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(value : felt):\n        let storage_addr = 0\n        call addr\n        call storage_write\n    end\nend",
-                "autogen/starknet/storage_var/counter/impl.cairo": "namespace counter:\n    from starkware.starknet.common.storage import normalize_address\n    from starkware.starknet.common.syscalls import storage_read, storage_write\n    from starkware.cairo.common.cairo_builtins import HashBuiltin\n    from starkware.cairo.common.hash import hash2\n\n    func addr{pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (res : felt):\n        let res = 223925651276572801467025322450506123433664924558092583619131301620304795732\n        return (res=res)\n    end\n\n    func read{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (\n        count : felt\n    ):\n        let (storage_addr) = addr()\n        let (__storage_var_temp0) = storage_read(address=storage_addr + 0)\n\n        tempvar syscall_ptr = syscall_ptr\n        tempvar pedersen_ptr = pedersen_ptr\n        tempvar range_check_ptr = range_check_ptr\n        tempvar __storage_var_temp0 : felt = __storage_var_temp0\n        return ([cast(&__storage_var_temp0, felt*)])\n    end\n\n    func write{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(value : felt):\n        let (storage_addr) = addr()\n        storage_write(address=storage_addr + 0, value=[cast(&value, felt) + 0])\n        return ()\n    end\nend",
-                "autogen/starknet/storage_var/rand/decl.cairo": "namespace rand:\n    from starkware.starknet.common.storage import normalize_address\n    from starkware.starknet.common.syscalls import storage_read, storage_write\n    from starkware.cairo.common.cairo_builtins import HashBuiltin\n    from starkware.cairo.common.hash import hash2\n\n    func addr{pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (res : felt):\n        let res = 0\n        call hash2\n        call normalize_address\n    end\n\n    func read{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (val : felt):\n        let storage_addr = 0\n        call addr\n        call storage_read\n    end\n\n    func write{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(value : felt):\n        let storage_addr = 0\n        call addr\n        call storage_write\n    end\nend",
-                "autogen/starknet/storage_var/rand/impl.cairo": "namespace rand:\n    from starkware.starknet.common.storage import normalize_address\n    from starkware.starknet.common.syscalls import storage_read, storage_write\n    from starkware.cairo.common.cairo_builtins import HashBuiltin\n    from starkware.cairo.common.hash import hash2\n\n    func addr{pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (res : felt):\n        let res = 356130213874467255641118164611403558384797874155211508364679455051938996037\n        return (res=res)\n    end\n\n    func read{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (val : felt):\n        let (storage_addr) = addr()\n        let (__storage_var_temp0) = storage_read(address=storage_addr + 0)\n\n        tempvar syscall_ptr = syscall_ptr\n        tempvar pedersen_ptr = pedersen_ptr\n        tempvar range_check_ptr = range_check_ptr\n        tempvar __storage_var_temp0 : felt = __storage_var_temp0\n        return ([cast(&__storage_var_temp0, felt*)])\n    end\n\n    func write{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(value : felt):\n        let (storage_addr) = addr()\n        storage_write(address=storage_addr + 0, value=[cast(&value, felt) + 0])\n        return ()\n    end\nend"
+                "autogen/starknet/arg_processor/00d32612ffd1b363842f1be7cd60cb81327d9483302b0da5c523e670bfa81692.cairo": "let __calldata_arg_val = [__calldata_ptr];\nlet __calldata_ptr = __calldata_ptr + 1;\n",
+                "autogen/starknet/arg_processor/01cba52f8515996bb9d7070bde81ff39281d096d7024a558efcba6e1fd2402cf.cairo": "assert [cast(fp + (-4), felt*)] = __calldata_actual_size;\n",
+                "autogen/starknet/arg_processor/87e45bfb98a0b53cc8f39ca993ad93db78b27dfeea193b24103c59c688f906ca.cairo": "assert [__return_value_ptr] = ret_value.val;\nlet __return_value_ptr = __return_value_ptr + 1;\n",
+                "autogen/starknet/arg_processor/95d2b1ea3726b72b3719bdfa0a12258ccf662f010c27f42865683ec83f32a1c9.cairo": "assert [__return_value_ptr] = ret_value.count;\nlet __return_value_ptr = __return_value_ptr + 1;\n",
+                "autogen/starknet/arg_processor/c31620b02d4d706f0542c989b2aadc01b0981d1f6a5933a8fe4937ace3d70d92.cairo": "let __calldata_actual_size =  __calldata_ptr - cast([cast(fp + (-3), felt**)], felt*);\n",
+                "autogen/starknet/external/constructor/741ea357d6336b0bed7bf0472425acd0311d543883b803388880e60a232040c7.cairo": "let range_check_ptr = [cast([cast(fp + (-5), felt**)] + 2, felt*)];\n",
+                "autogen/starknet/external/constructor/8f83d060e7e088c358526f8859eb82973ba2c094c7d9223df6230b744dfa211c.cairo": "let ret_value = __wrapped_func{syscall_ptr=syscall_ptr, pedersen_ptr=pedersen_ptr, range_check_ptr=range_check_ptr}();\n%{ memory[ap] = segments.add() %}        // Allocate memory for return value.\ntempvar retdata: felt*;\nlet retdata_size = 0;\n",
+                "autogen/starknet/external/constructor/9684a85e93c782014ca14293edea4eb2502039a5a7b6538ecd39c56faaf12529.cairo": "let pedersen_ptr = [cast([cast(fp + (-5), felt**)] + 1, starkware.cairo.common.cairo_builtins.HashBuiltin**)];\n",
+                "autogen/starknet/external/constructor/b2c52ca2d2a8fc8791a983086d8716c5eacd0c3d62934914d2286f84b98ff4cb.cairo": "let syscall_ptr = [cast([cast(fp + (-5), felt**)] + 0, felt**)];\n",
+                "autogen/starknet/external/constructor/da17921a4e81c09e730800bbf23bfdbe5e9e6bfaedc59d80fbf62087fa43c27d.cairo": "return (syscall_ptr,pedersen_ptr,range_check_ptr,retdata_size,retdata);\n",
+                "autogen/starknet/external/decrement/741ea357d6336b0bed7bf0472425acd0311d543883b803388880e60a232040c7.cairo": "let range_check_ptr = [cast([cast(fp + (-5), felt**)] + 2, felt*)];\n",
+                "autogen/starknet/external/decrement/9684a85e93c782014ca14293edea4eb2502039a5a7b6538ecd39c56faaf12529.cairo": "let pedersen_ptr = [cast([cast(fp + (-5), felt**)] + 1, starkware.cairo.common.cairo_builtins.HashBuiltin**)];\n",
+                "autogen/starknet/external/decrement/a716bcdc5921c838874dce3287d2988ac85ceac2c928df9be07d5e9a5cd28ad3.cairo": "let ret_value = __wrapped_func{syscall_ptr=syscall_ptr, pedersen_ptr=pedersen_ptr, range_check_ptr=range_check_ptr}();\nlet (range_check_ptr, retdata_size, retdata) = decrement_encode_return(ret_value, range_check_ptr);\n",
+                "autogen/starknet/external/decrement/b2c52ca2d2a8fc8791a983086d8716c5eacd0c3d62934914d2286f84b98ff4cb.cairo": "let syscall_ptr = [cast([cast(fp + (-5), felt**)] + 0, felt**)];\n",
+                "autogen/starknet/external/decrement/da17921a4e81c09e730800bbf23bfdbe5e9e6bfaedc59d80fbf62087fa43c27d.cairo": "return (syscall_ptr,pedersen_ptr,range_check_ptr,retdata_size,retdata);\n",
+                "autogen/starknet/external/get_count/741ea357d6336b0bed7bf0472425acd0311d543883b803388880e60a232040c7.cairo": "let range_check_ptr = [cast([cast(fp + (-5), felt**)] + 2, felt*)];\n",
+                "autogen/starknet/external/get_count/9684a85e93c782014ca14293edea4eb2502039a5a7b6538ecd39c56faaf12529.cairo": "let pedersen_ptr = [cast([cast(fp + (-5), felt**)] + 1, starkware.cairo.common.cairo_builtins.HashBuiltin**)];\n",
+                "autogen/starknet/external/get_count/b131978ca8e46a216e567d72366739bfc84c613d862a1e9402fc3d44c35d2bca.cairo": "let ret_value = __wrapped_func{syscall_ptr=syscall_ptr, pedersen_ptr=pedersen_ptr, range_check_ptr=range_check_ptr}();\nlet (range_check_ptr, retdata_size, retdata) = get_count_encode_return(ret_value, range_check_ptr);\n",
+                "autogen/starknet/external/get_count/b2c52ca2d2a8fc8791a983086d8716c5eacd0c3d62934914d2286f84b98ff4cb.cairo": "let syscall_ptr = [cast([cast(fp + (-5), felt**)] + 0, felt**)];\n",
+                "autogen/starknet/external/get_count/da17921a4e81c09e730800bbf23bfdbe5e9e6bfaedc59d80fbf62087fa43c27d.cairo": "return (syscall_ptr,pedersen_ptr,range_check_ptr,retdata_size,retdata);\n",
+                "autogen/starknet/external/get_rand/42bcd195580c73d7feb0ccb9abef0cf140ab57a3bc9557224ec11bf744e576da.cairo": "let ret_value = __wrapped_func{syscall_ptr=syscall_ptr, pedersen_ptr=pedersen_ptr, range_check_ptr=range_check_ptr}();\nlet (range_check_ptr, retdata_size, retdata) = get_rand_encode_return(ret_value, range_check_ptr);\n",
+                "autogen/starknet/external/get_rand/741ea357d6336b0bed7bf0472425acd0311d543883b803388880e60a232040c7.cairo": "let range_check_ptr = [cast([cast(fp + (-5), felt**)] + 2, felt*)];\n",
+                "autogen/starknet/external/get_rand/9684a85e93c782014ca14293edea4eb2502039a5a7b6538ecd39c56faaf12529.cairo": "let pedersen_ptr = [cast([cast(fp + (-5), felt**)] + 1, starkware.cairo.common.cairo_builtins.HashBuiltin**)];\n",
+                "autogen/starknet/external/get_rand/b2c52ca2d2a8fc8791a983086d8716c5eacd0c3d62934914d2286f84b98ff4cb.cairo": "let syscall_ptr = [cast([cast(fp + (-5), felt**)] + 0, felt**)];\n",
+                "autogen/starknet/external/get_rand/da17921a4e81c09e730800bbf23bfdbe5e9e6bfaedc59d80fbf62087fa43c27d.cairo": "return (syscall_ptr,pedersen_ptr,range_check_ptr,retdata_size,retdata);\n",
+                "autogen/starknet/external/increment/697ccb2f083dcbc909723b561a4e2c7f280c20a475a93b120cff6d9c6c6b6d62.cairo": "let ret_value = __wrapped_func{syscall_ptr=syscall_ptr, pedersen_ptr=pedersen_ptr, range_check_ptr=range_check_ptr}();\nlet (range_check_ptr, retdata_size, retdata) = increment_encode_return(ret_value, range_check_ptr);\n",
+                "autogen/starknet/external/increment/741ea357d6336b0bed7bf0472425acd0311d543883b803388880e60a232040c7.cairo": "let range_check_ptr = [cast([cast(fp + (-5), felt**)] + 2, felt*)];\n",
+                "autogen/starknet/external/increment/9684a85e93c782014ca14293edea4eb2502039a5a7b6538ecd39c56faaf12529.cairo": "let pedersen_ptr = [cast([cast(fp + (-5), felt**)] + 1, starkware.cairo.common.cairo_builtins.HashBuiltin**)];\n",
+                "autogen/starknet/external/increment/b2c52ca2d2a8fc8791a983086d8716c5eacd0c3d62934914d2286f84b98ff4cb.cairo": "let syscall_ptr = [cast([cast(fp + (-5), felt**)] + 0, felt**)];\n",
+                "autogen/starknet/external/increment/da17921a4e81c09e730800bbf23bfdbe5e9e6bfaedc59d80fbf62087fa43c27d.cairo": "return (syscall_ptr,pedersen_ptr,range_check_ptr,retdata_size,retdata);\n",
+                "autogen/starknet/external/return/decrement/9e681566f958be84ac78ad84746d06429698093804cb0e114f18399e5dccba8e.cairo": "func decrement_encode_return(ret_value: (count: felt), range_check_ptr) -> (\n        range_check_ptr: felt, data_len: felt, data: felt*) {\n    %{ memory[ap] = segments.add() %}\n    alloc_locals;\n    local __return_value_ptr_start: felt*;\n    let __return_value_ptr = __return_value_ptr_start;\n    with range_check_ptr {\n    }\n    return (\n        range_check_ptr=range_check_ptr,\n        data_len=__return_value_ptr - __return_value_ptr_start,\n        data=__return_value_ptr_start);\n}\n",
+                "autogen/starknet/external/return/get_count/0dee33d431beaa58b6acb544e06ae5448a753bd6e5689babe5272d33099a603a.cairo": "func get_count_encode_return(ret_value: (count: felt), range_check_ptr) -> (\n        range_check_ptr: felt, data_len: felt, data: felt*) {\n    %{ memory[ap] = segments.add() %}\n    alloc_locals;\n    local __return_value_ptr_start: felt*;\n    let __return_value_ptr = __return_value_ptr_start;\n    with range_check_ptr {\n    }\n    return (\n        range_check_ptr=range_check_ptr,\n        data_len=__return_value_ptr - __return_value_ptr_start,\n        data=__return_value_ptr_start);\n}\n",
+                "autogen/starknet/external/return/get_rand/21a83e9e2fd6a4d753f761e0f6160a23b0425d966b5a06c1ae424b0b23c78080.cairo": "func get_rand_encode_return(ret_value: (val: felt), range_check_ptr) -> (\n        range_check_ptr: felt, data_len: felt, data: felt*) {\n    %{ memory[ap] = segments.add() %}\n    alloc_locals;\n    local __return_value_ptr_start: felt*;\n    let __return_value_ptr = __return_value_ptr_start;\n    with range_check_ptr {\n    }\n    return (\n        range_check_ptr=range_check_ptr,\n        data_len=__return_value_ptr - __return_value_ptr_start,\n        data=__return_value_ptr_start);\n}\n",
+                "autogen/starknet/external/return/increment/13e3c8024d3012a81a9124b680cd43b23ca5867984f22715079ad99875a01901.cairo": "func increment_encode_return(ret_value: (count: felt), range_check_ptr) -> (\n        range_check_ptr: felt, data_len: felt, data: felt*) {\n    %{ memory[ap] = segments.add() %}\n    alloc_locals;\n    local __return_value_ptr_start: felt*;\n    let __return_value_ptr = __return_value_ptr_start;\n    with range_check_ptr {\n    }\n    return (\n        range_check_ptr=range_check_ptr,\n        data_len=__return_value_ptr - __return_value_ptr_start,\n        data=__return_value_ptr_start);\n}\n",
+                "autogen/starknet/external/set_rand/741ea357d6336b0bed7bf0472425acd0311d543883b803388880e60a232040c7.cairo": "let range_check_ptr = [cast([cast(fp + (-5), felt**)] + 2, felt*)];\n",
+                "autogen/starknet/external/set_rand/9684a85e93c782014ca14293edea4eb2502039a5a7b6538ecd39c56faaf12529.cairo": "let pedersen_ptr = [cast([cast(fp + (-5), felt**)] + 1, starkware.cairo.common.cairo_builtins.HashBuiltin**)];\n",
+                "autogen/starknet/external/set_rand/b2c52ca2d2a8fc8791a983086d8716c5eacd0c3d62934914d2286f84b98ff4cb.cairo": "let syscall_ptr = [cast([cast(fp + (-5), felt**)] + 0, felt**)];\n",
+                "autogen/starknet/external/set_rand/da17921a4e81c09e730800bbf23bfdbe5e9e6bfaedc59d80fbf62087fa43c27d.cairo": "return (syscall_ptr,pedersen_ptr,range_check_ptr,retdata_size,retdata);\n",
+                "autogen/starknet/external/set_rand/ee07832800ab98369e702a630fb9ee180df6817e88ecad55e9f688fdc0a1ff82.cairo": "let ret_value = __wrapped_func{syscall_ptr=syscall_ptr, pedersen_ptr=pedersen_ptr, range_check_ptr=range_check_ptr}(val=__calldata_arg_val,);\n%{ memory[ap] = segments.add() %}        // Allocate memory for return value.\ntempvar retdata: felt*;\nlet retdata_size = 0;\n",
+                "autogen/starknet/external/set_rand_signed/741ea357d6336b0bed7bf0472425acd0311d543883b803388880e60a232040c7.cairo": "let range_check_ptr = [cast([cast(fp + (-5), felt**)] + 2, felt*)];\n",
+                "autogen/starknet/external/set_rand_signed/9684a85e93c782014ca14293edea4eb2502039a5a7b6538ecd39c56faaf12529.cairo": "let pedersen_ptr = [cast([cast(fp + (-5), felt**)] + 1, starkware.cairo.common.cairo_builtins.HashBuiltin**)];\n",
+                "autogen/starknet/external/set_rand_signed/b2c52ca2d2a8fc8791a983086d8716c5eacd0c3d62934914d2286f84b98ff4cb.cairo": "let syscall_ptr = [cast([cast(fp + (-5), felt**)] + 0, felt**)];\n",
+                "autogen/starknet/external/set_rand_signed/da17921a4e81c09e730800bbf23bfdbe5e9e6bfaedc59d80fbf62087fa43c27d.cairo": "return (syscall_ptr,pedersen_ptr,range_check_ptr,retdata_size,retdata);\n",
+                "autogen/starknet/external/set_rand_signed/ee07832800ab98369e702a630fb9ee180df6817e88ecad55e9f688fdc0a1ff82.cairo": "let ret_value = __wrapped_func{syscall_ptr=syscall_ptr, pedersen_ptr=pedersen_ptr, range_check_ptr=range_check_ptr}(val=__calldata_arg_val,);\n%{ memory[ap] = segments.add() %}        // Allocate memory for return value.\ntempvar retdata: felt*;\nlet retdata_size = 0;\n",
+                "autogen/starknet/storage_var/counter/decl.cairo": "namespace counter {\n    from starkware.starknet.common.storage import normalize_address\n    from starkware.starknet.common.syscalls import storage_read, storage_write\n    from starkware.cairo.common.cairo_builtins import HashBuiltin\n    from starkware.cairo.common.hash import hash2\n\n    func addr{pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (res: felt) {\n        let res = 0;\n        call hash2;\n        call normalize_address;\n    }\n\n    func read{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (count: felt) {\n        let storage_addr = 0;\n        call addr;\n        call storage_read;\n    }\n\n    func write{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(value: felt) {\n        let storage_addr = 0;\n        call addr;\n        call storage_write;\n    }\n}",
+                "autogen/starknet/storage_var/counter/impl.cairo": "namespace counter {\n    from starkware.starknet.common.storage import normalize_address\n    from starkware.starknet.common.syscalls import storage_read, storage_write\n    from starkware.cairo.common.cairo_builtins import HashBuiltin\n    from starkware.cairo.common.hash import hash2\n\n    func addr{pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (res: felt) {\n        let res = 223925651276572801467025322450506123433664924558092583619131301620304795732;\n        return (res=res);\n    }\n\n    func read{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (count: felt) {\n        let (storage_addr) = addr();\n        let (__storage_var_temp0) = storage_read(address=storage_addr + 0);\n\n        tempvar syscall_ptr = syscall_ptr;\n        tempvar pedersen_ptr = pedersen_ptr;\n        tempvar range_check_ptr = range_check_ptr;\n        tempvar __storage_var_temp0: felt = __storage_var_temp0;\n        return ([cast(&__storage_var_temp0, felt*)],);\n    }\n\n    func write{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(value: felt) {\n        let (storage_addr) = addr();\n        storage_write(address=storage_addr + 0, value=[cast(&value, felt) + 0]);\n        return ();\n    }\n}",
+                "autogen/starknet/storage_var/rand/decl.cairo": "namespace rand {\n    from starkware.starknet.common.storage import normalize_address\n    from starkware.starknet.common.syscalls import storage_read, storage_write\n    from starkware.cairo.common.cairo_builtins import HashBuiltin\n    from starkware.cairo.common.hash import hash2\n\n    func addr{pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (res: felt) {\n        let res = 0;\n        call hash2;\n        call normalize_address;\n    }\n\n    func read{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (val: felt) {\n        let storage_addr = 0;\n        call addr;\n        call storage_read;\n    }\n\n    func write{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(value: felt) {\n        let storage_addr = 0;\n        call addr;\n        call storage_write;\n    }\n}",
+                "autogen/starknet/storage_var/rand/impl.cairo": "namespace rand {\n    from starkware.starknet.common.storage import normalize_address\n    from starkware.starknet.common.syscalls import storage_read, storage_write\n    from starkware.cairo.common.cairo_builtins import HashBuiltin\n    from starkware.cairo.common.hash import hash2\n\n    func addr{pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (res: felt) {\n        let res = 356130213874467255641118164611403558384797874155211508364679455051938996037;\n        return (res=res);\n    }\n\n    func read{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (val: felt) {\n        let (storage_addr) = addr();\n        let (__storage_var_temp0) = storage_read(address=storage_addr + 0);\n\n        tempvar syscall_ptr = syscall_ptr;\n        tempvar pedersen_ptr = pedersen_ptr;\n        tempvar range_check_ptr = range_check_ptr;\n        tempvar __storage_var_temp0: felt = __storage_var_temp0;\n        return ([cast(&__storage_var_temp0, felt*)],);\n    }\n\n    func write{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(value: felt) {\n        let (storage_addr) = addr();\n        storage_write(address=storage_addr + 0, value=[cast(&value, felt) + 0]);\n        return ();\n    }\n}"
             },
             "instruction_locations": {
                 "0": {
@@ -497,24 +498,24 @@
                         {
                             "location": {
                                 "end_col": 7,
-                                "end_line": 9,
+                                "end_line": 11,
                                 "input_file": {
-                                    "filename": "/Users/gregory/project/blaqkube/fan-onchain/venv/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                                    "filename": "/Users/gregory/project/blaqkube/starknet-burner/examples/controller/py/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
                                 },
                                 "start_col": 5,
-                                "start_line": 5
+                                "start_line": 7
                             },
                             "n_prefix_newlines": 1
                         }
                     ],
                     "inst": {
                         "end_col": 7,
-                        "end_line": 10,
+                        "end_line": 12,
                         "input_file": {
-                            "filename": "/Users/gregory/project/blaqkube/fan-onchain/venv/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                            "filename": "/Users/gregory/project/blaqkube/starknet-burner/examples/controller/py/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
                         },
                         "start_col": 5,
-                        "start_line": 10
+                        "start_line": 12
                     }
                 },
                 "2": {
@@ -526,12 +527,12 @@
                     "hints": [],
                     "inst": {
                         "end_col": 18,
-                        "end_line": 12,
+                        "end_line": 14,
                         "input_file": {
-                            "filename": "/Users/gregory/project/blaqkube/fan-onchain/venv/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                            "filename": "/Users/gregory/project/blaqkube/starknet-burner/examples/controller/py/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
                         },
                         "start_col": 9,
-                        "start_line": 12
+                        "start_line": 14
                     }
                 },
                 "4": {
@@ -542,13 +543,13 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 14,
-                        "end_line": 15,
+                        "end_col": 15,
+                        "end_line": 17,
                         "input_file": {
-                            "filename": "/Users/gregory/project/blaqkube/fan-onchain/venv/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                            "filename": "/Users/gregory/project/blaqkube/starknet-burner/examples/controller/py/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
                         },
                         "start_col": 5,
-                        "start_line": 15
+                        "start_line": 17
                     }
                 },
                 "5": {
@@ -560,12 +561,12 @@
                     "hints": [],
                     "inst": {
                         "end_col": 90,
-                        "end_line": 196,
+                        "end_line": 198,
                         "input_file": {
-                            "filename": "/Users/gregory/project/blaqkube/fan-onchain/venv/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
+                            "filename": "/Users/gregory/project/blaqkube/starknet-burner/examples/controller/py/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
                         },
                         "start_col": 63,
-                        "start_line": 196
+                        "start_line": 198
                     }
                 },
                 "7": {
@@ -576,13 +577,13 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 91,
-                        "end_line": 196,
+                        "end_col": 92,
+                        "end_line": 198,
                         "input_file": {
-                            "filename": "/Users/gregory/project/blaqkube/fan-onchain/venv/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
+                            "filename": "/Users/gregory/project/blaqkube/starknet-burner/examples/controller/py/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
                         },
                         "start_col": 5,
-                        "start_line": 196
+                        "start_line": 198
                     }
                 },
                 "8": {
@@ -595,48 +596,48 @@
                         {
                             "location": {
                                 "end_col": 93,
-                                "end_line": 197,
+                                "end_line": 199,
                                 "input_file": {
-                                    "filename": "/Users/gregory/project/blaqkube/fan-onchain/venv/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
+                                    "filename": "/Users/gregory/project/blaqkube/starknet-burner/examples/controller/py/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
                                 },
                                 "start_col": 5,
-                                "start_line": 197
+                                "start_line": 199
                             },
                             "n_prefix_newlines": 0
                         }
                     ],
                     "inst": {
                         "end_col": 58,
-                        "end_line": 198,
+                        "end_line": 200,
                         "input_file": {
-                            "filename": "/Users/gregory/project/blaqkube/fan-onchain/venv/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
+                            "filename": "/Users/gregory/project/blaqkube/starknet-burner/examples/controller/py/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 44,
-                                "end_line": 194,
+                                "end_col": 43,
+                                "end_line": 196,
                                 "input_file": {
-                                    "filename": "/Users/gregory/project/blaqkube/fan-onchain/venv/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
+                                    "filename": "/Users/gregory/project/blaqkube/starknet-burner/examples/controller/py/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
-                                        "end_col": 60,
-                                        "end_line": 199,
+                                        "end_col": 61,
+                                        "end_line": 201,
                                         "input_file": {
-                                            "filename": "/Users/gregory/project/blaqkube/fan-onchain/venv/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
+                                            "filename": "/Users/gregory/project/blaqkube/starknet-burner/examples/controller/py/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
                                         },
                                         "start_col": 5,
-                                        "start_line": 199
+                                        "start_line": 201
                                     },
                                     "While trying to retrieve the implicit argument 'syscall_ptr' in:"
                                 ],
                                 "start_col": 25,
-                                "start_line": 194
+                                "start_line": 196
                             },
                             "While expanding the reference 'syscall_ptr' in:"
                         ],
                         "start_col": 23,
-                        "start_line": 198
+                        "start_line": 200
                     }
                 },
                 "10": {
@@ -648,12 +649,12 @@
                     "hints": [],
                     "inst": {
                         "end_col": 59,
-                        "end_line": 199,
+                        "end_line": 201,
                         "input_file": {
-                            "filename": "/Users/gregory/project/blaqkube/fan-onchain/venv/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
+                            "filename": "/Users/gregory/project/blaqkube/starknet-burner/examples/controller/py/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
                         },
                         "start_col": 28,
-                        "start_line": 199
+                        "start_line": 201
                     }
                 },
                 "11": {
@@ -664,13 +665,13 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 60,
-                        "end_line": 199,
+                        "end_col": 61,
+                        "end_line": 201,
                         "input_file": {
-                            "filename": "/Users/gregory/project/blaqkube/fan-onchain/venv/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
+                            "filename": "/Users/gregory/project/blaqkube/starknet-burner/examples/controller/py/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
                         },
                         "start_col": 5,
-                        "start_line": 199
+                        "start_line": 201
                     }
                 },
                 "12": {
@@ -682,12 +683,12 @@
                     "hints": [],
                     "inst": {
                         "end_col": 79,
-                        "end_line": 348,
+                        "end_line": 350,
                         "input_file": {
-                            "filename": "/Users/gregory/project/blaqkube/fan-onchain/venv/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
+                            "filename": "/Users/gregory/project/blaqkube/starknet-burner/examples/controller/py/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
                         },
                         "start_col": 58,
-                        "start_line": 348
+                        "start_line": 350
                     }
                 },
                 "14": {
@@ -698,13 +699,13 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 97,
-                        "end_line": 348,
+                        "end_col": 98,
+                        "end_line": 350,
                         "input_file": {
-                            "filename": "/Users/gregory/project/blaqkube/fan-onchain/venv/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
+                            "filename": "/Users/gregory/project/blaqkube/starknet-burner/examples/controller/py/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
                         },
                         "start_col": 5,
-                        "start_line": 348
+                        "start_line": 350
                     }
                 },
                 "15": {
@@ -715,13 +716,13 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 97,
-                        "end_line": 348,
+                        "end_col": 98,
+                        "end_line": 350,
                         "input_file": {
-                            "filename": "/Users/gregory/project/blaqkube/fan-onchain/venv/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
+                            "filename": "/Users/gregory/project/blaqkube/starknet-burner/examples/controller/py/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
                         },
                         "start_col": 5,
-                        "start_line": 348
+                        "start_line": 350
                     }
                 },
                 "16": {
@@ -734,48 +735,48 @@
                         {
                             "location": {
                                 "end_col": 87,
-                                "end_line": 349,
+                                "end_line": 351,
                                 "input_file": {
-                                    "filename": "/Users/gregory/project/blaqkube/fan-onchain/venv/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
+                                    "filename": "/Users/gregory/project/blaqkube/starknet-burner/examples/controller/py/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
                                 },
                                 "start_col": 5,
-                                "start_line": 349
+                                "start_line": 351
                             },
                             "n_prefix_newlines": 0
                         }
                     ],
                     "inst": {
                         "end_col": 53,
-                        "end_line": 351,
+                        "end_line": 353,
                         "input_file": {
-                            "filename": "/Users/gregory/project/blaqkube/fan-onchain/venv/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
+                            "filename": "/Users/gregory/project/blaqkube/starknet-burner/examples/controller/py/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 38,
-                                "end_line": 346,
+                                "end_col": 37,
+                                "end_line": 348,
                                 "input_file": {
-                                    "filename": "/Users/gregory/project/blaqkube/fan-onchain/venv/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
+                                    "filename": "/Users/gregory/project/blaqkube/starknet-burner/examples/controller/py/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
-                                        "end_col": 34,
-                                        "end_line": 352,
+                                        "end_col": 35,
+                                        "end_line": 354,
                                         "input_file": {
-                                            "filename": "/Users/gregory/project/blaqkube/fan-onchain/venv/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
+                                            "filename": "/Users/gregory/project/blaqkube/starknet-burner/examples/controller/py/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
                                         },
                                         "start_col": 5,
-                                        "start_line": 352
+                                        "start_line": 354
                                     },
                                     "While trying to retrieve the implicit argument 'syscall_ptr' in:"
                                 ],
                                 "start_col": 19,
-                                "start_line": 346
+                                "start_line": 348
                             },
                             "While expanding the reference 'syscall_ptr' in:"
                         ],
                         "start_col": 23,
-                        "start_line": 351
+                        "start_line": 353
                     }
                 },
                 "18": {
@@ -787,12 +788,12 @@
                     "hints": [],
                     "inst": {
                         "end_col": 33,
-                        "end_line": 352,
+                        "end_line": 354,
                         "input_file": {
-                            "filename": "/Users/gregory/project/blaqkube/fan-onchain/venv/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
+                            "filename": "/Users/gregory/project/blaqkube/starknet-burner/examples/controller/py/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
                         },
                         "start_col": 19,
-                        "start_line": 352
+                        "start_line": 354
                     }
                 },
                 "19": {
@@ -803,13 +804,13 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 34,
-                        "end_line": 352,
+                        "end_col": 35,
+                        "end_line": 354,
                         "input_file": {
-                            "filename": "/Users/gregory/project/blaqkube/fan-onchain/venv/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
+                            "filename": "/Users/gregory/project/blaqkube/starknet-burner/examples/controller/py/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
                         },
                         "start_col": 5,
-                        "start_line": 352
+                        "start_line": 354
                     }
                 },
                 "20": {
@@ -821,12 +822,12 @@
                     "hints": [],
                     "inst": {
                         "end_col": 40,
-                        "end_line": 366,
+                        "end_line": 368,
                         "input_file": {
-                            "filename": "/Users/gregory/project/blaqkube/fan-onchain/venv/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
+                            "filename": "/Users/gregory/project/blaqkube/starknet-burner/examples/controller/py/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
                         },
                         "start_col": 18,
-                        "start_line": 366
+                        "start_line": 368
                     }
                 },
                 "22": {
@@ -837,13 +838,13 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 71,
-                        "end_line": 366,
+                        "end_col": 72,
+                        "end_line": 368,
                         "input_file": {
-                            "filename": "/Users/gregory/project/blaqkube/fan-onchain/venv/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
+                            "filename": "/Users/gregory/project/blaqkube/starknet-burner/examples/controller/py/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
                         },
                         "start_col": 5,
-                        "start_line": 365
+                        "start_line": 367
                     }
                 },
                 "23": {
@@ -854,13 +855,13 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 71,
-                        "end_line": 366,
+                        "end_col": 72,
+                        "end_line": 368,
                         "input_file": {
-                            "filename": "/Users/gregory/project/blaqkube/fan-onchain/venv/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
+                            "filename": "/Users/gregory/project/blaqkube/starknet-burner/examples/controller/py/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
                         },
                         "start_col": 5,
-                        "start_line": 365
+                        "start_line": 367
                     }
                 },
                 "24": {
@@ -871,13 +872,13 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 71,
-                        "end_line": 366,
+                        "end_col": 72,
+                        "end_line": 368,
                         "input_file": {
-                            "filename": "/Users/gregory/project/blaqkube/fan-onchain/venv/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
+                            "filename": "/Users/gregory/project/blaqkube/starknet-burner/examples/controller/py/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
                         },
                         "start_col": 5,
-                        "start_line": 365
+                        "start_line": 367
                     }
                 },
                 "25": {
@@ -890,48 +891,48 @@
                         {
                             "location": {
                                 "end_col": 88,
-                                "end_line": 367,
+                                "end_line": 369,
                                 "input_file": {
-                                    "filename": "/Users/gregory/project/blaqkube/fan-onchain/venv/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
+                                    "filename": "/Users/gregory/project/blaqkube/starknet-burner/examples/controller/py/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
                                 },
                                 "start_col": 5,
-                                "start_line": 367
+                                "start_line": 369
                             },
                             "n_prefix_newlines": 0
                         }
                     ],
                     "inst": {
                         "end_col": 54,
-                        "end_line": 368,
+                        "end_line": 370,
                         "input_file": {
-                            "filename": "/Users/gregory/project/blaqkube/fan-onchain/venv/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
+                            "filename": "/Users/gregory/project/blaqkube/starknet-burner/examples/controller/py/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 39,
-                                "end_line": 364,
+                                "end_col": 38,
+                                "end_line": 366,
                                 "input_file": {
-                                    "filename": "/Users/gregory/project/blaqkube/fan-onchain/venv/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
+                                    "filename": "/Users/gregory/project/blaqkube/starknet-burner/examples/controller/py/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
-                                        "end_col": 14,
-                                        "end_line": 369,
+                                        "end_col": 15,
+                                        "end_line": 371,
                                         "input_file": {
-                                            "filename": "/Users/gregory/project/blaqkube/fan-onchain/venv/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
+                                            "filename": "/Users/gregory/project/blaqkube/starknet-burner/examples/controller/py/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
                                         },
                                         "start_col": 5,
-                                        "start_line": 369
+                                        "start_line": 371
                                     },
                                     "While trying to retrieve the implicit argument 'syscall_ptr' in:"
                                 ],
                                 "start_col": 20,
-                                "start_line": 364
+                                "start_line": 366
                             },
                             "While expanding the reference 'syscall_ptr' in:"
                         ],
                         "start_col": 23,
-                        "start_line": 368
+                        "start_line": 370
                     }
                 },
                 "27": {
@@ -942,13 +943,13 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 14,
-                        "end_line": 369,
+                        "end_col": 15,
+                        "end_line": 371,
                         "input_file": {
-                            "filename": "/Users/gregory/project/blaqkube/fan-onchain/venv/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
+                            "filename": "/Users/gregory/project/blaqkube/starknet-burner/examples/controller/py/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
                         },
                         "start_col": 5,
-                        "start_line": 369
+                        "start_line": 371
                     }
                 },
                 "28": {
@@ -960,12 +961,12 @@
                     "hints": [],
                     "inst": {
                         "end_col": 76,
-                        "end_line": 435,
+                        "end_line": 440,
                         "input_file": {
-                            "filename": "/Users/gregory/project/blaqkube/fan-onchain/venv/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
+                            "filename": "/Users/gregory/project/blaqkube/starknet-burner/examples/controller/py/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
                         },
                         "start_col": 56,
-                        "start_line": 435
+                        "start_line": 440
                     }
                 },
                 "30": {
@@ -976,13 +977,13 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 77,
-                        "end_line": 435,
+                        "end_col": 78,
+                        "end_line": 440,
                         "input_file": {
-                            "filename": "/Users/gregory/project/blaqkube/fan-onchain/venv/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
+                            "filename": "/Users/gregory/project/blaqkube/starknet-burner/examples/controller/py/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
                         },
                         "start_col": 5,
-                        "start_line": 435
+                        "start_line": 440
                     }
                 },
                 "31": {
@@ -995,48 +996,48 @@
                         {
                             "location": {
                                 "end_col": 86,
-                                "end_line": 436,
+                                "end_line": 441,
                                 "input_file": {
-                                    "filename": "/Users/gregory/project/blaqkube/fan-onchain/venv/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
+                                    "filename": "/Users/gregory/project/blaqkube/starknet-burner/examples/controller/py/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
                                 },
                                 "start_col": 5,
-                                "start_line": 436
+                                "start_line": 441
                             },
                             "n_prefix_newlines": 0
                         }
                     ],
                     "inst": {
                         "end_col": 51,
-                        "end_line": 438,
+                        "end_line": 443,
                         "input_file": {
-                            "filename": "/Users/gregory/project/blaqkube/fan-onchain/venv/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
+                            "filename": "/Users/gregory/project/blaqkube/starknet-burner/examples/controller/py/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 37,
-                                "end_line": 433,
+                                "end_col": 36,
+                                "end_line": 438,
                                 "input_file": {
-                                    "filename": "/Users/gregory/project/blaqkube/fan-onchain/venv/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
+                                    "filename": "/Users/gregory/project/blaqkube/starknet-burner/examples/controller/py/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
-                                        "end_col": 38,
-                                        "end_line": 439,
+                                        "end_col": 39,
+                                        "end_line": 444,
                                         "input_file": {
-                                            "filename": "/Users/gregory/project/blaqkube/fan-onchain/venv/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
+                                            "filename": "/Users/gregory/project/blaqkube/starknet-burner/examples/controller/py/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
                                         },
                                         "start_col": 5,
-                                        "start_line": 439
+                                        "start_line": 444
                                     },
                                     "While trying to retrieve the implicit argument 'syscall_ptr' in:"
                                 ],
                                 "start_col": 18,
-                                "start_line": 433
+                                "start_line": 438
                             },
                             "While expanding the reference 'syscall_ptr' in:"
                         ],
                         "start_col": 23,
-                        "start_line": 438
+                        "start_line": 443
                     }
                 },
                 "33": {
@@ -1048,12 +1049,12 @@
                     "hints": [],
                     "inst": {
                         "end_col": 37,
-                        "end_line": 439,
+                        "end_line": 444,
                         "input_file": {
-                            "filename": "/Users/gregory/project/blaqkube/fan-onchain/venv/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
+                            "filename": "/Users/gregory/project/blaqkube/starknet-burner/examples/controller/py/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
                         },
                         "start_col": 21,
-                        "start_line": 439
+                        "start_line": 444
                     }
                 },
                 "34": {
@@ -1064,13 +1065,13 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 38,
-                        "end_line": 439,
+                        "end_col": 39,
+                        "end_line": 444,
                         "input_file": {
-                            "filename": "/Users/gregory/project/blaqkube/fan-onchain/venv/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
+                            "filename": "/Users/gregory/project/blaqkube/starknet-burner/examples/controller/py/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
                         },
                         "start_col": 5,
-                        "start_line": 439
+                        "start_line": 444
                     }
                 },
                 "35": {
@@ -1082,21 +1083,21 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 42,
+                        "end_col": 41,
                         "end_line": 7,
                         "input_file": {
                             "filename": "autogen/starknet/storage_var/counter/impl.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 42,
+                                "end_col": 41,
                                 "end_line": 7,
                                 "input_file": {
                                     "filename": "autogen/starknet/storage_var/counter/decl.cairo"
                                 },
                                 "parent_location": [
                                     {
-                                        "end_col": 25,
+                                        "end_col": 26,
                                         "end_line": 9,
                                         "input_file": {
                                             "filename": "autogen/starknet/storage_var/counter/impl.cairo"
@@ -1124,21 +1125,21 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 59,
+                        "end_col": 58,
                         "end_line": 7,
                         "input_file": {
                             "filename": "autogen/starknet/storage_var/counter/impl.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 59,
+                                "end_col": 58,
                                 "end_line": 7,
                                 "input_file": {
                                     "filename": "autogen/starknet/storage_var/counter/decl.cairo"
                                 },
                                 "parent_location": [
                                     {
-                                        "end_col": 25,
+                                        "end_col": 26,
                                         "end_line": 9,
                                         "input_file": {
                                             "filename": "autogen/starknet/storage_var/counter/impl.cairo"
@@ -1148,12 +1149,12 @@
                                     },
                                     "While trying to retrieve the implicit argument 'range_check_ptr' in:"
                                 ],
-                                "start_col": 44,
+                                "start_col": 43,
                                 "start_line": 7
                             },
                             "While expanding the reference 'range_check_ptr' in:"
                         ],
-                        "start_col": 44,
+                        "start_col": 43,
                         "start_line": 7
                     }
                 },
@@ -1196,7 +1197,7 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 25,
+                        "end_col": 26,
                         "end_line": 9,
                         "input_file": {
                             "filename": "autogen/starknet/storage_var/counter/impl.cairo"
@@ -1214,14 +1215,14 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 63,
+                        "end_col": 61,
                         "end_line": 12,
                         "input_file": {
                             "filename": "autogen/starknet/storage_var/counter/impl.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 42,
+                                "end_col": 41,
                                 "end_line": 7,
                                 "input_file": {
                                     "filename": "autogen/starknet/storage_var/counter/decl.cairo"
@@ -1229,12 +1230,12 @@
                                 "parent_location": [
                                     {
                                         "end_col": 36,
-                                        "end_line": 15,
+                                        "end_line": 13,
                                         "input_file": {
                                             "filename": "autogen/starknet/storage_var/counter/impl.cairo"
                                         },
                                         "start_col": 30,
-                                        "start_line": 15
+                                        "start_line": 13
                                     },
                                     "While trying to retrieve the implicit argument 'pedersen_ptr' in:"
                                 ],
@@ -1243,7 +1244,7 @@
                             },
                             "While expanding the reference 'pedersen_ptr' in:"
                         ],
-                        "start_col": 36,
+                        "start_col": 35,
                         "start_line": 12
                     }
                 },
@@ -1256,14 +1257,14 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 80,
+                        "end_col": 78,
                         "end_line": 12,
                         "input_file": {
                             "filename": "autogen/starknet/storage_var/counter/impl.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 59,
+                                "end_col": 58,
                                 "end_line": 7,
                                 "input_file": {
                                     "filename": "autogen/starknet/storage_var/counter/decl.cairo"
@@ -1271,21 +1272,21 @@
                                 "parent_location": [
                                     {
                                         "end_col": 36,
-                                        "end_line": 15,
+                                        "end_line": 13,
                                         "input_file": {
                                             "filename": "autogen/starknet/storage_var/counter/impl.cairo"
                                         },
                                         "start_col": 30,
-                                        "start_line": 15
+                                        "start_line": 13
                                     },
                                     "While trying to retrieve the implicit argument 'range_check_ptr' in:"
                                 ],
-                                "start_col": 44,
+                                "start_col": 43,
                                 "start_line": 7
                             },
                             "While expanding the reference 'range_check_ptr' in:"
                         ],
-                        "start_col": 65,
+                        "start_col": 63,
                         "start_line": 12
                     }
                 },
@@ -1299,12 +1300,12 @@
                     "hints": [],
                     "inst": {
                         "end_col": 36,
-                        "end_line": 15,
+                        "end_line": 13,
                         "input_file": {
                             "filename": "autogen/starknet/storage_var/counter/impl.cairo"
                         },
                         "start_col": 30,
-                        "start_line": 15
+                        "start_line": 13
                     }
                 },
                 "44": {
@@ -1316,32 +1317,32 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 34,
+                        "end_col": 33,
                         "end_line": 12,
                         "input_file": {
                             "filename": "autogen/starknet/storage_var/counter/impl.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 38,
-                                "end_line": 346,
+                                "end_col": 37,
+                                "end_line": 348,
                                 "input_file": {
-                                    "filename": "/Users/gregory/project/blaqkube/fan-onchain/venv/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
+                                    "filename": "/Users/gregory/project/blaqkube/starknet-burner/examples/controller/py/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 75,
-                                        "end_line": 16,
+                                        "end_line": 14,
                                         "input_file": {
                                             "filename": "autogen/starknet/storage_var/counter/impl.cairo"
                                         },
                                         "start_col": 37,
-                                        "start_line": 16
+                                        "start_line": 14
                                     },
                                     "While trying to retrieve the implicit argument 'syscall_ptr' in:"
                                 ],
                                 "start_col": 19,
-                                "start_line": 346
+                                "start_line": 348
                             },
                             "While expanding the reference 'syscall_ptr' in:"
                         ],
@@ -1359,24 +1360,24 @@
                     "hints": [],
                     "inst": {
                         "end_col": 26,
-                        "end_line": 15,
+                        "end_line": 13,
                         "input_file": {
                             "filename": "autogen/starknet/storage_var/counter/impl.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 70,
-                                "end_line": 16,
+                                "end_line": 14,
                                 "input_file": {
                                     "filename": "autogen/starknet/storage_var/counter/impl.cairo"
                                 },
                                 "start_col": 58,
-                                "start_line": 16
+                                "start_line": 14
                             },
                             "While expanding the reference 'storage_addr' in:"
                         ],
                         "start_col": 14,
-                        "start_line": 15
+                        "start_line": 13
                     }
                 },
                 "46": {
@@ -1389,12 +1390,12 @@
                     "hints": [],
                     "inst": {
                         "end_col": 75,
-                        "end_line": 16,
+                        "end_line": 14,
                         "input_file": {
                             "filename": "autogen/starknet/storage_var/counter/impl.cairo"
                         },
                         "start_col": 37,
-                        "start_line": 16
+                        "start_line": 14
                     }
                 },
                 "48": {
@@ -1406,37 +1407,37 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 38,
-                        "end_line": 346,
+                        "end_col": 37,
+                        "end_line": 348,
                         "input_file": {
-                            "filename": "/Users/gregory/project/blaqkube/fan-onchain/venv/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
+                            "filename": "/Users/gregory/project/blaqkube/starknet-burner/examples/controller/py/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 75,
-                                "end_line": 16,
+                                "end_line": 14,
                                 "input_file": {
                                     "filename": "autogen/starknet/storage_var/counter/impl.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 42,
-                                        "end_line": 18,
+                                        "end_line": 16,
                                         "input_file": {
                                             "filename": "autogen/starknet/storage_var/counter/impl.cairo"
                                         },
                                         "start_col": 31,
-                                        "start_line": 18
+                                        "start_line": 16
                                     },
                                     "While expanding the reference 'syscall_ptr' in:"
                                 ],
                                 "start_col": 37,
-                                "start_line": 16
+                                "start_line": 14
                             },
                             "While trying to update the implicit return value 'syscall_ptr' in:"
                         ],
                         "start_col": 19,
-                        "start_line": 346
+                        "start_line": 348
                     }
                 },
                 "49": {
@@ -1448,7 +1449,7 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 42,
+                        "end_col": 41,
                         "end_line": 7,
                         "input_file": {
                             "filename": "autogen/starknet/storage_var/counter/decl.cairo"
@@ -1456,24 +1457,24 @@
                         "parent_location": [
                             {
                                 "end_col": 36,
-                                "end_line": 15,
+                                "end_line": 13,
                                 "input_file": {
                                     "filename": "autogen/starknet/storage_var/counter/impl.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 44,
-                                        "end_line": 19,
+                                        "end_line": 17,
                                         "input_file": {
                                             "filename": "autogen/starknet/storage_var/counter/impl.cairo"
                                         },
                                         "start_col": 32,
-                                        "start_line": 19
+                                        "start_line": 17
                                     },
                                     "While expanding the reference 'pedersen_ptr' in:"
                                 ],
                                 "start_col": 30,
-                                "start_line": 15
+                                "start_line": 13
                             },
                             "While trying to update the implicit return value 'pedersen_ptr' in:"
                         ],
@@ -1490,7 +1491,7 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 59,
+                        "end_col": 58,
                         "end_line": 7,
                         "input_file": {
                             "filename": "autogen/starknet/storage_var/counter/decl.cairo"
@@ -1498,28 +1499,28 @@
                         "parent_location": [
                             {
                                 "end_col": 36,
-                                "end_line": 15,
+                                "end_line": 13,
                                 "input_file": {
                                     "filename": "autogen/starknet/storage_var/counter/impl.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 50,
-                                        "end_line": 20,
+                                        "end_line": 18,
                                         "input_file": {
                                             "filename": "autogen/starknet/storage_var/counter/impl.cairo"
                                         },
                                         "start_col": 35,
-                                        "start_line": 20
+                                        "start_line": 18
                                     },
                                     "While expanding the reference 'range_check_ptr' in:"
                                 ],
                                 "start_col": 30,
-                                "start_line": 15
+                                "start_line": 13
                             },
                             "While trying to update the implicit return value 'range_check_ptr' in:"
                         ],
-                        "start_col": 44,
+                        "start_col": 43,
                         "start_line": 7
                     }
                 },
@@ -1533,24 +1534,24 @@
                     "hints": [],
                     "inst": {
                         "end_col": 33,
-                        "end_line": 16,
+                        "end_line": 14,
                         "input_file": {
                             "filename": "autogen/starknet/storage_var/counter/impl.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 65,
-                                "end_line": 21,
+                                "end_col": 64,
+                                "end_line": 19,
                                 "input_file": {
                                     "filename": "autogen/starknet/storage_var/counter/impl.cairo"
                                 },
-                                "start_col": 46,
-                                "start_line": 21
+                                "start_col": 45,
+                                "start_line": 19
                             },
                             "While expanding the reference '__storage_var_temp0' in:"
                         ],
                         "start_col": 14,
-                        "start_line": 16
+                        "start_line": 14
                     }
                 },
                 "52": {
@@ -1562,13 +1563,13 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 53,
-                        "end_line": 22,
+                        "end_col": 55,
+                        "end_line": 20,
                         "input_file": {
                             "filename": "autogen/starknet/storage_var/counter/impl.cairo"
                         },
                         "start_col": 9,
-                        "start_line": 22
+                        "start_line": 20
                     }
                 },
                 "53": {
@@ -1580,14 +1581,14 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 64,
-                        "end_line": 25,
+                        "end_col": 62,
+                        "end_line": 23,
                         "input_file": {
                             "filename": "autogen/starknet/storage_var/counter/impl.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 42,
+                                "end_col": 41,
                                 "end_line": 7,
                                 "input_file": {
                                     "filename": "autogen/starknet/storage_var/counter/decl.cairo"
@@ -1595,12 +1596,12 @@
                                 "parent_location": [
                                     {
                                         "end_col": 36,
-                                        "end_line": 26,
+                                        "end_line": 24,
                                         "input_file": {
                                             "filename": "autogen/starknet/storage_var/counter/impl.cairo"
                                         },
                                         "start_col": 30,
-                                        "start_line": 26
+                                        "start_line": 24
                                     },
                                     "While trying to retrieve the implicit argument 'pedersen_ptr' in:"
                                 ],
@@ -1609,8 +1610,8 @@
                             },
                             "While expanding the reference 'pedersen_ptr' in:"
                         ],
-                        "start_col": 37,
-                        "start_line": 25
+                        "start_col": 36,
+                        "start_line": 23
                     }
                 },
                 "54": {
@@ -1622,14 +1623,14 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 81,
-                        "end_line": 25,
+                        "end_col": 79,
+                        "end_line": 23,
                         "input_file": {
                             "filename": "autogen/starknet/storage_var/counter/impl.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 59,
+                                "end_col": 58,
                                 "end_line": 7,
                                 "input_file": {
                                     "filename": "autogen/starknet/storage_var/counter/decl.cairo"
@@ -1637,22 +1638,22 @@
                                 "parent_location": [
                                     {
                                         "end_col": 36,
-                                        "end_line": 26,
+                                        "end_line": 24,
                                         "input_file": {
                                             "filename": "autogen/starknet/storage_var/counter/impl.cairo"
                                         },
                                         "start_col": 30,
-                                        "start_line": 26
+                                        "start_line": 24
                                     },
                                     "While trying to retrieve the implicit argument 'range_check_ptr' in:"
                                 ],
-                                "start_col": 44,
+                                "start_col": 43,
                                 "start_line": 7
                             },
                             "While expanding the reference 'range_check_ptr' in:"
                         ],
-                        "start_col": 66,
-                        "start_line": 25
+                        "start_col": 64,
+                        "start_line": 23
                     }
                 },
                 "55": {
@@ -1665,12 +1666,12 @@
                     "hints": [],
                     "inst": {
                         "end_col": 36,
-                        "end_line": 26,
+                        "end_line": 24,
                         "input_file": {
                             "filename": "autogen/starknet/storage_var/counter/impl.cairo"
                         },
                         "start_col": 30,
-                        "start_line": 26
+                        "start_line": 24
                     }
                 },
                 "57": {
@@ -1682,37 +1683,37 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 35,
-                        "end_line": 25,
+                        "end_col": 34,
+                        "end_line": 23,
                         "input_file": {
                             "filename": "autogen/starknet/storage_var/counter/impl.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 39,
-                                "end_line": 364,
+                                "end_col": 38,
+                                "end_line": 366,
                                 "input_file": {
-                                    "filename": "/Users/gregory/project/blaqkube/fan-onchain/venv/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
+                                    "filename": "/Users/gregory/project/blaqkube/starknet-burner/examples/controller/py/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 80,
-                                        "end_line": 27,
+                                        "end_line": 25,
                                         "input_file": {
                                             "filename": "autogen/starknet/storage_var/counter/impl.cairo"
                                         },
                                         "start_col": 9,
-                                        "start_line": 27
+                                        "start_line": 25
                                     },
                                     "While trying to retrieve the implicit argument 'syscall_ptr' in:"
                                 ],
                                 "start_col": 20,
-                                "start_line": 364
+                                "start_line": 366
                             },
                             "While expanding the reference 'syscall_ptr' in:"
                         ],
                         "start_col": 16,
-                        "start_line": 25
+                        "start_line": 23
                     }
                 },
                 "58": {
@@ -1725,24 +1726,24 @@
                     "hints": [],
                     "inst": {
                         "end_col": 26,
-                        "end_line": 26,
+                        "end_line": 24,
                         "input_file": {
                             "filename": "autogen/starknet/storage_var/counter/impl.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 43,
-                                "end_line": 27,
+                                "end_line": 25,
                                 "input_file": {
                                     "filename": "autogen/starknet/storage_var/counter/impl.cairo"
                                 },
                                 "start_col": 31,
-                                "start_line": 27
+                                "start_line": 25
                             },
                             "While expanding the reference 'storage_addr' in:"
                         ],
                         "start_col": 14,
-                        "start_line": 26
+                        "start_line": 24
                     }
                 },
                 "59": {
@@ -1755,12 +1756,12 @@
                     "hints": [],
                     "inst": {
                         "end_col": 79,
-                        "end_line": 27,
+                        "end_line": 25,
                         "input_file": {
                             "filename": "autogen/starknet/storage_var/counter/impl.cairo"
                         },
                         "start_col": 55,
-                        "start_line": 27
+                        "start_line": 25
                     }
                 },
                 "60": {
@@ -1773,12 +1774,12 @@
                     "hints": [],
                     "inst": {
                         "end_col": 80,
-                        "end_line": 27,
+                        "end_line": 25,
                         "input_file": {
                             "filename": "autogen/starknet/storage_var/counter/impl.cairo"
                         },
                         "start_col": 9,
-                        "start_line": 27
+                        "start_line": 25
                     }
                 },
                 "62": {
@@ -1790,7 +1791,7 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 42,
+                        "end_col": 41,
                         "end_line": 7,
                         "input_file": {
                             "filename": "autogen/starknet/storage_var/counter/decl.cairo"
@@ -1798,36 +1799,36 @@
                         "parent_location": [
                             {
                                 "end_col": 36,
-                                "end_line": 26,
+                                "end_line": 24,
                                 "input_file": {
                                     "filename": "autogen/starknet/storage_var/counter/impl.cairo"
                                 },
                                 "parent_location": [
                                     {
-                                        "end_col": 64,
-                                        "end_line": 21,
+                                        "end_col": 62,
+                                        "end_line": 19,
                                         "input_file": {
                                             "filename": "autogen/starknet/storage_var/counter/decl.cairo"
                                         },
                                         "parent_location": [
                                             {
-                                                "end_col": 18,
-                                                "end_line": 28,
+                                                "end_col": 19,
+                                                "end_line": 26,
                                                 "input_file": {
                                                     "filename": "autogen/starknet/storage_var/counter/impl.cairo"
                                                 },
                                                 "start_col": 9,
-                                                "start_line": 28
+                                                "start_line": 26
                                             },
                                             "While trying to retrieve the implicit argument 'pedersen_ptr' in:"
                                         ],
-                                        "start_col": 37,
-                                        "start_line": 21
+                                        "start_col": 36,
+                                        "start_line": 19
                                     },
                                     "While expanding the reference 'pedersen_ptr' in:"
                                 ],
                                 "start_col": 30,
-                                "start_line": 26
+                                "start_line": 24
                             },
                             "While trying to update the implicit return value 'pedersen_ptr' in:"
                         ],
@@ -1844,7 +1845,7 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 59,
+                        "end_col": 58,
                         "end_line": 7,
                         "input_file": {
                             "filename": "autogen/starknet/storage_var/counter/decl.cairo"
@@ -1852,40 +1853,40 @@
                         "parent_location": [
                             {
                                 "end_col": 36,
-                                "end_line": 26,
+                                "end_line": 24,
                                 "input_file": {
                                     "filename": "autogen/starknet/storage_var/counter/impl.cairo"
                                 },
                                 "parent_location": [
                                     {
-                                        "end_col": 81,
-                                        "end_line": 21,
+                                        "end_col": 79,
+                                        "end_line": 19,
                                         "input_file": {
                                             "filename": "autogen/starknet/storage_var/counter/decl.cairo"
                                         },
                                         "parent_location": [
                                             {
-                                                "end_col": 18,
-                                                "end_line": 28,
+                                                "end_col": 19,
+                                                "end_line": 26,
                                                 "input_file": {
                                                     "filename": "autogen/starknet/storage_var/counter/impl.cairo"
                                                 },
                                                 "start_col": 9,
-                                                "start_line": 28
+                                                "start_line": 26
                                             },
                                             "While trying to retrieve the implicit argument 'range_check_ptr' in:"
                                         ],
-                                        "start_col": 66,
-                                        "start_line": 21
+                                        "start_col": 64,
+                                        "start_line": 19
                                     },
                                     "While expanding the reference 'range_check_ptr' in:"
                                 ],
                                 "start_col": 30,
-                                "start_line": 26
+                                "start_line": 24
                             },
                             "While trying to update the implicit return value 'range_check_ptr' in:"
                         ],
-                        "start_col": 44,
+                        "start_col": 43,
                         "start_line": 7
                     }
                 },
@@ -1898,13 +1899,13 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 18,
-                        "end_line": 28,
+                        "end_col": 19,
+                        "end_line": 26,
                         "input_file": {
                             "filename": "autogen/starknet/storage_var/counter/impl.cairo"
                         },
                         "start_col": 9,
-                        "start_line": 28
+                        "start_line": 26
                     }
                 },
                 "65": {
@@ -1916,21 +1917,21 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 42,
+                        "end_col": 41,
                         "end_line": 7,
                         "input_file": {
                             "filename": "autogen/starknet/storage_var/rand/impl.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 42,
+                                "end_col": 41,
                                 "end_line": 7,
                                 "input_file": {
                                     "filename": "autogen/starknet/storage_var/rand/decl.cairo"
                                 },
                                 "parent_location": [
                                     {
-                                        "end_col": 25,
+                                        "end_col": 26,
                                         "end_line": 9,
                                         "input_file": {
                                             "filename": "autogen/starknet/storage_var/rand/impl.cairo"
@@ -1958,21 +1959,21 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 59,
+                        "end_col": 58,
                         "end_line": 7,
                         "input_file": {
                             "filename": "autogen/starknet/storage_var/rand/impl.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 59,
+                                "end_col": 58,
                                 "end_line": 7,
                                 "input_file": {
                                     "filename": "autogen/starknet/storage_var/rand/decl.cairo"
                                 },
                                 "parent_location": [
                                     {
-                                        "end_col": 25,
+                                        "end_col": 26,
                                         "end_line": 9,
                                         "input_file": {
                                             "filename": "autogen/starknet/storage_var/rand/impl.cairo"
@@ -1982,12 +1983,12 @@
                                     },
                                     "While trying to retrieve the implicit argument 'range_check_ptr' in:"
                                 ],
-                                "start_col": 44,
+                                "start_col": 43,
                                 "start_line": 7
                             },
                             "While expanding the reference 'range_check_ptr' in:"
                         ],
-                        "start_col": 44,
+                        "start_col": 43,
                         "start_line": 7
                     }
                 },
@@ -2030,7 +2031,7 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 25,
+                        "end_col": 26,
                         "end_line": 9,
                         "input_file": {
                             "filename": "autogen/starknet/storage_var/rand/impl.cairo"
@@ -2048,14 +2049,14 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 63,
+                        "end_col": 61,
                         "end_line": 12,
                         "input_file": {
                             "filename": "autogen/starknet/storage_var/rand/impl.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 42,
+                                "end_col": 41,
                                 "end_line": 7,
                                 "input_file": {
                                     "filename": "autogen/starknet/storage_var/rand/decl.cairo"
@@ -2077,7 +2078,7 @@
                             },
                             "While expanding the reference 'pedersen_ptr' in:"
                         ],
-                        "start_col": 36,
+                        "start_col": 35,
                         "start_line": 12
                     }
                 },
@@ -2090,14 +2091,14 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 80,
+                        "end_col": 78,
                         "end_line": 12,
                         "input_file": {
                             "filename": "autogen/starknet/storage_var/rand/impl.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 59,
+                                "end_col": 58,
                                 "end_line": 7,
                                 "input_file": {
                                     "filename": "autogen/starknet/storage_var/rand/decl.cairo"
@@ -2114,12 +2115,12 @@
                                     },
                                     "While trying to retrieve the implicit argument 'range_check_ptr' in:"
                                 ],
-                                "start_col": 44,
+                                "start_col": 43,
                                 "start_line": 7
                             },
                             "While expanding the reference 'range_check_ptr' in:"
                         ],
-                        "start_col": 65,
+                        "start_col": 63,
                         "start_line": 12
                     }
                 },
@@ -2150,17 +2151,17 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 34,
+                        "end_col": 33,
                         "end_line": 12,
                         "input_file": {
                             "filename": "autogen/starknet/storage_var/rand/impl.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 38,
-                                "end_line": 346,
+                                "end_col": 37,
+                                "end_line": 348,
                                 "input_file": {
-                                    "filename": "/Users/gregory/project/blaqkube/fan-onchain/venv/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
+                                    "filename": "/Users/gregory/project/blaqkube/starknet-burner/examples/controller/py/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
@@ -2175,7 +2176,7 @@
                                     "While trying to retrieve the implicit argument 'syscall_ptr' in:"
                                 ],
                                 "start_col": 19,
-                                "start_line": 346
+                                "start_line": 348
                             },
                             "While expanding the reference 'syscall_ptr' in:"
                         ],
@@ -2240,10 +2241,10 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 38,
-                        "end_line": 346,
+                        "end_col": 37,
+                        "end_line": 348,
                         "input_file": {
-                            "filename": "/Users/gregory/project/blaqkube/fan-onchain/venv/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
+                            "filename": "/Users/gregory/project/blaqkube/starknet-burner/examples/controller/py/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
                         },
                         "parent_location": [
                             {
@@ -2270,7 +2271,7 @@
                             "While trying to update the implicit return value 'syscall_ptr' in:"
                         ],
                         "start_col": 19,
-                        "start_line": 346
+                        "start_line": 348
                     }
                 },
                 "79": {
@@ -2282,7 +2283,7 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 42,
+                        "end_col": 41,
                         "end_line": 7,
                         "input_file": {
                             "filename": "autogen/starknet/storage_var/rand/decl.cairo"
@@ -2324,7 +2325,7 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 59,
+                        "end_col": 58,
                         "end_line": 7,
                         "input_file": {
                             "filename": "autogen/starknet/storage_var/rand/decl.cairo"
@@ -2353,7 +2354,7 @@
                             },
                             "While trying to update the implicit return value 'range_check_ptr' in:"
                         ],
-                        "start_col": 44,
+                        "start_col": 43,
                         "start_line": 7
                     }
                 },
@@ -2373,12 +2374,12 @@
                         },
                         "parent_location": [
                             {
-                                "end_col": 65,
+                                "end_col": 64,
                                 "end_line": 19,
                                 "input_file": {
                                     "filename": "autogen/starknet/storage_var/rand/impl.cairo"
                                 },
-                                "start_col": 46,
+                                "start_col": 45,
                                 "start_line": 19
                             },
                             "While expanding the reference '__storage_var_temp0' in:"
@@ -2396,7 +2397,7 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 53,
+                        "end_col": 55,
                         "end_line": 20,
                         "input_file": {
                             "filename": "autogen/starknet/storage_var/rand/impl.cairo"
@@ -2414,14 +2415,14 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 64,
+                        "end_col": 62,
                         "end_line": 23,
                         "input_file": {
                             "filename": "autogen/starknet/storage_var/rand/impl.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 42,
+                                "end_col": 41,
                                 "end_line": 7,
                                 "input_file": {
                                     "filename": "autogen/starknet/storage_var/rand/decl.cairo"
@@ -2443,7 +2444,7 @@
                             },
                             "While expanding the reference 'pedersen_ptr' in:"
                         ],
-                        "start_col": 37,
+                        "start_col": 36,
                         "start_line": 23
                     }
                 },
@@ -2456,14 +2457,14 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 81,
+                        "end_col": 79,
                         "end_line": 23,
                         "input_file": {
                             "filename": "autogen/starknet/storage_var/rand/impl.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 59,
+                                "end_col": 58,
                                 "end_line": 7,
                                 "input_file": {
                                     "filename": "autogen/starknet/storage_var/rand/decl.cairo"
@@ -2480,12 +2481,12 @@
                                     },
                                     "While trying to retrieve the implicit argument 'range_check_ptr' in:"
                                 ],
-                                "start_col": 44,
+                                "start_col": 43,
                                 "start_line": 7
                             },
                             "While expanding the reference 'range_check_ptr' in:"
                         ],
-                        "start_col": 66,
+                        "start_col": 64,
                         "start_line": 23
                     }
                 },
@@ -2516,17 +2517,17 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 35,
+                        "end_col": 34,
                         "end_line": 23,
                         "input_file": {
                             "filename": "autogen/starknet/storage_var/rand/impl.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 39,
-                                "end_line": 364,
+                                "end_col": 38,
+                                "end_line": 366,
                                 "input_file": {
-                                    "filename": "/Users/gregory/project/blaqkube/fan-onchain/venv/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
+                                    "filename": "/Users/gregory/project/blaqkube/starknet-burner/examples/controller/py/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
@@ -2541,7 +2542,7 @@
                                     "While trying to retrieve the implicit argument 'syscall_ptr' in:"
                                 ],
                                 "start_col": 20,
-                                "start_line": 364
+                                "start_line": 366
                             },
                             "While expanding the reference 'syscall_ptr' in:"
                         ],
@@ -2624,7 +2625,7 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 42,
+                        "end_col": 41,
                         "end_line": 7,
                         "input_file": {
                             "filename": "autogen/starknet/storage_var/rand/decl.cairo"
@@ -2638,14 +2639,14 @@
                                 },
                                 "parent_location": [
                                     {
-                                        "end_col": 64,
+                                        "end_col": 62,
                                         "end_line": 19,
                                         "input_file": {
                                             "filename": "autogen/starknet/storage_var/rand/decl.cairo"
                                         },
                                         "parent_location": [
                                             {
-                                                "end_col": 18,
+                                                "end_col": 19,
                                                 "end_line": 26,
                                                 "input_file": {
                                                     "filename": "autogen/starknet/storage_var/rand/impl.cairo"
@@ -2655,7 +2656,7 @@
                                             },
                                             "While trying to retrieve the implicit argument 'pedersen_ptr' in:"
                                         ],
-                                        "start_col": 37,
+                                        "start_col": 36,
                                         "start_line": 19
                                     },
                                     "While expanding the reference 'pedersen_ptr' in:"
@@ -2678,7 +2679,7 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 59,
+                        "end_col": 58,
                         "end_line": 7,
                         "input_file": {
                             "filename": "autogen/starknet/storage_var/rand/decl.cairo"
@@ -2692,14 +2693,14 @@
                                 },
                                 "parent_location": [
                                     {
-                                        "end_col": 81,
+                                        "end_col": 79,
                                         "end_line": 19,
                                         "input_file": {
                                             "filename": "autogen/starknet/storage_var/rand/decl.cairo"
                                         },
                                         "parent_location": [
                                             {
-                                                "end_col": 18,
+                                                "end_col": 19,
                                                 "end_line": 26,
                                                 "input_file": {
                                                     "filename": "autogen/starknet/storage_var/rand/impl.cairo"
@@ -2709,7 +2710,7 @@
                                             },
                                             "While trying to retrieve the implicit argument 'range_check_ptr' in:"
                                         ],
-                                        "start_col": 66,
+                                        "start_col": 64,
                                         "start_line": 19
                                     },
                                     "While expanding the reference 'range_check_ptr' in:"
@@ -2719,7 +2720,7 @@
                             },
                             "While trying to update the implicit return value 'range_check_ptr' in:"
                         ],
-                        "start_col": 44,
+                        "start_col": 43,
                         "start_line": 7
                     }
                 },
@@ -2732,7 +2733,7 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 18,
+                        "end_col": 19,
                         "end_line": 26,
                         "input_file": {
                             "filename": "autogen/starknet/storage_var/rand/impl.cairo"
@@ -2750,15 +2751,15 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 37,
+                        "end_col": 36,
                         "end_line": 22,
                         "input_file": {
-                            "filename": "contracts/counter.cairo"
+                            "filename": "counter.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 35,
-                                "end_line": 21,
+                                "end_col": 34,
+                                "end_line": 19,
                                 "input_file": {
                                     "filename": "autogen/starknet/storage_var/counter/decl.cairo"
                                 },
@@ -2767,7 +2768,7 @@
                                         "end_col": 21,
                                         "end_line": 23,
                                         "input_file": {
-                                            "filename": "contracts/counter.cairo"
+                                            "filename": "counter.cairo"
                                         },
                                         "start_col": 5,
                                         "start_line": 23
@@ -2775,7 +2776,7 @@
                                     "While trying to retrieve the implicit argument 'syscall_ptr' in:"
                                 ],
                                 "start_col": 16,
-                                "start_line": 21
+                                "start_line": 19
                             },
                             "While expanding the reference 'syscall_ptr' in:"
                         ],
@@ -2792,15 +2793,15 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 66,
+                        "end_col": 64,
                         "end_line": 22,
                         "input_file": {
-                            "filename": "contracts/counter.cairo"
+                            "filename": "counter.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 64,
-                                "end_line": 21,
+                                "end_col": 62,
+                                "end_line": 19,
                                 "input_file": {
                                     "filename": "autogen/starknet/storage_var/counter/decl.cairo"
                                 },
@@ -2809,19 +2810,19 @@
                                         "end_col": 21,
                                         "end_line": 23,
                                         "input_file": {
-                                            "filename": "contracts/counter.cairo"
+                                            "filename": "counter.cairo"
                                         },
                                         "start_col": 5,
                                         "start_line": 23
                                     },
                                     "While trying to retrieve the implicit argument 'pedersen_ptr' in:"
                                 ],
-                                "start_col": 37,
-                                "start_line": 21
+                                "start_col": 36,
+                                "start_line": 19
                             },
                             "While expanding the reference 'pedersen_ptr' in:"
                         ],
-                        "start_col": 39,
+                        "start_col": 38,
                         "start_line": 22
                     }
                 },
@@ -2834,15 +2835,15 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 83,
+                        "end_col": 81,
                         "end_line": 22,
                         "input_file": {
-                            "filename": "contracts/counter.cairo"
+                            "filename": "counter.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 81,
-                                "end_line": 21,
+                                "end_col": 79,
+                                "end_line": 19,
                                 "input_file": {
                                     "filename": "autogen/starknet/storage_var/counter/decl.cairo"
                                 },
@@ -2851,19 +2852,19 @@
                                         "end_col": 21,
                                         "end_line": 23,
                                         "input_file": {
-                                            "filename": "contracts/counter.cairo"
+                                            "filename": "counter.cairo"
                                         },
                                         "start_col": 5,
                                         "start_line": 23
                                     },
                                     "While trying to retrieve the implicit argument 'range_check_ptr' in:"
                                 ],
-                                "start_col": 66,
-                                "start_line": 21
+                                "start_col": 64,
+                                "start_line": 19
                             },
                             "While expanding the reference 'range_check_ptr' in:"
                         ],
-                        "start_col": 68,
+                        "start_col": 66,
                         "start_line": 22
                     }
                 },
@@ -2879,7 +2880,7 @@
                         "end_col": 20,
                         "end_line": 23,
                         "input_file": {
-                            "filename": "contracts/counter.cairo"
+                            "filename": "counter.cairo"
                         },
                         "start_col": 19,
                         "start_line": 23
@@ -2897,7 +2898,7 @@
                         "end_col": 21,
                         "end_line": 23,
                         "input_file": {
-                            "filename": "contracts/counter.cairo"
+                            "filename": "counter.cairo"
                         },
                         "start_col": 5,
                         "start_line": 23
@@ -2912,10 +2913,10 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 14,
+                        "end_col": 15,
                         "end_line": 25,
                         "input_file": {
-                            "filename": "contracts/counter.cairo"
+                            "filename": "counter.cairo"
                         },
                         "start_col": 5,
                         "start_line": 25
@@ -2931,17 +2932,17 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 57,
+                        "end_col": 58,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/arg_processor/1b562308a65653425ce06491fa4b4539466f3251a07e73e099d0afe86a48900e.cairo"
+                            "filename": "autogen/starknet/arg_processor/01cba52f8515996bb9d7070bde81ff39281d096d7024a558efcba6e1fd2402cf.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 17,
                                 "end_line": 22,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "start_col": 6,
                                 "start_line": 22
@@ -2965,28 +2966,28 @@
                         "end_col": 64,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/external/constructor/c7060df96cb0acca1380ae43bf758cab727bfdf73cb5d34a93e24a9742817fda.cairo"
+                            "filename": "autogen/starknet/external/constructor/b2c52ca2d2a8fc8791a983086d8716c5eacd0c3d62934914d2286f84b98ff4cb.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 37,
+                                "end_col": 36,
                                 "end_line": 22,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 55,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/constructor/ef3a79c18d46a9fa62dfdc7620278a45e5a135102b4efbfbcf08b5b08cd0430f.cairo"
+                                            "filename": "autogen/starknet/external/constructor/8f83d060e7e088c358526f8859eb82973ba2c094c7d9223df6230b744dfa211c.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 17,
                                                 "end_line": 22,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "start_col": 6,
                                                 "start_line": 22
@@ -3020,28 +3021,28 @@
                         "end_col": 110,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/external/constructor/424b26e79f70343cc02557f1fbd25745138efb26a3dc5c8b593ca765b73138b7.cairo"
+                            "filename": "autogen/starknet/external/constructor/9684a85e93c782014ca14293edea4eb2502039a5a7b6538ecd39c56faaf12529.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 66,
+                                "end_col": 64,
                                 "end_line": 22,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 82,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/constructor/ef3a79c18d46a9fa62dfdc7620278a45e5a135102b4efbfbcf08b5b08cd0430f.cairo"
+                                            "filename": "autogen/starknet/external/constructor/8f83d060e7e088c358526f8859eb82973ba2c094c7d9223df6230b744dfa211c.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 17,
                                                 "end_line": 22,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "start_col": 6,
                                                 "start_line": 22
@@ -3053,7 +3054,7 @@
                                     },
                                     "While expanding the reference 'pedersen_ptr' in:"
                                 ],
-                                "start_col": 39,
+                                "start_col": 38,
                                 "start_line": 22
                             },
                             "While constructing the external wrapper for:"
@@ -3075,28 +3076,28 @@
                         "end_col": 67,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/external/constructor/e651458745e7cd218121c342e0915890767e2f59ddc2e315b8844ad0f47d582e.cairo"
+                            "filename": "autogen/starknet/external/constructor/741ea357d6336b0bed7bf0472425acd0311d543883b803388880e60a232040c7.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 83,
+                                "end_col": 81,
                                 "end_line": 22,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 115,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/constructor/ef3a79c18d46a9fa62dfdc7620278a45e5a135102b4efbfbcf08b5b08cd0430f.cairo"
+                                            "filename": "autogen/starknet/external/constructor/8f83d060e7e088c358526f8859eb82973ba2c094c7d9223df6230b744dfa211c.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 17,
                                                 "end_line": 22,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "start_col": 6,
                                                 "start_line": 22
@@ -3108,7 +3109,7 @@
                                     },
                                     "While expanding the reference 'range_check_ptr' in:"
                                 ],
-                                "start_col": 68,
+                                "start_col": 66,
                                 "start_line": 22
                             },
                             "While constructing the external wrapper for:"
@@ -3130,7 +3131,7 @@
                         "end_col": 17,
                         "end_line": 22,
                         "input_file": {
-                            "filename": "contracts/counter.cairo"
+                            "filename": "counter.cairo"
                         },
                         "start_col": 6,
                         "start_line": 22
@@ -3150,14 +3151,14 @@
                                 "end_col": 34,
                                 "end_line": 2,
                                 "input_file": {
-                                    "filename": "autogen/starknet/external/constructor/ef3a79c18d46a9fa62dfdc7620278a45e5a135102b4efbfbcf08b5b08cd0430f.cairo"
+                                    "filename": "autogen/starknet/external/constructor/8f83d060e7e088c358526f8859eb82973ba2c094c7d9223df6230b744dfa211c.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 17,
                                         "end_line": 22,
                                         "input_file": {
-                                            "filename": "contracts/counter.cairo"
+                                            "filename": "counter.cairo"
                                         },
                                         "start_col": 6,
                                         "start_line": 22
@@ -3174,14 +3175,14 @@
                         "end_col": 24,
                         "end_line": 3,
                         "input_file": {
-                            "filename": "autogen/starknet/external/constructor/ef3a79c18d46a9fa62dfdc7620278a45e5a135102b4efbfbcf08b5b08cd0430f.cairo"
+                            "filename": "autogen/starknet/external/constructor/8f83d060e7e088c358526f8859eb82973ba2c094c7d9223df6230b744dfa211c.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 17,
                                 "end_line": 22,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "start_col": 6,
                                 "start_line": 22
@@ -3205,28 +3206,28 @@
                         "end_col": 55,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/external/constructor/ef3a79c18d46a9fa62dfdc7620278a45e5a135102b4efbfbcf08b5b08cd0430f.cairo"
+                            "filename": "autogen/starknet/external/constructor/8f83d060e7e088c358526f8859eb82973ba2c094c7d9223df6230b744dfa211c.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 17,
                                 "end_line": 22,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 20,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/constructor/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo"
+                                            "filename": "autogen/starknet/external/constructor/da17921a4e81c09e730800bbf23bfdbe5e9e6bfaedc59d80fbf62087fa43c27d.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 17,
                                                 "end_line": 22,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "start_col": 6,
                                                 "start_line": 22
@@ -3260,28 +3261,28 @@
                         "end_col": 82,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/external/constructor/ef3a79c18d46a9fa62dfdc7620278a45e5a135102b4efbfbcf08b5b08cd0430f.cairo"
+                            "filename": "autogen/starknet/external/constructor/8f83d060e7e088c358526f8859eb82973ba2c094c7d9223df6230b744dfa211c.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 17,
                                 "end_line": 22,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 33,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/constructor/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo"
+                                            "filename": "autogen/starknet/external/constructor/da17921a4e81c09e730800bbf23bfdbe5e9e6bfaedc59d80fbf62087fa43c27d.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 17,
                                                 "end_line": 22,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "start_col": 6,
                                                 "start_line": 22
@@ -3315,28 +3316,28 @@
                         "end_col": 115,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/external/constructor/ef3a79c18d46a9fa62dfdc7620278a45e5a135102b4efbfbcf08b5b08cd0430f.cairo"
+                            "filename": "autogen/starknet/external/constructor/8f83d060e7e088c358526f8859eb82973ba2c094c7d9223df6230b744dfa211c.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 17,
                                 "end_line": 22,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 49,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/constructor/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo"
+                                            "filename": "autogen/starknet/external/constructor/da17921a4e81c09e730800bbf23bfdbe5e9e6bfaedc59d80fbf62087fa43c27d.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 17,
                                                 "end_line": 22,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "start_col": 6,
                                                 "start_line": 22
@@ -3370,28 +3371,28 @@
                         "end_col": 21,
                         "end_line": 4,
                         "input_file": {
-                            "filename": "autogen/starknet/external/constructor/ef3a79c18d46a9fa62dfdc7620278a45e5a135102b4efbfbcf08b5b08cd0430f.cairo"
+                            "filename": "autogen/starknet/external/constructor/8f83d060e7e088c358526f8859eb82973ba2c094c7d9223df6230b744dfa211c.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 17,
                                 "end_line": 22,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 62,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/constructor/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo"
+                                            "filename": "autogen/starknet/external/constructor/da17921a4e81c09e730800bbf23bfdbe5e9e6bfaedc59d80fbf62087fa43c27d.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 17,
                                                 "end_line": 22,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "start_col": 6,
                                                 "start_line": 22
@@ -3425,28 +3426,28 @@
                         "end_col": 16,
                         "end_line": 3,
                         "input_file": {
-                            "filename": "autogen/starknet/external/constructor/ef3a79c18d46a9fa62dfdc7620278a45e5a135102b4efbfbcf08b5b08cd0430f.cairo"
+                            "filename": "autogen/starknet/external/constructor/8f83d060e7e088c358526f8859eb82973ba2c094c7d9223df6230b744dfa211c.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 17,
                                 "end_line": 22,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 70,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/constructor/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo"
+                                            "filename": "autogen/starknet/external/constructor/da17921a4e81c09e730800bbf23bfdbe5e9e6bfaedc59d80fbf62087fa43c27d.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 17,
                                                 "end_line": 22,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "start_col": 6,
                                                 "start_line": 22
@@ -3477,17 +3478,17 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 71,
+                        "end_col": 72,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/external/constructor/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo"
+                            "filename": "autogen/starknet/external/constructor/da17921a4e81c09e730800bbf23bfdbe5e9e6bfaedc59d80fbf62087fa43c27d.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 17,
                                 "end_line": 22,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "start_col": 6,
                                 "start_line": 22
@@ -3507,14 +3508,14 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 35,
+                        "end_col": 34,
                         "end_line": 32,
                         "input_file": {
-                            "filename": "contracts/counter.cairo"
+                            "filename": "counter.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 34,
+                                "end_col": 33,
                                 "end_line": 13,
                                 "input_file": {
                                     "filename": "autogen/starknet/storage_var/counter/decl.cairo"
@@ -3522,12 +3523,12 @@
                                 "parent_location": [
                                     {
                                         "end_col": 33,
-                                        "end_line": 35,
+                                        "end_line": 33,
                                         "input_file": {
-                                            "filename": "contracts/counter.cairo"
+                                            "filename": "counter.cairo"
                                         },
                                         "start_col": 19,
-                                        "start_line": 35
+                                        "start_line": 33
                                     },
                                     "While trying to retrieve the implicit argument 'syscall_ptr' in:"
                                 ],
@@ -3549,14 +3550,14 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 64,
+                        "end_col": 62,
                         "end_line": 32,
                         "input_file": {
-                            "filename": "contracts/counter.cairo"
+                            "filename": "counter.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 63,
+                                "end_col": 61,
                                 "end_line": 13,
                                 "input_file": {
                                     "filename": "autogen/starknet/storage_var/counter/decl.cairo"
@@ -3564,21 +3565,21 @@
                                 "parent_location": [
                                     {
                                         "end_col": 33,
-                                        "end_line": 35,
+                                        "end_line": 33,
                                         "input_file": {
-                                            "filename": "contracts/counter.cairo"
+                                            "filename": "counter.cairo"
                                         },
                                         "start_col": 19,
-                                        "start_line": 35
+                                        "start_line": 33
                                     },
                                     "While trying to retrieve the implicit argument 'pedersen_ptr' in:"
                                 ],
-                                "start_col": 36,
+                                "start_col": 35,
                                 "start_line": 13
                             },
                             "While expanding the reference 'pedersen_ptr' in:"
                         ],
-                        "start_col": 37,
+                        "start_col": 36,
                         "start_line": 32
                     }
                 },
@@ -3591,14 +3592,14 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 81,
+                        "end_col": 79,
                         "end_line": 32,
                         "input_file": {
-                            "filename": "contracts/counter.cairo"
+                            "filename": "counter.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 80,
+                                "end_col": 78,
                                 "end_line": 13,
                                 "input_file": {
                                     "filename": "autogen/starknet/storage_var/counter/decl.cairo"
@@ -3606,21 +3607,21 @@
                                 "parent_location": [
                                     {
                                         "end_col": 33,
-                                        "end_line": 35,
+                                        "end_line": 33,
                                         "input_file": {
-                                            "filename": "contracts/counter.cairo"
+                                            "filename": "counter.cairo"
                                         },
                                         "start_col": 19,
-                                        "start_line": 35
+                                        "start_line": 33
                                     },
                                     "While trying to retrieve the implicit argument 'range_check_ptr' in:"
                                 ],
-                                "start_col": 65,
+                                "start_col": 63,
                                 "start_line": 13
                             },
                             "While expanding the reference 'range_check_ptr' in:"
                         ],
-                        "start_col": 66,
+                        "start_col": 64,
                         "start_line": 32
                     }
                 },
@@ -3634,12 +3635,12 @@
                     "hints": [],
                     "inst": {
                         "end_col": 33,
-                        "end_line": 35,
+                        "end_line": 33,
                         "input_file": {
-                            "filename": "contracts/counter.cairo"
+                            "filename": "counter.cairo"
                         },
                         "start_col": 19,
-                        "start_line": 35
+                        "start_line": 33
                     }
                 },
                 "123": {
@@ -3651,13 +3652,13 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 19,
-                        "end_line": 37,
+                        "end_col": 21,
+                        "end_line": 35,
                         "input_file": {
-                            "filename": "contracts/counter.cairo"
+                            "filename": "counter.cairo"
                         },
                         "start_col": 5,
-                        "start_line": 37
+                        "start_line": 35
                     }
                 },
                 "124": {
@@ -3674,14 +3675,14 @@
                                 "end_col": 38,
                                 "end_line": 3,
                                 "input_file": {
-                                    "filename": "autogen/starknet/external/return/get_count/d04953fbc799b56c10331939a73220559ea6fa67ac77f91ebc8738661fcc1714.cairo"
+                                    "filename": "autogen/starknet/external/return/get_count/0dee33d431beaa58b6acb544e06ae5448a753bd6e5689babe5272d33099a603a.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 15,
                                         "end_line": 32,
                                         "input_file": {
-                                            "filename": "contracts/counter.cairo"
+                                            "filename": "counter.cairo"
                                         },
                                         "start_col": 6,
                                         "start_line": 32
@@ -3695,17 +3696,17 @@
                         }
                     ],
                     "inst": {
-                        "end_col": 17,
+                        "end_col": 18,
                         "end_line": 4,
                         "input_file": {
-                            "filename": "autogen/starknet/external/return/get_count/d04953fbc799b56c10331939a73220559ea6fa67ac77f91ebc8738661fcc1714.cairo"
+                            "filename": "autogen/starknet/external/return/get_count/0dee33d431beaa58b6acb544e06ae5448a753bd6e5689babe5272d33099a603a.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 15,
                                 "end_line": 32,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "start_col": 6,
                                 "start_line": 32
@@ -3726,20 +3727,20 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 46,
+                        "end_col": 47,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/arg_processor/0e9d4c974a6b6ace74b8b3274b87fad1f5800d4af46cff21a4b9883e1a1b0574.cairo"
+                            "filename": "autogen/starknet/arg_processor/95d2b1ea3726b72b3719bdfa0a12258ccf662f010c27f42865683ec83f32a1c9.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 17,
-                                "end_line": 33,
+                                "end_col": 98,
+                                "end_line": 32,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
-                                "start_col": 5,
-                                "start_line": 33
+                                "start_col": 87,
+                                "start_line": 32
                             },
                             "While handling return value 'count'"
                         ],
@@ -3760,28 +3761,28 @@
                         "end_col": 48,
                         "end_line": 2,
                         "input_file": {
-                            "filename": "autogen/starknet/arg_processor/0e9d4c974a6b6ace74b8b3274b87fad1f5800d4af46cff21a4b9883e1a1b0574.cairo"
+                            "filename": "autogen/starknet/arg_processor/95d2b1ea3726b72b3719bdfa0a12258ccf662f010c27f42865683ec83f32a1c9.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 17,
-                                "end_line": 33,
+                                "end_col": 98,
+                                "end_line": 32,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 36,
                                         "end_line": 11,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/return/get_count/d04953fbc799b56c10331939a73220559ea6fa67ac77f91ebc8738661fcc1714.cairo"
+                                            "filename": "autogen/starknet/external/return/get_count/0dee33d431beaa58b6acb544e06ae5448a753bd6e5689babe5272d33099a603a.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 15,
                                                 "end_line": 32,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "start_col": 6,
                                                 "start_line": 32
@@ -3793,8 +3794,8 @@
                                     },
                                     "While expanding the reference '__return_value_ptr' in:"
                                 ],
-                                "start_col": 5,
-                                "start_line": 33
+                                "start_col": 87,
+                                "start_line": 32
                             },
                             "While handling return value 'count'"
                         ],
@@ -3812,31 +3813,31 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 73,
+                        "end_col": 71,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/external/return/get_count/d04953fbc799b56c10331939a73220559ea6fa67ac77f91ebc8738661fcc1714.cairo"
+                            "filename": "autogen/starknet/external/return/get_count/0dee33d431beaa58b6acb544e06ae5448a753bd6e5689babe5272d33099a603a.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 15,
                                 "end_line": 32,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 40,
                                         "end_line": 10,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/return/get_count/d04953fbc799b56c10331939a73220559ea6fa67ac77f91ebc8738661fcc1714.cairo"
+                                            "filename": "autogen/starknet/external/return/get_count/0dee33d431beaa58b6acb544e06ae5448a753bd6e5689babe5272d33099a603a.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 15,
                                                 "end_line": 32,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "start_col": 6,
                                                 "start_line": 32
@@ -3853,7 +3854,7 @@
                             },
                             "While handling return value of"
                         ],
-                        "start_col": 58,
+                        "start_col": 56,
                         "start_line": 1
                     }
                 },
@@ -3870,14 +3871,14 @@
                         "end_col": 63,
                         "end_line": 11,
                         "input_file": {
-                            "filename": "autogen/starknet/external/return/get_count/d04953fbc799b56c10331939a73220559ea6fa67ac77f91ebc8738661fcc1714.cairo"
+                            "filename": "autogen/starknet/external/return/get_count/0dee33d431beaa58b6acb544e06ae5448a753bd6e5689babe5272d33099a603a.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 15,
                                 "end_line": 32,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "start_col": 6,
                                 "start_line": 32
@@ -3901,28 +3902,28 @@
                         "end_col": 35,
                         "end_line": 5,
                         "input_file": {
-                            "filename": "autogen/starknet/external/return/get_count/d04953fbc799b56c10331939a73220559ea6fa67ac77f91ebc8738661fcc1714.cairo"
+                            "filename": "autogen/starknet/external/return/get_count/0dee33d431beaa58b6acb544e06ae5448a753bd6e5689babe5272d33099a603a.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 15,
                                 "end_line": 32,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 38,
                                         "end_line": 12,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/return/get_count/d04953fbc799b56c10331939a73220559ea6fa67ac77f91ebc8738661fcc1714.cairo"
+                                            "filename": "autogen/starknet/external/return/get_count/0dee33d431beaa58b6acb544e06ae5448a753bd6e5689babe5272d33099a603a.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 15,
                                                 "end_line": 32,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "start_col": 6,
                                                 "start_line": 32
@@ -3953,17 +3954,17 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 39,
+                        "end_col": 40,
                         "end_line": 12,
                         "input_file": {
-                            "filename": "autogen/starknet/external/return/get_count/d04953fbc799b56c10331939a73220559ea6fa67ac77f91ebc8738661fcc1714.cairo"
+                            "filename": "autogen/starknet/external/return/get_count/0dee33d431beaa58b6acb544e06ae5448a753bd6e5689babe5272d33099a603a.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 15,
                                 "end_line": 32,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "start_col": 6,
                                 "start_line": 32
@@ -3984,17 +3985,17 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 57,
+                        "end_col": 58,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/arg_processor/1b562308a65653425ce06491fa4b4539466f3251a07e73e099d0afe86a48900e.cairo"
+                            "filename": "autogen/starknet/arg_processor/01cba52f8515996bb9d7070bde81ff39281d096d7024a558efcba6e1fd2402cf.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 15,
                                 "end_line": 32,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "start_col": 6,
                                 "start_line": 32
@@ -4018,28 +4019,28 @@
                         "end_col": 64,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/external/get_count/c7060df96cb0acca1380ae43bf758cab727bfdf73cb5d34a93e24a9742817fda.cairo"
+                            "filename": "autogen/starknet/external/get_count/b2c52ca2d2a8fc8791a983086d8716c5eacd0c3d62934914d2286f84b98ff4cb.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 35,
+                                "end_col": 34,
                                 "end_line": 32,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 55,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/get_count/f8bf6f462c384fec4c4809e698679b696d8dda6a3d3aa885d7e695c195989fd2.cairo"
+                                            "filename": "autogen/starknet/external/get_count/b131978ca8e46a216e567d72366739bfc84c613d862a1e9402fc3d44c35d2bca.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 15,
                                                 "end_line": 32,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "start_col": 6,
                                                 "start_line": 32
@@ -4073,28 +4074,28 @@
                         "end_col": 110,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/external/get_count/424b26e79f70343cc02557f1fbd25745138efb26a3dc5c8b593ca765b73138b7.cairo"
+                            "filename": "autogen/starknet/external/get_count/9684a85e93c782014ca14293edea4eb2502039a5a7b6538ecd39c56faaf12529.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 64,
+                                "end_col": 62,
                                 "end_line": 32,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 82,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/get_count/f8bf6f462c384fec4c4809e698679b696d8dda6a3d3aa885d7e695c195989fd2.cairo"
+                                            "filename": "autogen/starknet/external/get_count/b131978ca8e46a216e567d72366739bfc84c613d862a1e9402fc3d44c35d2bca.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 15,
                                                 "end_line": 32,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "start_col": 6,
                                                 "start_line": 32
@@ -4106,7 +4107,7 @@
                                     },
                                     "While expanding the reference 'pedersen_ptr' in:"
                                 ],
-                                "start_col": 37,
+                                "start_col": 36,
                                 "start_line": 32
                             },
                             "While constructing the external wrapper for:"
@@ -4128,28 +4129,28 @@
                         "end_col": 67,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/external/get_count/e651458745e7cd218121c342e0915890767e2f59ddc2e315b8844ad0f47d582e.cairo"
+                            "filename": "autogen/starknet/external/get_count/741ea357d6336b0bed7bf0472425acd0311d543883b803388880e60a232040c7.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 81,
+                                "end_col": 79,
                                 "end_line": 32,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 115,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/get_count/f8bf6f462c384fec4c4809e698679b696d8dda6a3d3aa885d7e695c195989fd2.cairo"
+                                            "filename": "autogen/starknet/external/get_count/b131978ca8e46a216e567d72366739bfc84c613d862a1e9402fc3d44c35d2bca.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 15,
                                                 "end_line": 32,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "start_col": 6,
                                                 "start_line": 32
@@ -4161,7 +4162,7 @@
                                     },
                                     "While expanding the reference 'range_check_ptr' in:"
                                 ],
-                                "start_col": 66,
+                                "start_col": 64,
                                 "start_line": 32
                             },
                             "While constructing the external wrapper for:"
@@ -4183,7 +4184,7 @@
                         "end_col": 15,
                         "end_line": 32,
                         "input_file": {
-                            "filename": "contracts/counter.cairo"
+                            "filename": "counter.cairo"
                         },
                         "start_col": 6,
                         "start_line": 32
@@ -4202,28 +4203,28 @@
                         "end_col": 115,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/external/get_count/f8bf6f462c384fec4c4809e698679b696d8dda6a3d3aa885d7e695c195989fd2.cairo"
+                            "filename": "autogen/starknet/external/get_count/b131978ca8e46a216e567d72366739bfc84c613d862a1e9402fc3d44c35d2bca.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 15,
                                 "end_line": 32,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 98,
                                         "end_line": 2,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/get_count/f8bf6f462c384fec4c4809e698679b696d8dda6a3d3aa885d7e695c195989fd2.cairo"
+                                            "filename": "autogen/starknet/external/get_count/b131978ca8e46a216e567d72366739bfc84c613d862a1e9402fc3d44c35d2bca.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 15,
                                                 "end_line": 32,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "start_col": 6,
                                                 "start_line": 32
@@ -4257,14 +4258,14 @@
                         "end_col": 99,
                         "end_line": 2,
                         "input_file": {
-                            "filename": "autogen/starknet/external/get_count/f8bf6f462c384fec4c4809e698679b696d8dda6a3d3aa885d7e695c195989fd2.cairo"
+                            "filename": "autogen/starknet/external/get_count/b131978ca8e46a216e567d72366739bfc84c613d862a1e9402fc3d44c35d2bca.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 15,
                                 "end_line": 32,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "start_col": 6,
                                 "start_line": 32
@@ -4288,28 +4289,28 @@
                         "end_col": 55,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/external/get_count/f8bf6f462c384fec4c4809e698679b696d8dda6a3d3aa885d7e695c195989fd2.cairo"
+                            "filename": "autogen/starknet/external/get_count/b131978ca8e46a216e567d72366739bfc84c613d862a1e9402fc3d44c35d2bca.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 15,
                                 "end_line": 32,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 20,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/get_count/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo"
+                                            "filename": "autogen/starknet/external/get_count/da17921a4e81c09e730800bbf23bfdbe5e9e6bfaedc59d80fbf62087fa43c27d.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 15,
                                                 "end_line": 32,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "start_col": 6,
                                                 "start_line": 32
@@ -4343,28 +4344,28 @@
                         "end_col": 82,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/external/get_count/f8bf6f462c384fec4c4809e698679b696d8dda6a3d3aa885d7e695c195989fd2.cairo"
+                            "filename": "autogen/starknet/external/get_count/b131978ca8e46a216e567d72366739bfc84c613d862a1e9402fc3d44c35d2bca.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 15,
                                 "end_line": 32,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 33,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/get_count/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo"
+                                            "filename": "autogen/starknet/external/get_count/da17921a4e81c09e730800bbf23bfdbe5e9e6bfaedc59d80fbf62087fa43c27d.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 15,
                                                 "end_line": 32,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "start_col": 6,
                                                 "start_line": 32
@@ -4398,28 +4399,28 @@
                         "end_col": 21,
                         "end_line": 2,
                         "input_file": {
-                            "filename": "autogen/starknet/external/get_count/f8bf6f462c384fec4c4809e698679b696d8dda6a3d3aa885d7e695c195989fd2.cairo"
+                            "filename": "autogen/starknet/external/get_count/b131978ca8e46a216e567d72366739bfc84c613d862a1e9402fc3d44c35d2bca.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 15,
                                 "end_line": 32,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 49,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/get_count/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo"
+                                            "filename": "autogen/starknet/external/get_count/da17921a4e81c09e730800bbf23bfdbe5e9e6bfaedc59d80fbf62087fa43c27d.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 15,
                                                 "end_line": 32,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "start_col": 6,
                                                 "start_line": 32
@@ -4453,28 +4454,28 @@
                         "end_col": 35,
                         "end_line": 2,
                         "input_file": {
-                            "filename": "autogen/starknet/external/get_count/f8bf6f462c384fec4c4809e698679b696d8dda6a3d3aa885d7e695c195989fd2.cairo"
+                            "filename": "autogen/starknet/external/get_count/b131978ca8e46a216e567d72366739bfc84c613d862a1e9402fc3d44c35d2bca.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 15,
                                 "end_line": 32,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 62,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/get_count/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo"
+                                            "filename": "autogen/starknet/external/get_count/da17921a4e81c09e730800bbf23bfdbe5e9e6bfaedc59d80fbf62087fa43c27d.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 15,
                                                 "end_line": 32,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "start_col": 6,
                                                 "start_line": 32
@@ -4508,28 +4509,28 @@
                         "end_col": 44,
                         "end_line": 2,
                         "input_file": {
-                            "filename": "autogen/starknet/external/get_count/f8bf6f462c384fec4c4809e698679b696d8dda6a3d3aa885d7e695c195989fd2.cairo"
+                            "filename": "autogen/starknet/external/get_count/b131978ca8e46a216e567d72366739bfc84c613d862a1e9402fc3d44c35d2bca.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 15,
                                 "end_line": 32,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 70,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/get_count/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo"
+                                            "filename": "autogen/starknet/external/get_count/da17921a4e81c09e730800bbf23bfdbe5e9e6bfaedc59d80fbf62087fa43c27d.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 15,
                                                 "end_line": 32,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "start_col": 6,
                                                 "start_line": 32
@@ -4560,17 +4561,17 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 71,
+                        "end_col": 72,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/external/get_count/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo"
+                            "filename": "autogen/starknet/external/get_count/da17921a4e81c09e730800bbf23bfdbe5e9e6bfaedc59d80fbf62087fa43c27d.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 15,
                                 "end_line": 32,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "start_col": 6,
                                 "start_line": 32
@@ -4590,14 +4591,14 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 34,
-                        "end_line": 41,
+                        "end_col": 33,
+                        "end_line": 39,
                         "input_file": {
-                            "filename": "contracts/counter.cairo"
+                            "filename": "counter.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 34,
+                                "end_col": 33,
                                 "end_line": 13,
                                 "input_file": {
                                     "filename": "autogen/starknet/storage_var/rand/decl.cairo"
@@ -4605,12 +4606,12 @@
                                 "parent_location": [
                                     {
                                         "end_col": 28,
-                                        "end_line": 42,
+                                        "end_line": 40,
                                         "input_file": {
-                                            "filename": "contracts/counter.cairo"
+                                            "filename": "counter.cairo"
                                         },
                                         "start_col": 17,
-                                        "start_line": 42
+                                        "start_line": 40
                                     },
                                     "While trying to retrieve the implicit argument 'syscall_ptr' in:"
                                 ],
@@ -4620,7 +4621,7 @@
                             "While expanding the reference 'syscall_ptr' in:"
                         ],
                         "start_col": 15,
-                        "start_line": 41
+                        "start_line": 39
                     }
                 },
                 "149": {
@@ -4632,14 +4633,14 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 63,
-                        "end_line": 41,
+                        "end_col": 61,
+                        "end_line": 39,
                         "input_file": {
-                            "filename": "contracts/counter.cairo"
+                            "filename": "counter.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 63,
+                                "end_col": 61,
                                 "end_line": 13,
                                 "input_file": {
                                     "filename": "autogen/starknet/storage_var/rand/decl.cairo"
@@ -4647,22 +4648,22 @@
                                 "parent_location": [
                                     {
                                         "end_col": 28,
-                                        "end_line": 42,
+                                        "end_line": 40,
                                         "input_file": {
-                                            "filename": "contracts/counter.cairo"
+                                            "filename": "counter.cairo"
                                         },
                                         "start_col": 17,
-                                        "start_line": 42
+                                        "start_line": 40
                                     },
                                     "While trying to retrieve the implicit argument 'pedersen_ptr' in:"
                                 ],
-                                "start_col": 36,
+                                "start_col": 35,
                                 "start_line": 13
                             },
                             "While expanding the reference 'pedersen_ptr' in:"
                         ],
-                        "start_col": 36,
-                        "start_line": 41
+                        "start_col": 35,
+                        "start_line": 39
                     }
                 },
                 "150": {
@@ -4674,14 +4675,14 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 80,
-                        "end_line": 41,
+                        "end_col": 78,
+                        "end_line": 39,
                         "input_file": {
-                            "filename": "contracts/counter.cairo"
+                            "filename": "counter.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 80,
+                                "end_col": 78,
                                 "end_line": 13,
                                 "input_file": {
                                     "filename": "autogen/starknet/storage_var/rand/decl.cairo"
@@ -4689,22 +4690,22 @@
                                 "parent_location": [
                                     {
                                         "end_col": 28,
-                                        "end_line": 42,
+                                        "end_line": 40,
                                         "input_file": {
-                                            "filename": "contracts/counter.cairo"
+                                            "filename": "counter.cairo"
                                         },
                                         "start_col": 17,
-                                        "start_line": 42
+                                        "start_line": 40
                                     },
                                     "While trying to retrieve the implicit argument 'range_check_ptr' in:"
                                 ],
-                                "start_col": 65,
+                                "start_col": 63,
                                 "start_line": 13
                             },
                             "While expanding the reference 'range_check_ptr' in:"
                         ],
-                        "start_col": 65,
-                        "start_line": 41
+                        "start_col": 63,
+                        "start_line": 39
                     }
                 },
                 "151": {
@@ -4717,12 +4718,12 @@
                     "hints": [],
                     "inst": {
                         "end_col": 28,
-                        "end_line": 42,
+                        "end_line": 40,
                         "input_file": {
-                            "filename": "contracts/counter.cairo"
+                            "filename": "counter.cairo"
                         },
                         "start_col": 17,
-                        "start_line": 42
+                        "start_line": 40
                     }
                 },
                 "153": {
@@ -4734,13 +4735,13 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 17,
-                        "end_line": 44,
+                        "end_col": 19,
+                        "end_line": 42,
                         "input_file": {
-                            "filename": "contracts/counter.cairo"
+                            "filename": "counter.cairo"
                         },
                         "start_col": 5,
-                        "start_line": 44
+                        "start_line": 42
                     }
                 },
                 "154": {
@@ -4757,17 +4758,17 @@
                                 "end_col": 38,
                                 "end_line": 3,
                                 "input_file": {
-                                    "filename": "autogen/starknet/external/return/get_rand/fe4c96e3c91b4c042788f080214cea51dee669de3a1544eba01eaa4b1d50b306.cairo"
+                                    "filename": "autogen/starknet/external/return/get_rand/21a83e9e2fd6a4d753f761e0f6160a23b0425d966b5a06c1ae424b0b23c78080.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 14,
-                                        "end_line": 41,
+                                        "end_line": 39,
                                         "input_file": {
-                                            "filename": "contracts/counter.cairo"
+                                            "filename": "counter.cairo"
                                         },
                                         "start_col": 6,
-                                        "start_line": 41
+                                        "start_line": 39
                                     },
                                     "While handling return value of"
                                 ],
@@ -4778,20 +4779,20 @@
                         }
                     ],
                     "inst": {
-                        "end_col": 17,
+                        "end_col": 18,
                         "end_line": 4,
                         "input_file": {
-                            "filename": "autogen/starknet/external/return/get_rand/fe4c96e3c91b4c042788f080214cea51dee669de3a1544eba01eaa4b1d50b306.cairo"
+                            "filename": "autogen/starknet/external/return/get_rand/21a83e9e2fd6a4d753f761e0f6160a23b0425d966b5a06c1ae424b0b23c78080.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 14,
-                                "end_line": 41,
+                                "end_line": 39,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "start_col": 6,
-                                "start_line": 41
+                                "start_line": 39
                             },
                             "While handling return value of"
                         ],
@@ -4809,20 +4810,20 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 44,
+                        "end_col": 45,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/arg_processor/c11cfe8d534f163fffd92734efaf54f4ba09cfa5ec207c5020b2eed1ea236bf6.cairo"
+                            "filename": "autogen/starknet/arg_processor/87e45bfb98a0b53cc8f39ca993ad93db78b27dfeea193b24103c59c688f906ca.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 98,
-                                "end_line": 41,
+                                "end_col": 95,
+                                "end_line": 39,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
-                                "start_col": 88,
-                                "start_line": 41
+                                "start_col": 86,
+                                "start_line": 39
                             },
                             "While handling return value 'val'"
                         ],
@@ -4843,31 +4844,31 @@
                         "end_col": 48,
                         "end_line": 2,
                         "input_file": {
-                            "filename": "autogen/starknet/arg_processor/c11cfe8d534f163fffd92734efaf54f4ba09cfa5ec207c5020b2eed1ea236bf6.cairo"
+                            "filename": "autogen/starknet/arg_processor/87e45bfb98a0b53cc8f39ca993ad93db78b27dfeea193b24103c59c688f906ca.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 98,
-                                "end_line": 41,
+                                "end_col": 95,
+                                "end_line": 39,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 36,
                                         "end_line": 11,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/return/get_rand/fe4c96e3c91b4c042788f080214cea51dee669de3a1544eba01eaa4b1d50b306.cairo"
+                                            "filename": "autogen/starknet/external/return/get_rand/21a83e9e2fd6a4d753f761e0f6160a23b0425d966b5a06c1ae424b0b23c78080.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 14,
-                                                "end_line": 41,
+                                                "end_line": 39,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 41
+                                                "start_line": 39
                                             },
                                             "While handling return value of"
                                         ],
@@ -4876,8 +4877,8 @@
                                     },
                                     "While expanding the reference '__return_value_ptr' in:"
                                 ],
-                                "start_col": 88,
-                                "start_line": 41
+                                "start_col": 86,
+                                "start_line": 39
                             },
                             "While handling return value 'val'"
                         ],
@@ -4895,34 +4896,34 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 70,
+                        "end_col": 68,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/external/return/get_rand/fe4c96e3c91b4c042788f080214cea51dee669de3a1544eba01eaa4b1d50b306.cairo"
+                            "filename": "autogen/starknet/external/return/get_rand/21a83e9e2fd6a4d753f761e0f6160a23b0425d966b5a06c1ae424b0b23c78080.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 14,
-                                "end_line": 41,
+                                "end_line": 39,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 40,
                                         "end_line": 10,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/return/get_rand/fe4c96e3c91b4c042788f080214cea51dee669de3a1544eba01eaa4b1d50b306.cairo"
+                                            "filename": "autogen/starknet/external/return/get_rand/21a83e9e2fd6a4d753f761e0f6160a23b0425d966b5a06c1ae424b0b23c78080.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 14,
-                                                "end_line": 41,
+                                                "end_line": 39,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 41
+                                                "start_line": 39
                                             },
                                             "While handling return value of"
                                         ],
@@ -4932,11 +4933,11 @@
                                     "While expanding the reference 'range_check_ptr' in:"
                                 ],
                                 "start_col": 6,
-                                "start_line": 41
+                                "start_line": 39
                             },
                             "While handling return value of"
                         ],
-                        "start_col": 55,
+                        "start_col": 53,
                         "start_line": 1
                     }
                 },
@@ -4953,17 +4954,17 @@
                         "end_col": 63,
                         "end_line": 11,
                         "input_file": {
-                            "filename": "autogen/starknet/external/return/get_rand/fe4c96e3c91b4c042788f080214cea51dee669de3a1544eba01eaa4b1d50b306.cairo"
+                            "filename": "autogen/starknet/external/return/get_rand/21a83e9e2fd6a4d753f761e0f6160a23b0425d966b5a06c1ae424b0b23c78080.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 14,
-                                "end_line": 41,
+                                "end_line": 39,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "start_col": 6,
-                                "start_line": 41
+                                "start_line": 39
                             },
                             "While handling return value of"
                         ],
@@ -4984,31 +4985,31 @@
                         "end_col": 35,
                         "end_line": 5,
                         "input_file": {
-                            "filename": "autogen/starknet/external/return/get_rand/fe4c96e3c91b4c042788f080214cea51dee669de3a1544eba01eaa4b1d50b306.cairo"
+                            "filename": "autogen/starknet/external/return/get_rand/21a83e9e2fd6a4d753f761e0f6160a23b0425d966b5a06c1ae424b0b23c78080.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 14,
-                                "end_line": 41,
+                                "end_line": 39,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 38,
                                         "end_line": 12,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/return/get_rand/fe4c96e3c91b4c042788f080214cea51dee669de3a1544eba01eaa4b1d50b306.cairo"
+                                            "filename": "autogen/starknet/external/return/get_rand/21a83e9e2fd6a4d753f761e0f6160a23b0425d966b5a06c1ae424b0b23c78080.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 14,
-                                                "end_line": 41,
+                                                "end_line": 39,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 41
+                                                "start_line": 39
                                             },
                                             "While handling return value of"
                                         ],
@@ -5018,7 +5019,7 @@
                                     "While expanding the reference '__return_value_ptr_start' in:"
                                 ],
                                 "start_col": 6,
-                                "start_line": 41
+                                "start_line": 39
                             },
                             "While handling return value of"
                         ],
@@ -5036,20 +5037,20 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 39,
+                        "end_col": 40,
                         "end_line": 12,
                         "input_file": {
-                            "filename": "autogen/starknet/external/return/get_rand/fe4c96e3c91b4c042788f080214cea51dee669de3a1544eba01eaa4b1d50b306.cairo"
+                            "filename": "autogen/starknet/external/return/get_rand/21a83e9e2fd6a4d753f761e0f6160a23b0425d966b5a06c1ae424b0b23c78080.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 14,
-                                "end_line": 41,
+                                "end_line": 39,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "start_col": 6,
-                                "start_line": 41
+                                "start_line": 39
                             },
                             "While handling return value of"
                         ],
@@ -5067,20 +5068,20 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 57,
+                        "end_col": 58,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/arg_processor/1b562308a65653425ce06491fa4b4539466f3251a07e73e099d0afe86a48900e.cairo"
+                            "filename": "autogen/starknet/arg_processor/01cba52f8515996bb9d7070bde81ff39281d096d7024a558efcba6e1fd2402cf.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 14,
-                                "end_line": 41,
+                                "end_line": 39,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "start_col": 6,
-                                "start_line": 41
+                                "start_line": 39
                             },
                             "While handling calldata of"
                         ],
@@ -5101,31 +5102,31 @@
                         "end_col": 64,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/external/get_rand/c7060df96cb0acca1380ae43bf758cab727bfdf73cb5d34a93e24a9742817fda.cairo"
+                            "filename": "autogen/starknet/external/get_rand/b2c52ca2d2a8fc8791a983086d8716c5eacd0c3d62934914d2286f84b98ff4cb.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 34,
-                                "end_line": 41,
+                                "end_col": 33,
+                                "end_line": 39,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 55,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/get_rand/d48875e526340a1dcff06e3bc494c0ada98a469fc60e878ec3084da28e6dc8ba.cairo"
+                                            "filename": "autogen/starknet/external/get_rand/42bcd195580c73d7feb0ccb9abef0cf140ab57a3bc9557224ec11bf744e576da.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 14,
-                                                "end_line": 41,
+                                                "end_line": 39,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 41
+                                                "start_line": 39
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -5135,7 +5136,7 @@
                                     "While expanding the reference 'syscall_ptr' in:"
                                 ],
                                 "start_col": 15,
-                                "start_line": 41
+                                "start_line": 39
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -5156,31 +5157,31 @@
                         "end_col": 110,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/external/get_rand/424b26e79f70343cc02557f1fbd25745138efb26a3dc5c8b593ca765b73138b7.cairo"
+                            "filename": "autogen/starknet/external/get_rand/9684a85e93c782014ca14293edea4eb2502039a5a7b6538ecd39c56faaf12529.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 63,
-                                "end_line": 41,
+                                "end_col": 61,
+                                "end_line": 39,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 82,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/get_rand/d48875e526340a1dcff06e3bc494c0ada98a469fc60e878ec3084da28e6dc8ba.cairo"
+                                            "filename": "autogen/starknet/external/get_rand/42bcd195580c73d7feb0ccb9abef0cf140ab57a3bc9557224ec11bf744e576da.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 14,
-                                                "end_line": 41,
+                                                "end_line": 39,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 41
+                                                "start_line": 39
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -5189,8 +5190,8 @@
                                     },
                                     "While expanding the reference 'pedersen_ptr' in:"
                                 ],
-                                "start_col": 36,
-                                "start_line": 41
+                                "start_col": 35,
+                                "start_line": 39
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -5211,31 +5212,31 @@
                         "end_col": 67,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/external/get_rand/e651458745e7cd218121c342e0915890767e2f59ddc2e315b8844ad0f47d582e.cairo"
+                            "filename": "autogen/starknet/external/get_rand/741ea357d6336b0bed7bf0472425acd0311d543883b803388880e60a232040c7.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 80,
-                                "end_line": 41,
+                                "end_col": 78,
+                                "end_line": 39,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 115,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/get_rand/d48875e526340a1dcff06e3bc494c0ada98a469fc60e878ec3084da28e6dc8ba.cairo"
+                                            "filename": "autogen/starknet/external/get_rand/42bcd195580c73d7feb0ccb9abef0cf140ab57a3bc9557224ec11bf744e576da.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 14,
-                                                "end_line": 41,
+                                                "end_line": 39,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 41
+                                                "start_line": 39
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -5244,8 +5245,8 @@
                                     },
                                     "While expanding the reference 'range_check_ptr' in:"
                                 ],
-                                "start_col": 65,
-                                "start_line": 41
+                                "start_col": 63,
+                                "start_line": 39
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -5264,12 +5265,12 @@
                     "hints": [],
                     "inst": {
                         "end_col": 14,
-                        "end_line": 41,
+                        "end_line": 39,
                         "input_file": {
-                            "filename": "contracts/counter.cairo"
+                            "filename": "counter.cairo"
                         },
                         "start_col": 6,
-                        "start_line": 41
+                        "start_line": 39
                     }
                 },
                 "169": {
@@ -5285,31 +5286,31 @@
                         "end_col": 115,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/external/get_rand/d48875e526340a1dcff06e3bc494c0ada98a469fc60e878ec3084da28e6dc8ba.cairo"
+                            "filename": "autogen/starknet/external/get_rand/42bcd195580c73d7feb0ccb9abef0cf140ab57a3bc9557224ec11bf744e576da.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 14,
-                                "end_line": 41,
+                                "end_line": 39,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 97,
                                         "end_line": 2,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/get_rand/d48875e526340a1dcff06e3bc494c0ada98a469fc60e878ec3084da28e6dc8ba.cairo"
+                                            "filename": "autogen/starknet/external/get_rand/42bcd195580c73d7feb0ccb9abef0cf140ab57a3bc9557224ec11bf744e576da.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 14,
-                                                "end_line": 41,
+                                                "end_line": 39,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 41
+                                                "start_line": 39
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -5319,7 +5320,7 @@
                                     "While expanding the reference 'range_check_ptr' in:"
                                 ],
                                 "start_col": 6,
-                                "start_line": 41
+                                "start_line": 39
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -5340,17 +5341,17 @@
                         "end_col": 98,
                         "end_line": 2,
                         "input_file": {
-                            "filename": "autogen/starknet/external/get_rand/d48875e526340a1dcff06e3bc494c0ada98a469fc60e878ec3084da28e6dc8ba.cairo"
+                            "filename": "autogen/starknet/external/get_rand/42bcd195580c73d7feb0ccb9abef0cf140ab57a3bc9557224ec11bf744e576da.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 14,
-                                "end_line": 41,
+                                "end_line": 39,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "start_col": 6,
-                                "start_line": 41
+                                "start_line": 39
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -5371,31 +5372,31 @@
                         "end_col": 55,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/external/get_rand/d48875e526340a1dcff06e3bc494c0ada98a469fc60e878ec3084da28e6dc8ba.cairo"
+                            "filename": "autogen/starknet/external/get_rand/42bcd195580c73d7feb0ccb9abef0cf140ab57a3bc9557224ec11bf744e576da.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 14,
-                                "end_line": 41,
+                                "end_line": 39,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 20,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/get_rand/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo"
+                                            "filename": "autogen/starknet/external/get_rand/da17921a4e81c09e730800bbf23bfdbe5e9e6bfaedc59d80fbf62087fa43c27d.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 14,
-                                                "end_line": 41,
+                                                "end_line": 39,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 41
+                                                "start_line": 39
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -5405,7 +5406,7 @@
                                     "While expanding the reference 'syscall_ptr' in:"
                                 ],
                                 "start_col": 6,
-                                "start_line": 41
+                                "start_line": 39
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -5426,31 +5427,31 @@
                         "end_col": 82,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/external/get_rand/d48875e526340a1dcff06e3bc494c0ada98a469fc60e878ec3084da28e6dc8ba.cairo"
+                            "filename": "autogen/starknet/external/get_rand/42bcd195580c73d7feb0ccb9abef0cf140ab57a3bc9557224ec11bf744e576da.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 14,
-                                "end_line": 41,
+                                "end_line": 39,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 33,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/get_rand/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo"
+                                            "filename": "autogen/starknet/external/get_rand/da17921a4e81c09e730800bbf23bfdbe5e9e6bfaedc59d80fbf62087fa43c27d.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 14,
-                                                "end_line": 41,
+                                                "end_line": 39,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 41
+                                                "start_line": 39
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -5460,7 +5461,7 @@
                                     "While expanding the reference 'pedersen_ptr' in:"
                                 ],
                                 "start_col": 6,
-                                "start_line": 41
+                                "start_line": 39
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -5481,31 +5482,31 @@
                         "end_col": 21,
                         "end_line": 2,
                         "input_file": {
-                            "filename": "autogen/starknet/external/get_rand/d48875e526340a1dcff06e3bc494c0ada98a469fc60e878ec3084da28e6dc8ba.cairo"
+                            "filename": "autogen/starknet/external/get_rand/42bcd195580c73d7feb0ccb9abef0cf140ab57a3bc9557224ec11bf744e576da.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 14,
-                                "end_line": 41,
+                                "end_line": 39,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 49,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/get_rand/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo"
+                                            "filename": "autogen/starknet/external/get_rand/da17921a4e81c09e730800bbf23bfdbe5e9e6bfaedc59d80fbf62087fa43c27d.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 14,
-                                                "end_line": 41,
+                                                "end_line": 39,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 41
+                                                "start_line": 39
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -5515,7 +5516,7 @@
                                     "While expanding the reference 'range_check_ptr' in:"
                                 ],
                                 "start_col": 6,
-                                "start_line": 41
+                                "start_line": 39
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -5536,31 +5537,31 @@
                         "end_col": 35,
                         "end_line": 2,
                         "input_file": {
-                            "filename": "autogen/starknet/external/get_rand/d48875e526340a1dcff06e3bc494c0ada98a469fc60e878ec3084da28e6dc8ba.cairo"
+                            "filename": "autogen/starknet/external/get_rand/42bcd195580c73d7feb0ccb9abef0cf140ab57a3bc9557224ec11bf744e576da.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 14,
-                                "end_line": 41,
+                                "end_line": 39,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 62,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/get_rand/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo"
+                                            "filename": "autogen/starknet/external/get_rand/da17921a4e81c09e730800bbf23bfdbe5e9e6bfaedc59d80fbf62087fa43c27d.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 14,
-                                                "end_line": 41,
+                                                "end_line": 39,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 41
+                                                "start_line": 39
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -5570,7 +5571,7 @@
                                     "While expanding the reference 'retdata_size' in:"
                                 ],
                                 "start_col": 6,
-                                "start_line": 41
+                                "start_line": 39
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -5591,31 +5592,31 @@
                         "end_col": 44,
                         "end_line": 2,
                         "input_file": {
-                            "filename": "autogen/starknet/external/get_rand/d48875e526340a1dcff06e3bc494c0ada98a469fc60e878ec3084da28e6dc8ba.cairo"
+                            "filename": "autogen/starknet/external/get_rand/42bcd195580c73d7feb0ccb9abef0cf140ab57a3bc9557224ec11bf744e576da.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 14,
-                                "end_line": 41,
+                                "end_line": 39,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 70,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/get_rand/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo"
+                                            "filename": "autogen/starknet/external/get_rand/da17921a4e81c09e730800bbf23bfdbe5e9e6bfaedc59d80fbf62087fa43c27d.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 14,
-                                                "end_line": 41,
+                                                "end_line": 39,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 41
+                                                "start_line": 39
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -5625,7 +5626,7 @@
                                     "While expanding the reference 'retdata' in:"
                                 ],
                                 "start_col": 6,
-                                "start_line": 41
+                                "start_line": 39
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -5643,20 +5644,20 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 71,
+                        "end_col": 72,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/external/get_rand/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo"
+                            "filename": "autogen/starknet/external/get_rand/da17921a4e81c09e730800bbf23bfdbe5e9e6bfaedc59d80fbf62087fa43c27d.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 14,
-                                "end_line": 41,
+                                "end_line": 39,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "start_col": 6,
-                                "start_line": 41
+                                "start_line": 39
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -5673,14 +5674,14 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 34,
-                        "end_line": 51,
+                        "end_col": 33,
+                        "end_line": 49,
                         "input_file": {
-                            "filename": "contracts/counter.cairo"
+                            "filename": "counter.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 35,
+                                "end_col": 34,
                                 "end_line": 19,
                                 "input_file": {
                                     "filename": "autogen/starknet/storage_var/rand/decl.cairo"
@@ -5688,12 +5689,12 @@
                                 "parent_location": [
                                     {
                                         "end_col": 20,
-                                        "end_line": 52,
+                                        "end_line": 50,
                                         "input_file": {
-                                            "filename": "contracts/counter.cairo"
+                                            "filename": "counter.cairo"
                                         },
                                         "start_col": 5,
-                                        "start_line": 52
+                                        "start_line": 50
                                     },
                                     "While trying to retrieve the implicit argument 'syscall_ptr' in:"
                                 ],
@@ -5703,7 +5704,7 @@
                             "While expanding the reference 'syscall_ptr' in:"
                         ],
                         "start_col": 15,
-                        "start_line": 51
+                        "start_line": 49
                     }
                 },
                 "179": {
@@ -5715,14 +5716,14 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 63,
-                        "end_line": 51,
+                        "end_col": 61,
+                        "end_line": 49,
                         "input_file": {
-                            "filename": "contracts/counter.cairo"
+                            "filename": "counter.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 64,
+                                "end_col": 62,
                                 "end_line": 19,
                                 "input_file": {
                                     "filename": "autogen/starknet/storage_var/rand/decl.cairo"
@@ -5730,22 +5731,22 @@
                                 "parent_location": [
                                     {
                                         "end_col": 20,
-                                        "end_line": 52,
+                                        "end_line": 50,
                                         "input_file": {
-                                            "filename": "contracts/counter.cairo"
+                                            "filename": "counter.cairo"
                                         },
                                         "start_col": 5,
-                                        "start_line": 52
+                                        "start_line": 50
                                     },
                                     "While trying to retrieve the implicit argument 'pedersen_ptr' in:"
                                 ],
-                                "start_col": 37,
+                                "start_col": 36,
                                 "start_line": 19
                             },
                             "While expanding the reference 'pedersen_ptr' in:"
                         ],
-                        "start_col": 36,
-                        "start_line": 51
+                        "start_col": 35,
+                        "start_line": 49
                     }
                 },
                 "180": {
@@ -5757,14 +5758,14 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 80,
-                        "end_line": 51,
+                        "end_col": 78,
+                        "end_line": 49,
                         "input_file": {
-                            "filename": "contracts/counter.cairo"
+                            "filename": "counter.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 81,
+                                "end_col": 79,
                                 "end_line": 19,
                                 "input_file": {
                                     "filename": "autogen/starknet/storage_var/rand/decl.cairo"
@@ -5772,22 +5773,22 @@
                                 "parent_location": [
                                     {
                                         "end_col": 20,
-                                        "end_line": 52,
+                                        "end_line": 50,
                                         "input_file": {
-                                            "filename": "contracts/counter.cairo"
+                                            "filename": "counter.cairo"
                                         },
                                         "start_col": 5,
-                                        "start_line": 52
+                                        "start_line": 50
                                     },
                                     "While trying to retrieve the implicit argument 'range_check_ptr' in:"
                                 ],
-                                "start_col": 66,
+                                "start_col": 64,
                                 "start_line": 19
                             },
                             "While expanding the reference 'range_check_ptr' in:"
                         ],
-                        "start_col": 65,
-                        "start_line": 51
+                        "start_col": 63,
+                        "start_line": 49
                     }
                 },
                 "181": {
@@ -5799,25 +5800,25 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 92,
-                        "end_line": 51,
+                        "end_col": 89,
+                        "end_line": 49,
                         "input_file": {
-                            "filename": "contracts/counter.cairo"
+                            "filename": "counter.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 19,
-                                "end_line": 52,
+                                "end_line": 50,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "start_col": 16,
-                                "start_line": 52
+                                "start_line": 50
                             },
                             "While expanding the reference 'val' in:"
                         ],
-                        "start_col": 82,
-                        "start_line": 51
+                        "start_col": 80,
+                        "start_line": 49
                     }
                 },
                 "182": {
@@ -5830,12 +5831,12 @@
                     "hints": [],
                     "inst": {
                         "end_col": 20,
-                        "end_line": 52,
+                        "end_line": 50,
                         "input_file": {
-                            "filename": "contracts/counter.cairo"
+                            "filename": "counter.cairo"
                         },
                         "start_col": 5,
-                        "start_line": 52
+                        "start_line": 50
                     }
                 },
                 "184": {
@@ -5847,13 +5848,13 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 14,
-                        "end_line": 54,
+                        "end_col": 15,
+                        "end_line": 52,
                         "input_file": {
-                            "filename": "contracts/counter.cairo"
+                            "filename": "counter.cairo"
                         },
                         "start_col": 5,
-                        "start_line": 54
+                        "start_line": 52
                     }
                 },
                 "185": {
@@ -5869,45 +5870,45 @@
                         "end_col": 40,
                         "end_line": 2,
                         "input_file": {
-                            "filename": "autogen/starknet/arg_processor/a9266930b90536cd6d9acab036ca1b6f8ca9fd5be109686bde4c26dae53e3682.cairo"
+                            "filename": "autogen/starknet/arg_processor/00d32612ffd1b363842f1be7cd60cb81327d9483302b0da5c523e670bfa81692.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 92,
-                                "end_line": 51,
+                                "end_col": 89,
+                                "end_line": 49,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 45,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/arg_processor/5e1cc73f0b484f90bb02da164d88332b40c6f698801aa4d3c603dab22157e902.cairo"
+                                            "filename": "autogen/starknet/arg_processor/c31620b02d4d706f0542c989b2aadc01b0981d1f6a5933a8fe4937ace3d70d92.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 14,
-                                                "end_line": 51,
+                                                "end_line": 49,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "parent_location": [
                                                     {
                                                         "end_col": 57,
                                                         "end_line": 1,
                                                         "input_file": {
-                                                            "filename": "autogen/starknet/arg_processor/1b562308a65653425ce06491fa4b4539466f3251a07e73e099d0afe86a48900e.cairo"
+                                                            "filename": "autogen/starknet/arg_processor/01cba52f8515996bb9d7070bde81ff39281d096d7024a558efcba6e1fd2402cf.cairo"
                                                         },
                                                         "parent_location": [
                                                             {
                                                                 "end_col": 14,
-                                                                "end_line": 51,
+                                                                "end_line": 49,
                                                                 "input_file": {
-                                                                    "filename": "contracts/counter.cairo"
+                                                                    "filename": "counter.cairo"
                                                                 },
                                                                 "start_col": 6,
-                                                                "start_line": 51
+                                                                "start_line": 49
                                                             },
                                                             "While handling calldata of"
                                                         ],
@@ -5917,7 +5918,7 @@
                                                     "While expanding the reference '__calldata_actual_size' in:"
                                                 ],
                                                 "start_col": 6,
-                                                "start_line": 51
+                                                "start_line": 49
                                             },
                                             "While handling calldata of"
                                         ],
@@ -5926,8 +5927,8 @@
                                     },
                                     "While expanding the reference '__calldata_ptr' in:"
                                 ],
-                                "start_col": 82,
-                                "start_line": 51
+                                "start_col": 80,
+                                "start_line": 49
                             },
                             "While handling calldata argument 'val'"
                         ],
@@ -5945,20 +5946,20 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 57,
+                        "end_col": 58,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/arg_processor/1b562308a65653425ce06491fa4b4539466f3251a07e73e099d0afe86a48900e.cairo"
+                            "filename": "autogen/starknet/arg_processor/01cba52f8515996bb9d7070bde81ff39281d096d7024a558efcba6e1fd2402cf.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 14,
-                                "end_line": 51,
+                                "end_line": 49,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "start_col": 6,
-                                "start_line": 51
+                                "start_line": 49
                             },
                             "While handling calldata of"
                         ],
@@ -5979,31 +5980,31 @@
                         "end_col": 64,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/external/set_rand/c7060df96cb0acca1380ae43bf758cab727bfdf73cb5d34a93e24a9742817fda.cairo"
+                            "filename": "autogen/starknet/external/set_rand/b2c52ca2d2a8fc8791a983086d8716c5eacd0c3d62934914d2286f84b98ff4cb.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 34,
-                                "end_line": 51,
+                                "end_col": 33,
+                                "end_line": 49,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 55,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/set_rand/2c999e3fe134bd4d5d23d149df69642a5e99354b178e46fc4ed43cd0ed6de4bd.cairo"
+                                            "filename": "autogen/starknet/external/set_rand/ee07832800ab98369e702a630fb9ee180df6817e88ecad55e9f688fdc0a1ff82.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 14,
-                                                "end_line": 51,
+                                                "end_line": 49,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 51
+                                                "start_line": 49
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -6013,7 +6014,7 @@
                                     "While expanding the reference 'syscall_ptr' in:"
                                 ],
                                 "start_col": 15,
-                                "start_line": 51
+                                "start_line": 49
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -6034,31 +6035,31 @@
                         "end_col": 110,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/external/set_rand/424b26e79f70343cc02557f1fbd25745138efb26a3dc5c8b593ca765b73138b7.cairo"
+                            "filename": "autogen/starknet/external/set_rand/9684a85e93c782014ca14293edea4eb2502039a5a7b6538ecd39c56faaf12529.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 63,
-                                "end_line": 51,
+                                "end_col": 61,
+                                "end_line": 49,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 82,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/set_rand/2c999e3fe134bd4d5d23d149df69642a5e99354b178e46fc4ed43cd0ed6de4bd.cairo"
+                                            "filename": "autogen/starknet/external/set_rand/ee07832800ab98369e702a630fb9ee180df6817e88ecad55e9f688fdc0a1ff82.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 14,
-                                                "end_line": 51,
+                                                "end_line": 49,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 51
+                                                "start_line": 49
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -6067,8 +6068,8 @@
                                     },
                                     "While expanding the reference 'pedersen_ptr' in:"
                                 ],
-                                "start_col": 36,
-                                "start_line": 51
+                                "start_col": 35,
+                                "start_line": 49
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -6089,31 +6090,31 @@
                         "end_col": 67,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/external/set_rand/e651458745e7cd218121c342e0915890767e2f59ddc2e315b8844ad0f47d582e.cairo"
+                            "filename": "autogen/starknet/external/set_rand/741ea357d6336b0bed7bf0472425acd0311d543883b803388880e60a232040c7.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 80,
-                                "end_line": 51,
+                                "end_col": 78,
+                                "end_line": 49,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 115,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/set_rand/2c999e3fe134bd4d5d23d149df69642a5e99354b178e46fc4ed43cd0ed6de4bd.cairo"
+                                            "filename": "autogen/starknet/external/set_rand/ee07832800ab98369e702a630fb9ee180df6817e88ecad55e9f688fdc0a1ff82.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 14,
-                                                "end_line": 51,
+                                                "end_line": 49,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 51
+                                                "start_line": 49
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -6122,8 +6123,8 @@
                                     },
                                     "While expanding the reference 'range_check_ptr' in:"
                                 ],
-                                "start_col": 65,
-                                "start_line": 51
+                                "start_col": 63,
+                                "start_line": 49
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -6144,31 +6145,31 @@
                         "end_col": 42,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/arg_processor/a9266930b90536cd6d9acab036ca1b6f8ca9fd5be109686bde4c26dae53e3682.cairo"
+                            "filename": "autogen/starknet/arg_processor/00d32612ffd1b363842f1be7cd60cb81327d9483302b0da5c523e670bfa81692.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 92,
-                                "end_line": 51,
+                                "end_col": 89,
+                                "end_line": 49,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 139,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/set_rand/2c999e3fe134bd4d5d23d149df69642a5e99354b178e46fc4ed43cd0ed6de4bd.cairo"
+                                            "filename": "autogen/starknet/external/set_rand/ee07832800ab98369e702a630fb9ee180df6817e88ecad55e9f688fdc0a1ff82.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 14,
-                                                "end_line": 51,
+                                                "end_line": 49,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 51
+                                                "start_line": 49
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -6177,8 +6178,8 @@
                                     },
                                     "While expanding the reference '__calldata_arg_val' in:"
                                 ],
-                                "start_col": 82,
-                                "start_line": 51
+                                "start_col": 80,
+                                "start_line": 49
                             },
                             "While handling calldata argument 'val'"
                         ],
@@ -6197,12 +6198,12 @@
                     "hints": [],
                     "inst": {
                         "end_col": 14,
-                        "end_line": 51,
+                        "end_line": 49,
                         "input_file": {
-                            "filename": "contracts/counter.cairo"
+                            "filename": "counter.cairo"
                         },
                         "start_col": 6,
-                        "start_line": 51
+                        "start_line": 49
                     }
                 },
                 "194": {
@@ -6219,17 +6220,17 @@
                                 "end_col": 34,
                                 "end_line": 2,
                                 "input_file": {
-                                    "filename": "autogen/starknet/external/set_rand/2c999e3fe134bd4d5d23d149df69642a5e99354b178e46fc4ed43cd0ed6de4bd.cairo"
+                                    "filename": "autogen/starknet/external/set_rand/ee07832800ab98369e702a630fb9ee180df6817e88ecad55e9f688fdc0a1ff82.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 14,
-                                        "end_line": 51,
+                                        "end_line": 49,
                                         "input_file": {
-                                            "filename": "contracts/counter.cairo"
+                                            "filename": "counter.cairo"
                                         },
                                         "start_col": 6,
-                                        "start_line": 51
+                                        "start_line": 49
                                     },
                                     "While constructing the external wrapper for:"
                                 ],
@@ -6243,17 +6244,17 @@
                         "end_col": 24,
                         "end_line": 3,
                         "input_file": {
-                            "filename": "autogen/starknet/external/set_rand/2c999e3fe134bd4d5d23d149df69642a5e99354b178e46fc4ed43cd0ed6de4bd.cairo"
+                            "filename": "autogen/starknet/external/set_rand/ee07832800ab98369e702a630fb9ee180df6817e88ecad55e9f688fdc0a1ff82.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 14,
-                                "end_line": 51,
+                                "end_line": 49,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "start_col": 6,
-                                "start_line": 51
+                                "start_line": 49
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -6274,31 +6275,31 @@
                         "end_col": 55,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/external/set_rand/2c999e3fe134bd4d5d23d149df69642a5e99354b178e46fc4ed43cd0ed6de4bd.cairo"
+                            "filename": "autogen/starknet/external/set_rand/ee07832800ab98369e702a630fb9ee180df6817e88ecad55e9f688fdc0a1ff82.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 14,
-                                "end_line": 51,
+                                "end_line": 49,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 20,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/set_rand/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo"
+                                            "filename": "autogen/starknet/external/set_rand/da17921a4e81c09e730800bbf23bfdbe5e9e6bfaedc59d80fbf62087fa43c27d.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 14,
-                                                "end_line": 51,
+                                                "end_line": 49,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 51
+                                                "start_line": 49
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -6308,7 +6309,7 @@
                                     "While expanding the reference 'syscall_ptr' in:"
                                 ],
                                 "start_col": 6,
-                                "start_line": 51
+                                "start_line": 49
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -6329,31 +6330,31 @@
                         "end_col": 82,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/external/set_rand/2c999e3fe134bd4d5d23d149df69642a5e99354b178e46fc4ed43cd0ed6de4bd.cairo"
+                            "filename": "autogen/starknet/external/set_rand/ee07832800ab98369e702a630fb9ee180df6817e88ecad55e9f688fdc0a1ff82.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 14,
-                                "end_line": 51,
+                                "end_line": 49,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 33,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/set_rand/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo"
+                                            "filename": "autogen/starknet/external/set_rand/da17921a4e81c09e730800bbf23bfdbe5e9e6bfaedc59d80fbf62087fa43c27d.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 14,
-                                                "end_line": 51,
+                                                "end_line": 49,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 51
+                                                "start_line": 49
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -6363,7 +6364,7 @@
                                     "While expanding the reference 'pedersen_ptr' in:"
                                 ],
                                 "start_col": 6,
-                                "start_line": 51
+                                "start_line": 49
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -6384,31 +6385,31 @@
                         "end_col": 115,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/external/set_rand/2c999e3fe134bd4d5d23d149df69642a5e99354b178e46fc4ed43cd0ed6de4bd.cairo"
+                            "filename": "autogen/starknet/external/set_rand/ee07832800ab98369e702a630fb9ee180df6817e88ecad55e9f688fdc0a1ff82.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 14,
-                                "end_line": 51,
+                                "end_line": 49,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 49,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/set_rand/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo"
+                                            "filename": "autogen/starknet/external/set_rand/da17921a4e81c09e730800bbf23bfdbe5e9e6bfaedc59d80fbf62087fa43c27d.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 14,
-                                                "end_line": 51,
+                                                "end_line": 49,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 51
+                                                "start_line": 49
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -6418,7 +6419,7 @@
                                     "While expanding the reference 'range_check_ptr' in:"
                                 ],
                                 "start_col": 6,
-                                "start_line": 51
+                                "start_line": 49
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -6439,31 +6440,31 @@
                         "end_col": 21,
                         "end_line": 4,
                         "input_file": {
-                            "filename": "autogen/starknet/external/set_rand/2c999e3fe134bd4d5d23d149df69642a5e99354b178e46fc4ed43cd0ed6de4bd.cairo"
+                            "filename": "autogen/starknet/external/set_rand/ee07832800ab98369e702a630fb9ee180df6817e88ecad55e9f688fdc0a1ff82.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 14,
-                                "end_line": 51,
+                                "end_line": 49,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 62,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/set_rand/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo"
+                                            "filename": "autogen/starknet/external/set_rand/da17921a4e81c09e730800bbf23bfdbe5e9e6bfaedc59d80fbf62087fa43c27d.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 14,
-                                                "end_line": 51,
+                                                "end_line": 49,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 51
+                                                "start_line": 49
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -6473,7 +6474,7 @@
                                     "While expanding the reference 'retdata_size' in:"
                                 ],
                                 "start_col": 6,
-                                "start_line": 51
+                                "start_line": 49
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -6494,31 +6495,31 @@
                         "end_col": 16,
                         "end_line": 3,
                         "input_file": {
-                            "filename": "autogen/starknet/external/set_rand/2c999e3fe134bd4d5d23d149df69642a5e99354b178e46fc4ed43cd0ed6de4bd.cairo"
+                            "filename": "autogen/starknet/external/set_rand/ee07832800ab98369e702a630fb9ee180df6817e88ecad55e9f688fdc0a1ff82.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 14,
-                                "end_line": 51,
+                                "end_line": 49,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 70,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/set_rand/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo"
+                                            "filename": "autogen/starknet/external/set_rand/da17921a4e81c09e730800bbf23bfdbe5e9e6bfaedc59d80fbf62087fa43c27d.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 14,
-                                                "end_line": 51,
+                                                "end_line": 49,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 51
+                                                "start_line": 49
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -6528,7 +6529,7 @@
                                     "While expanding the reference 'retdata' in:"
                                 ],
                                 "start_col": 6,
-                                "start_line": 51
+                                "start_line": 49
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -6546,20 +6547,20 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 71,
+                        "end_col": 72,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/external/set_rand/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo"
+                            "filename": "autogen/starknet/external/set_rand/da17921a4e81c09e730800bbf23bfdbe5e9e6bfaedc59d80fbf62087fa43c27d.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 14,
-                                "end_line": 51,
+                                "end_line": 49,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "start_col": 6,
-                                "start_line": 51
+                                "start_line": 49
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -6576,37 +6577,37 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 41,
-                        "end_line": 58,
+                        "end_col": 40,
+                        "end_line": 56,
                         "input_file": {
-                            "filename": "contracts/counter.cairo"
+                            "filename": "counter.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 44,
-                                "end_line": 194,
+                                "end_col": 43,
+                                "end_line": 196,
                                 "input_file": {
-                                    "filename": "/Users/gregory/project/blaqkube/fan-onchain/venv/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
+                                    "filename": "/Users/gregory/project/blaqkube/starknet-burner/examples/controller/py/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 40,
-                                        "end_line": 59,
+                                        "end_line": 57,
                                         "input_file": {
-                                            "filename": "contracts/counter.cairo"
+                                            "filename": "counter.cairo"
                                         },
                                         "start_col": 20,
-                                        "start_line": 59
+                                        "start_line": 57
                                     },
                                     "While trying to retrieve the implicit argument 'syscall_ptr' in:"
                                 ],
                                 "start_col": 25,
-                                "start_line": 194
+                                "start_line": 196
                             },
                             "While expanding the reference 'syscall_ptr' in:"
                         ],
                         "start_col": 22,
-                        "start_line": 58
+                        "start_line": 56
                     }
                 },
                 "204": {
@@ -6619,12 +6620,12 @@
                     "hints": [],
                     "inst": {
                         "end_col": 40,
-                        "end_line": 59,
+                        "end_line": 57,
                         "input_file": {
-                            "filename": "contracts/counter.cairo"
+                            "filename": "counter.cairo"
                         },
                         "start_col": 20,
-                        "start_line": 59
+                        "start_line": 57
                     }
                 },
                 "206": {
@@ -6636,49 +6637,49 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 44,
-                        "end_line": 194,
+                        "end_col": 43,
+                        "end_line": 196,
                         "input_file": {
-                            "filename": "/Users/gregory/project/blaqkube/fan-onchain/venv/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
+                            "filename": "/Users/gregory/project/blaqkube/starknet-burner/examples/controller/py/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 40,
-                                "end_line": 59,
+                                "end_line": 57,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
-                                        "end_col": 37,
-                                        "end_line": 433,
+                                        "end_col": 36,
+                                        "end_line": 438,
                                         "input_file": {
-                                            "filename": "/Users/gregory/project/blaqkube/fan-onchain/venv/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
+                                            "filename": "/Users/gregory/project/blaqkube/starknet-burner/examples/controller/py/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 34,
-                                                "end_line": 60,
+                                                "end_line": 58,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "start_col": 21,
-                                                "start_line": 60
+                                                "start_line": 58
                                             },
                                             "While trying to retrieve the implicit argument 'syscall_ptr' in:"
                                         ],
                                         "start_col": 18,
-                                        "start_line": 433
+                                        "start_line": 438
                                     },
                                     "While expanding the reference 'syscall_ptr' in:"
                                 ],
                                 "start_col": 20,
-                                "start_line": 59
+                                "start_line": 57
                             },
                             "While trying to update the implicit return value 'syscall_ptr' in:"
                         ],
                         "start_col": 25,
-                        "start_line": 194
+                        "start_line": 196
                     }
                 },
                 "207": {
@@ -6691,12 +6692,12 @@
                     "hints": [],
                     "inst": {
                         "end_col": 34,
-                        "end_line": 60,
+                        "end_line": 58,
                         "input_file": {
-                            "filename": "contracts/counter.cairo"
+                            "filename": "counter.cairo"
                         },
                         "start_col": 21,
-                        "start_line": 60
+                        "start_line": 58
                     }
                 },
                 "209": {
@@ -6709,12 +6710,12 @@
                     "hints": [],
                     "inst": {
                         "end_col": 42,
-                        "end_line": 62,
+                        "end_line": 60,
                         "input_file": {
-                            "filename": "contracts/counter.cairo"
+                            "filename": "counter.cairo"
                         },
                         "start_col": 21,
-                        "start_line": 62
+                        "start_line": 60
                     }
                 },
                 "210": {
@@ -6727,12 +6728,12 @@
                     "hints": [],
                     "inst": {
                         "end_col": 43,
-                        "end_line": 62,
+                        "end_line": 60,
                         "input_file": {
-                            "filename": "contracts/counter.cairo"
+                            "filename": "counter.cairo"
                         },
                         "start_col": 5,
-                        "start_line": 62
+                        "start_line": 60
                     }
                 },
                 "212": {
@@ -6744,21 +6745,21 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 37,
-                        "end_line": 433,
+                        "end_col": 36,
+                        "end_line": 438,
                         "input_file": {
-                            "filename": "/Users/gregory/project/blaqkube/fan-onchain/venv/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
+                            "filename": "/Users/gregory/project/blaqkube/starknet-burner/examples/controller/py/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 34,
-                                "end_line": 60,
+                                "end_line": 58,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
-                                        "end_col": 35,
+                                        "end_col": 34,
                                         "end_line": 19,
                                         "input_file": {
                                             "filename": "autogen/starknet/storage_var/rand/decl.cairo"
@@ -6766,12 +6767,12 @@
                                         "parent_location": [
                                             {
                                                 "end_col": 20,
-                                                "end_line": 64,
+                                                "end_line": 62,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "start_col": 5,
-                                                "start_line": 64
+                                                "start_line": 62
                                             },
                                             "While trying to retrieve the implicit argument 'syscall_ptr' in:"
                                         ],
@@ -6781,12 +6782,12 @@
                                     "While expanding the reference 'syscall_ptr' in:"
                                 ],
                                 "start_col": 21,
-                                "start_line": 60
+                                "start_line": 58
                             },
                             "While trying to update the implicit return value 'syscall_ptr' in:"
                         ],
                         "start_col": 18,
-                        "start_line": 433
+                        "start_line": 438
                     }
                 },
                 "213": {
@@ -6798,14 +6799,14 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 70,
-                        "end_line": 58,
+                        "end_col": 68,
+                        "end_line": 56,
                         "input_file": {
-                            "filename": "contracts/counter.cairo"
+                            "filename": "counter.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 64,
+                                "end_col": 62,
                                 "end_line": 19,
                                 "input_file": {
                                     "filename": "autogen/starknet/storage_var/rand/decl.cairo"
@@ -6813,22 +6814,22 @@
                                 "parent_location": [
                                     {
                                         "end_col": 20,
-                                        "end_line": 64,
+                                        "end_line": 62,
                                         "input_file": {
-                                            "filename": "contracts/counter.cairo"
+                                            "filename": "counter.cairo"
                                         },
                                         "start_col": 5,
-                                        "start_line": 64
+                                        "start_line": 62
                                     },
                                     "While trying to retrieve the implicit argument 'pedersen_ptr' in:"
                                 ],
-                                "start_col": 37,
+                                "start_col": 36,
                                 "start_line": 19
                             },
                             "While expanding the reference 'pedersen_ptr' in:"
                         ],
-                        "start_col": 43,
-                        "start_line": 58
+                        "start_col": 42,
+                        "start_line": 56
                     }
                 },
                 "214": {
@@ -6840,14 +6841,14 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 87,
-                        "end_line": 58,
+                        "end_col": 85,
+                        "end_line": 56,
                         "input_file": {
-                            "filename": "contracts/counter.cairo"
+                            "filename": "counter.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 81,
+                                "end_col": 79,
                                 "end_line": 19,
                                 "input_file": {
                                     "filename": "autogen/starknet/storage_var/rand/decl.cairo"
@@ -6855,22 +6856,22 @@
                                 "parent_location": [
                                     {
                                         "end_col": 20,
-                                        "end_line": 64,
+                                        "end_line": 62,
                                         "input_file": {
-                                            "filename": "contracts/counter.cairo"
+                                            "filename": "counter.cairo"
                                         },
                                         "start_col": 5,
-                                        "start_line": 64
+                                        "start_line": 62
                                     },
                                     "While trying to retrieve the implicit argument 'range_check_ptr' in:"
                                 ],
-                                "start_col": 66,
+                                "start_col": 64,
                                 "start_line": 19
                             },
                             "While expanding the reference 'range_check_ptr' in:"
                         ],
-                        "start_col": 72,
-                        "start_line": 58
+                        "start_col": 70,
+                        "start_line": 56
                     }
                 },
                 "215": {
@@ -6882,25 +6883,25 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 99,
-                        "end_line": 58,
+                        "end_col": 96,
+                        "end_line": 56,
                         "input_file": {
-                            "filename": "contracts/counter.cairo"
+                            "filename": "counter.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 19,
-                                "end_line": 64,
+                                "end_line": 62,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "start_col": 16,
-                                "start_line": 64
+                                "start_line": 62
                             },
                             "While expanding the reference 'val' in:"
                         ],
-                        "start_col": 89,
-                        "start_line": 58
+                        "start_col": 87,
+                        "start_line": 56
                     }
                 },
                 "216": {
@@ -6913,12 +6914,12 @@
                     "hints": [],
                     "inst": {
                         "end_col": 20,
-                        "end_line": 64,
+                        "end_line": 62,
                         "input_file": {
-                            "filename": "contracts/counter.cairo"
+                            "filename": "counter.cairo"
                         },
                         "start_col": 5,
-                        "start_line": 64
+                        "start_line": 62
                     }
                 },
                 "218": {
@@ -6930,13 +6931,13 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 14,
-                        "end_line": 66,
+                        "end_col": 15,
+                        "end_line": 64,
                         "input_file": {
-                            "filename": "contracts/counter.cairo"
+                            "filename": "counter.cairo"
                         },
                         "start_col": 5,
-                        "start_line": 66
+                        "start_line": 64
                     }
                 },
                 "219": {
@@ -6952,45 +6953,45 @@
                         "end_col": 40,
                         "end_line": 2,
                         "input_file": {
-                            "filename": "autogen/starknet/arg_processor/a9266930b90536cd6d9acab036ca1b6f8ca9fd5be109686bde4c26dae53e3682.cairo"
+                            "filename": "autogen/starknet/arg_processor/00d32612ffd1b363842f1be7cd60cb81327d9483302b0da5c523e670bfa81692.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 99,
-                                "end_line": 58,
+                                "end_col": 96,
+                                "end_line": 56,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 45,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/arg_processor/5e1cc73f0b484f90bb02da164d88332b40c6f698801aa4d3c603dab22157e902.cairo"
+                                            "filename": "autogen/starknet/arg_processor/c31620b02d4d706f0542c989b2aadc01b0981d1f6a5933a8fe4937ace3d70d92.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 21,
-                                                "end_line": 58,
+                                                "end_line": 56,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "parent_location": [
                                                     {
                                                         "end_col": 57,
                                                         "end_line": 1,
                                                         "input_file": {
-                                                            "filename": "autogen/starknet/arg_processor/1b562308a65653425ce06491fa4b4539466f3251a07e73e099d0afe86a48900e.cairo"
+                                                            "filename": "autogen/starknet/arg_processor/01cba52f8515996bb9d7070bde81ff39281d096d7024a558efcba6e1fd2402cf.cairo"
                                                         },
                                                         "parent_location": [
                                                             {
                                                                 "end_col": 21,
-                                                                "end_line": 58,
+                                                                "end_line": 56,
                                                                 "input_file": {
-                                                                    "filename": "contracts/counter.cairo"
+                                                                    "filename": "counter.cairo"
                                                                 },
                                                                 "start_col": 6,
-                                                                "start_line": 58
+                                                                "start_line": 56
                                                             },
                                                             "While handling calldata of"
                                                         ],
@@ -7000,7 +7001,7 @@
                                                     "While expanding the reference '__calldata_actual_size' in:"
                                                 ],
                                                 "start_col": 6,
-                                                "start_line": 58
+                                                "start_line": 56
                                             },
                                             "While handling calldata of"
                                         ],
@@ -7009,8 +7010,8 @@
                                     },
                                     "While expanding the reference '__calldata_ptr' in:"
                                 ],
-                                "start_col": 89,
-                                "start_line": 58
+                                "start_col": 87,
+                                "start_line": 56
                             },
                             "While handling calldata argument 'val'"
                         ],
@@ -7028,20 +7029,20 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 57,
+                        "end_col": 58,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/arg_processor/1b562308a65653425ce06491fa4b4539466f3251a07e73e099d0afe86a48900e.cairo"
+                            "filename": "autogen/starknet/arg_processor/01cba52f8515996bb9d7070bde81ff39281d096d7024a558efcba6e1fd2402cf.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 21,
-                                "end_line": 58,
+                                "end_line": 56,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "start_col": 6,
-                                "start_line": 58
+                                "start_line": 56
                             },
                             "While handling calldata of"
                         ],
@@ -7062,31 +7063,31 @@
                         "end_col": 64,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/external/set_rand_signed/c7060df96cb0acca1380ae43bf758cab727bfdf73cb5d34a93e24a9742817fda.cairo"
+                            "filename": "autogen/starknet/external/set_rand_signed/b2c52ca2d2a8fc8791a983086d8716c5eacd0c3d62934914d2286f84b98ff4cb.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 41,
-                                "end_line": 58,
+                                "end_col": 40,
+                                "end_line": 56,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 55,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/set_rand_signed/2c999e3fe134bd4d5d23d149df69642a5e99354b178e46fc4ed43cd0ed6de4bd.cairo"
+                                            "filename": "autogen/starknet/external/set_rand_signed/ee07832800ab98369e702a630fb9ee180df6817e88ecad55e9f688fdc0a1ff82.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 21,
-                                                "end_line": 58,
+                                                "end_line": 56,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 58
+                                                "start_line": 56
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -7096,7 +7097,7 @@
                                     "While expanding the reference 'syscall_ptr' in:"
                                 ],
                                 "start_col": 22,
-                                "start_line": 58
+                                "start_line": 56
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -7117,31 +7118,31 @@
                         "end_col": 110,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/external/set_rand_signed/424b26e79f70343cc02557f1fbd25745138efb26a3dc5c8b593ca765b73138b7.cairo"
+                            "filename": "autogen/starknet/external/set_rand_signed/9684a85e93c782014ca14293edea4eb2502039a5a7b6538ecd39c56faaf12529.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 70,
-                                "end_line": 58,
+                                "end_col": 68,
+                                "end_line": 56,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 82,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/set_rand_signed/2c999e3fe134bd4d5d23d149df69642a5e99354b178e46fc4ed43cd0ed6de4bd.cairo"
+                                            "filename": "autogen/starknet/external/set_rand_signed/ee07832800ab98369e702a630fb9ee180df6817e88ecad55e9f688fdc0a1ff82.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 21,
-                                                "end_line": 58,
+                                                "end_line": 56,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 58
+                                                "start_line": 56
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -7150,8 +7151,8 @@
                                     },
                                     "While expanding the reference 'pedersen_ptr' in:"
                                 ],
-                                "start_col": 43,
-                                "start_line": 58
+                                "start_col": 42,
+                                "start_line": 56
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -7172,31 +7173,31 @@
                         "end_col": 67,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/external/set_rand_signed/e651458745e7cd218121c342e0915890767e2f59ddc2e315b8844ad0f47d582e.cairo"
+                            "filename": "autogen/starknet/external/set_rand_signed/741ea357d6336b0bed7bf0472425acd0311d543883b803388880e60a232040c7.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 87,
-                                "end_line": 58,
+                                "end_col": 85,
+                                "end_line": 56,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 115,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/set_rand_signed/2c999e3fe134bd4d5d23d149df69642a5e99354b178e46fc4ed43cd0ed6de4bd.cairo"
+                                            "filename": "autogen/starknet/external/set_rand_signed/ee07832800ab98369e702a630fb9ee180df6817e88ecad55e9f688fdc0a1ff82.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 21,
-                                                "end_line": 58,
+                                                "end_line": 56,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 58
+                                                "start_line": 56
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -7205,8 +7206,8 @@
                                     },
                                     "While expanding the reference 'range_check_ptr' in:"
                                 ],
-                                "start_col": 72,
-                                "start_line": 58
+                                "start_col": 70,
+                                "start_line": 56
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -7227,31 +7228,31 @@
                         "end_col": 42,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/arg_processor/a9266930b90536cd6d9acab036ca1b6f8ca9fd5be109686bde4c26dae53e3682.cairo"
+                            "filename": "autogen/starknet/arg_processor/00d32612ffd1b363842f1be7cd60cb81327d9483302b0da5c523e670bfa81692.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 99,
-                                "end_line": 58,
+                                "end_col": 96,
+                                "end_line": 56,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 139,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/set_rand_signed/2c999e3fe134bd4d5d23d149df69642a5e99354b178e46fc4ed43cd0ed6de4bd.cairo"
+                                            "filename": "autogen/starknet/external/set_rand_signed/ee07832800ab98369e702a630fb9ee180df6817e88ecad55e9f688fdc0a1ff82.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 21,
-                                                "end_line": 58,
+                                                "end_line": 56,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 58
+                                                "start_line": 56
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -7260,8 +7261,8 @@
                                     },
                                     "While expanding the reference '__calldata_arg_val' in:"
                                 ],
-                                "start_col": 89,
-                                "start_line": 58
+                                "start_col": 87,
+                                "start_line": 56
                             },
                             "While handling calldata argument 'val'"
                         ],
@@ -7280,12 +7281,12 @@
                     "hints": [],
                     "inst": {
                         "end_col": 21,
-                        "end_line": 58,
+                        "end_line": 56,
                         "input_file": {
-                            "filename": "contracts/counter.cairo"
+                            "filename": "counter.cairo"
                         },
                         "start_col": 6,
-                        "start_line": 58
+                        "start_line": 56
                     }
                 },
                 "228": {
@@ -7302,17 +7303,17 @@
                                 "end_col": 34,
                                 "end_line": 2,
                                 "input_file": {
-                                    "filename": "autogen/starknet/external/set_rand_signed/2c999e3fe134bd4d5d23d149df69642a5e99354b178e46fc4ed43cd0ed6de4bd.cairo"
+                                    "filename": "autogen/starknet/external/set_rand_signed/ee07832800ab98369e702a630fb9ee180df6817e88ecad55e9f688fdc0a1ff82.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 21,
-                                        "end_line": 58,
+                                        "end_line": 56,
                                         "input_file": {
-                                            "filename": "contracts/counter.cairo"
+                                            "filename": "counter.cairo"
                                         },
                                         "start_col": 6,
-                                        "start_line": 58
+                                        "start_line": 56
                                     },
                                     "While constructing the external wrapper for:"
                                 ],
@@ -7326,17 +7327,17 @@
                         "end_col": 24,
                         "end_line": 3,
                         "input_file": {
-                            "filename": "autogen/starknet/external/set_rand_signed/2c999e3fe134bd4d5d23d149df69642a5e99354b178e46fc4ed43cd0ed6de4bd.cairo"
+                            "filename": "autogen/starknet/external/set_rand_signed/ee07832800ab98369e702a630fb9ee180df6817e88ecad55e9f688fdc0a1ff82.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 21,
-                                "end_line": 58,
+                                "end_line": 56,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "start_col": 6,
-                                "start_line": 58
+                                "start_line": 56
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -7357,31 +7358,31 @@
                         "end_col": 55,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/external/set_rand_signed/2c999e3fe134bd4d5d23d149df69642a5e99354b178e46fc4ed43cd0ed6de4bd.cairo"
+                            "filename": "autogen/starknet/external/set_rand_signed/ee07832800ab98369e702a630fb9ee180df6817e88ecad55e9f688fdc0a1ff82.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 21,
-                                "end_line": 58,
+                                "end_line": 56,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 20,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/set_rand_signed/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo"
+                                            "filename": "autogen/starknet/external/set_rand_signed/da17921a4e81c09e730800bbf23bfdbe5e9e6bfaedc59d80fbf62087fa43c27d.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 21,
-                                                "end_line": 58,
+                                                "end_line": 56,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 58
+                                                "start_line": 56
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -7391,7 +7392,7 @@
                                     "While expanding the reference 'syscall_ptr' in:"
                                 ],
                                 "start_col": 6,
-                                "start_line": 58
+                                "start_line": 56
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -7412,31 +7413,31 @@
                         "end_col": 82,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/external/set_rand_signed/2c999e3fe134bd4d5d23d149df69642a5e99354b178e46fc4ed43cd0ed6de4bd.cairo"
+                            "filename": "autogen/starknet/external/set_rand_signed/ee07832800ab98369e702a630fb9ee180df6817e88ecad55e9f688fdc0a1ff82.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 21,
-                                "end_line": 58,
+                                "end_line": 56,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 33,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/set_rand_signed/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo"
+                                            "filename": "autogen/starknet/external/set_rand_signed/da17921a4e81c09e730800bbf23bfdbe5e9e6bfaedc59d80fbf62087fa43c27d.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 21,
-                                                "end_line": 58,
+                                                "end_line": 56,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 58
+                                                "start_line": 56
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -7446,7 +7447,7 @@
                                     "While expanding the reference 'pedersen_ptr' in:"
                                 ],
                                 "start_col": 6,
-                                "start_line": 58
+                                "start_line": 56
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -7467,31 +7468,31 @@
                         "end_col": 115,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/external/set_rand_signed/2c999e3fe134bd4d5d23d149df69642a5e99354b178e46fc4ed43cd0ed6de4bd.cairo"
+                            "filename": "autogen/starknet/external/set_rand_signed/ee07832800ab98369e702a630fb9ee180df6817e88ecad55e9f688fdc0a1ff82.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 21,
-                                "end_line": 58,
+                                "end_line": 56,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 49,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/set_rand_signed/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo"
+                                            "filename": "autogen/starknet/external/set_rand_signed/da17921a4e81c09e730800bbf23bfdbe5e9e6bfaedc59d80fbf62087fa43c27d.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 21,
-                                                "end_line": 58,
+                                                "end_line": 56,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 58
+                                                "start_line": 56
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -7501,7 +7502,7 @@
                                     "While expanding the reference 'range_check_ptr' in:"
                                 ],
                                 "start_col": 6,
-                                "start_line": 58
+                                "start_line": 56
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -7522,31 +7523,31 @@
                         "end_col": 21,
                         "end_line": 4,
                         "input_file": {
-                            "filename": "autogen/starknet/external/set_rand_signed/2c999e3fe134bd4d5d23d149df69642a5e99354b178e46fc4ed43cd0ed6de4bd.cairo"
+                            "filename": "autogen/starknet/external/set_rand_signed/ee07832800ab98369e702a630fb9ee180df6817e88ecad55e9f688fdc0a1ff82.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 21,
-                                "end_line": 58,
+                                "end_line": 56,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 62,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/set_rand_signed/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo"
+                                            "filename": "autogen/starknet/external/set_rand_signed/da17921a4e81c09e730800bbf23bfdbe5e9e6bfaedc59d80fbf62087fa43c27d.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 21,
-                                                "end_line": 58,
+                                                "end_line": 56,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 58
+                                                "start_line": 56
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -7556,7 +7557,7 @@
                                     "While expanding the reference 'retdata_size' in:"
                                 ],
                                 "start_col": 6,
-                                "start_line": 58
+                                "start_line": 56
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -7577,31 +7578,31 @@
                         "end_col": 16,
                         "end_line": 3,
                         "input_file": {
-                            "filename": "autogen/starknet/external/set_rand_signed/2c999e3fe134bd4d5d23d149df69642a5e99354b178e46fc4ed43cd0ed6de4bd.cairo"
+                            "filename": "autogen/starknet/external/set_rand_signed/ee07832800ab98369e702a630fb9ee180df6817e88ecad55e9f688fdc0a1ff82.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 21,
-                                "end_line": 58,
+                                "end_line": 56,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 70,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/set_rand_signed/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo"
+                                            "filename": "autogen/starknet/external/set_rand_signed/da17921a4e81c09e730800bbf23bfdbe5e9e6bfaedc59d80fbf62087fa43c27d.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 21,
-                                                "end_line": 58,
+                                                "end_line": 56,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 58
+                                                "start_line": 56
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -7611,7 +7612,7 @@
                                     "While expanding the reference 'retdata' in:"
                                 ],
                                 "start_col": 6,
-                                "start_line": 58
+                                "start_line": 56
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -7629,20 +7630,20 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 71,
+                        "end_col": 72,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/external/set_rand_signed/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo"
+                            "filename": "autogen/starknet/external/set_rand_signed/da17921a4e81c09e730800bbf23bfdbe5e9e6bfaedc59d80fbf62087fa43c27d.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 21,
-                                "end_line": 58,
+                                "end_line": 56,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "start_col": 6,
-                                "start_line": 58
+                                "start_line": 56
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -7659,14 +7660,14 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 35,
-                        "end_line": 70,
+                        "end_col": 34,
+                        "end_line": 68,
                         "input_file": {
-                            "filename": "contracts/counter.cairo"
+                            "filename": "counter.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 34,
+                                "end_col": 33,
                                 "end_line": 13,
                                 "input_file": {
                                     "filename": "autogen/starknet/storage_var/counter/decl.cairo"
@@ -7674,12 +7675,12 @@
                                 "parent_location": [
                                     {
                                         "end_col": 33,
-                                        "end_line": 73,
+                                        "end_line": 69,
                                         "input_file": {
-                                            "filename": "contracts/counter.cairo"
+                                            "filename": "counter.cairo"
                                         },
                                         "start_col": 19,
-                                        "start_line": 73
+                                        "start_line": 69
                                     },
                                     "While trying to retrieve the implicit argument 'syscall_ptr' in:"
                                 ],
@@ -7689,7 +7690,7 @@
                             "While expanding the reference 'syscall_ptr' in:"
                         ],
                         "start_col": 16,
-                        "start_line": 70
+                        "start_line": 68
                     }
                 },
                 "238": {
@@ -7701,14 +7702,14 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 64,
-                        "end_line": 70,
+                        "end_col": 62,
+                        "end_line": 68,
                         "input_file": {
-                            "filename": "contracts/counter.cairo"
+                            "filename": "counter.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 63,
+                                "end_col": 61,
                                 "end_line": 13,
                                 "input_file": {
                                     "filename": "autogen/starknet/storage_var/counter/decl.cairo"
@@ -7716,22 +7717,22 @@
                                 "parent_location": [
                                     {
                                         "end_col": 33,
-                                        "end_line": 73,
+                                        "end_line": 69,
                                         "input_file": {
-                                            "filename": "contracts/counter.cairo"
+                                            "filename": "counter.cairo"
                                         },
                                         "start_col": 19,
-                                        "start_line": 73
+                                        "start_line": 69
                                     },
                                     "While trying to retrieve the implicit argument 'pedersen_ptr' in:"
                                 ],
-                                "start_col": 36,
+                                "start_col": 35,
                                 "start_line": 13
                             },
                             "While expanding the reference 'pedersen_ptr' in:"
                         ],
-                        "start_col": 37,
-                        "start_line": 70
+                        "start_col": 36,
+                        "start_line": 68
                     }
                 },
                 "239": {
@@ -7743,14 +7744,14 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 81,
-                        "end_line": 70,
+                        "end_col": 79,
+                        "end_line": 68,
                         "input_file": {
-                            "filename": "contracts/counter.cairo"
+                            "filename": "counter.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 80,
+                                "end_col": 78,
                                 "end_line": 13,
                                 "input_file": {
                                     "filename": "autogen/starknet/storage_var/counter/decl.cairo"
@@ -7758,22 +7759,22 @@
                                 "parent_location": [
                                     {
                                         "end_col": 33,
-                                        "end_line": 73,
+                                        "end_line": 69,
                                         "input_file": {
-                                            "filename": "contracts/counter.cairo"
+                                            "filename": "counter.cairo"
                                         },
                                         "start_col": 19,
-                                        "start_line": 73
+                                        "start_line": 69
                                     },
                                     "While trying to retrieve the implicit argument 'range_check_ptr' in:"
                                 ],
-                                "start_col": 65,
+                                "start_col": 63,
                                 "start_line": 13
                             },
                             "While expanding the reference 'range_check_ptr' in:"
                         ],
-                        "start_col": 66,
-                        "start_line": 70
+                        "start_col": 64,
+                        "start_line": 68
                     }
                 },
                 "240": {
@@ -7786,12 +7787,12 @@
                     "hints": [],
                     "inst": {
                         "end_col": 33,
-                        "end_line": 73,
+                        "end_line": 69,
                         "input_file": {
-                            "filename": "contracts/counter.cairo"
+                            "filename": "counter.cairo"
                         },
                         "start_col": 19,
-                        "start_line": 73
+                        "start_line": 69
                     }
                 },
                 "242": {
@@ -7803,7 +7804,7 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 34,
+                        "end_col": 33,
                         "end_line": 13,
                         "input_file": {
                             "filename": "autogen/starknet/storage_var/counter/decl.cairo"
@@ -7811,36 +7812,36 @@
                         "parent_location": [
                             {
                                 "end_col": 33,
-                                "end_line": 73,
+                                "end_line": 69,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
-                                        "end_col": 35,
-                                        "end_line": 21,
+                                        "end_col": 34,
+                                        "end_line": 19,
                                         "input_file": {
                                             "filename": "autogen/starknet/storage_var/counter/decl.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 29,
-                                                "end_line": 74,
+                                                "end_line": 70,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "start_col": 5,
-                                                "start_line": 74
+                                                "start_line": 70
                                             },
                                             "While trying to retrieve the implicit argument 'syscall_ptr' in:"
                                         ],
                                         "start_col": 16,
-                                        "start_line": 21
+                                        "start_line": 19
                                     },
                                     "While expanding the reference 'syscall_ptr' in:"
                                 ],
                                 "start_col": 19,
-                                "start_line": 73
+                                "start_line": 69
                             },
                             "While trying to update the implicit return value 'syscall_ptr' in:"
                         ],
@@ -7857,7 +7858,7 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 63,
+                        "end_col": 61,
                         "end_line": 13,
                         "input_file": {
                             "filename": "autogen/starknet/storage_var/counter/decl.cairo"
@@ -7865,40 +7866,40 @@
                         "parent_location": [
                             {
                                 "end_col": 33,
-                                "end_line": 73,
+                                "end_line": 69,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
-                                        "end_col": 64,
-                                        "end_line": 21,
+                                        "end_col": 62,
+                                        "end_line": 19,
                                         "input_file": {
                                             "filename": "autogen/starknet/storage_var/counter/decl.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 29,
-                                                "end_line": 74,
+                                                "end_line": 70,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "start_col": 5,
-                                                "start_line": 74
+                                                "start_line": 70
                                             },
                                             "While trying to retrieve the implicit argument 'pedersen_ptr' in:"
                                         ],
-                                        "start_col": 37,
-                                        "start_line": 21
+                                        "start_col": 36,
+                                        "start_line": 19
                                     },
                                     "While expanding the reference 'pedersen_ptr' in:"
                                 ],
                                 "start_col": 19,
-                                "start_line": 73
+                                "start_line": 69
                             },
                             "While trying to update the implicit return value 'pedersen_ptr' in:"
                         ],
-                        "start_col": 36,
+                        "start_col": 35,
                         "start_line": 13
                     }
                 },
@@ -7911,7 +7912,7 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 80,
+                        "end_col": 78,
                         "end_line": 13,
                         "input_file": {
                             "filename": "autogen/starknet/storage_var/counter/decl.cairo"
@@ -7919,40 +7920,40 @@
                         "parent_location": [
                             {
                                 "end_col": 33,
-                                "end_line": 73,
+                                "end_line": 69,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
-                                        "end_col": 81,
-                                        "end_line": 21,
+                                        "end_col": 79,
+                                        "end_line": 19,
                                         "input_file": {
                                             "filename": "autogen/starknet/storage_var/counter/decl.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 29,
-                                                "end_line": 74,
+                                                "end_line": 70,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "start_col": 5,
-                                                "start_line": 74
+                                                "start_line": 70
                                             },
                                             "While trying to retrieve the implicit argument 'range_check_ptr' in:"
                                         ],
-                                        "start_col": 66,
-                                        "start_line": 21
+                                        "start_col": 64,
+                                        "start_line": 19
                                     },
                                     "While expanding the reference 'range_check_ptr' in:"
                                 ],
                                 "start_col": 19,
-                                "start_line": 73
+                                "start_line": 69
                             },
                             "While trying to update the implicit return value 'range_check_ptr' in:"
                         ],
-                        "start_col": 65,
+                        "start_col": 63,
                         "start_line": 13
                     }
                 },
@@ -7966,12 +7967,12 @@
                     "hints": [],
                     "inst": {
                         "end_col": 28,
-                        "end_line": 74,
+                        "end_line": 70,
                         "input_file": {
-                            "filename": "contracts/counter.cairo"
+                            "filename": "counter.cairo"
                         },
                         "start_col": 19,
-                        "start_line": 74
+                        "start_line": 70
                     }
                 },
                 "247": {
@@ -7984,12 +7985,12 @@
                     "hints": [],
                     "inst": {
                         "end_col": 29,
-                        "end_line": 74,
+                        "end_line": 70,
                         "input_file": {
-                            "filename": "contracts/counter.cairo"
+                            "filename": "counter.cairo"
                         },
                         "start_col": 5,
-                        "start_line": 74
+                        "start_line": 70
                     }
                 },
                 "249": {
@@ -8002,12 +8003,12 @@
                     "hints": [],
                     "inst": {
                         "end_col": 37,
-                        "end_line": 76,
+                        "end_line": 72,
                         "input_file": {
-                            "filename": "contracts/counter.cairo"
+                            "filename": "counter.cairo"
                         },
                         "start_col": 23,
-                        "start_line": 76
+                        "start_line": 72
                     }
                 },
                 "251": {
@@ -8019,13 +8020,13 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 29,
-                        "end_line": 78,
+                        "end_col": 30,
+                        "end_line": 74,
                         "input_file": {
-                            "filename": "contracts/counter.cairo"
+                            "filename": "counter.cairo"
                         },
                         "start_col": 5,
-                        "start_line": 78
+                        "start_line": 74
                     }
                 },
                 "252": {
@@ -8042,17 +8043,17 @@
                                 "end_col": 38,
                                 "end_line": 3,
                                 "input_file": {
-                                    "filename": "autogen/starknet/external/return/increment/adb54f6bab72175c1c54ee4b1895325ce3bf4b9032bc5a52084ebf756d63d09a.cairo"
+                                    "filename": "autogen/starknet/external/return/increment/13e3c8024d3012a81a9124b680cd43b23ca5867984f22715079ad99875a01901.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 15,
-                                        "end_line": 70,
+                                        "end_line": 68,
                                         "input_file": {
-                                            "filename": "contracts/counter.cairo"
+                                            "filename": "counter.cairo"
                                         },
                                         "start_col": 6,
-                                        "start_line": 70
+                                        "start_line": 68
                                     },
                                     "While handling return value of"
                                 ],
@@ -8063,20 +8064,20 @@
                         }
                     ],
                     "inst": {
-                        "end_col": 17,
+                        "end_col": 18,
                         "end_line": 4,
                         "input_file": {
-                            "filename": "autogen/starknet/external/return/increment/adb54f6bab72175c1c54ee4b1895325ce3bf4b9032bc5a52084ebf756d63d09a.cairo"
+                            "filename": "autogen/starknet/external/return/increment/13e3c8024d3012a81a9124b680cd43b23ca5867984f22715079ad99875a01901.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 15,
-                                "end_line": 70,
+                                "end_line": 68,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "start_col": 6,
-                                "start_line": 70
+                                "start_line": 68
                             },
                             "While handling return value of"
                         ],
@@ -8094,20 +8095,20 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 46,
+                        "end_col": 47,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/arg_processor/0e9d4c974a6b6ace74b8b3274b87fad1f5800d4af46cff21a4b9883e1a1b0574.cairo"
+                            "filename": "autogen/starknet/arg_processor/95d2b1ea3726b72b3719bdfa0a12258ccf662f010c27f42865683ec83f32a1c9.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 17,
-                                "end_line": 71,
+                                "end_col": 98,
+                                "end_line": 68,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
-                                "start_col": 5,
-                                "start_line": 71
+                                "start_col": 87,
+                                "start_line": 68
                             },
                             "While handling return value 'count'"
                         ],
@@ -8128,31 +8129,31 @@
                         "end_col": 48,
                         "end_line": 2,
                         "input_file": {
-                            "filename": "autogen/starknet/arg_processor/0e9d4c974a6b6ace74b8b3274b87fad1f5800d4af46cff21a4b9883e1a1b0574.cairo"
+                            "filename": "autogen/starknet/arg_processor/95d2b1ea3726b72b3719bdfa0a12258ccf662f010c27f42865683ec83f32a1c9.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 17,
-                                "end_line": 71,
+                                "end_col": 98,
+                                "end_line": 68,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 36,
                                         "end_line": 11,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/return/increment/adb54f6bab72175c1c54ee4b1895325ce3bf4b9032bc5a52084ebf756d63d09a.cairo"
+                                            "filename": "autogen/starknet/external/return/increment/13e3c8024d3012a81a9124b680cd43b23ca5867984f22715079ad99875a01901.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 15,
-                                                "end_line": 70,
+                                                "end_line": 68,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 70
+                                                "start_line": 68
                                             },
                                             "While handling return value of"
                                         ],
@@ -8161,8 +8162,8 @@
                                     },
                                     "While expanding the reference '__return_value_ptr' in:"
                                 ],
-                                "start_col": 5,
-                                "start_line": 71
+                                "start_col": 87,
+                                "start_line": 68
                             },
                             "While handling return value 'count'"
                         ],
@@ -8180,34 +8181,34 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 73,
+                        "end_col": 71,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/external/return/increment/adb54f6bab72175c1c54ee4b1895325ce3bf4b9032bc5a52084ebf756d63d09a.cairo"
+                            "filename": "autogen/starknet/external/return/increment/13e3c8024d3012a81a9124b680cd43b23ca5867984f22715079ad99875a01901.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 15,
-                                "end_line": 70,
+                                "end_line": 68,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 40,
                                         "end_line": 10,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/return/increment/adb54f6bab72175c1c54ee4b1895325ce3bf4b9032bc5a52084ebf756d63d09a.cairo"
+                                            "filename": "autogen/starknet/external/return/increment/13e3c8024d3012a81a9124b680cd43b23ca5867984f22715079ad99875a01901.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 15,
-                                                "end_line": 70,
+                                                "end_line": 68,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 70
+                                                "start_line": 68
                                             },
                                             "While handling return value of"
                                         ],
@@ -8217,11 +8218,11 @@
                                     "While expanding the reference 'range_check_ptr' in:"
                                 ],
                                 "start_col": 6,
-                                "start_line": 70
+                                "start_line": 68
                             },
                             "While handling return value of"
                         ],
-                        "start_col": 58,
+                        "start_col": 56,
                         "start_line": 1
                     }
                 },
@@ -8238,17 +8239,17 @@
                         "end_col": 63,
                         "end_line": 11,
                         "input_file": {
-                            "filename": "autogen/starknet/external/return/increment/adb54f6bab72175c1c54ee4b1895325ce3bf4b9032bc5a52084ebf756d63d09a.cairo"
+                            "filename": "autogen/starknet/external/return/increment/13e3c8024d3012a81a9124b680cd43b23ca5867984f22715079ad99875a01901.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 15,
-                                "end_line": 70,
+                                "end_line": 68,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "start_col": 6,
-                                "start_line": 70
+                                "start_line": 68
                             },
                             "While handling return value of"
                         ],
@@ -8269,31 +8270,31 @@
                         "end_col": 35,
                         "end_line": 5,
                         "input_file": {
-                            "filename": "autogen/starknet/external/return/increment/adb54f6bab72175c1c54ee4b1895325ce3bf4b9032bc5a52084ebf756d63d09a.cairo"
+                            "filename": "autogen/starknet/external/return/increment/13e3c8024d3012a81a9124b680cd43b23ca5867984f22715079ad99875a01901.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 15,
-                                "end_line": 70,
+                                "end_line": 68,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 38,
                                         "end_line": 12,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/return/increment/adb54f6bab72175c1c54ee4b1895325ce3bf4b9032bc5a52084ebf756d63d09a.cairo"
+                                            "filename": "autogen/starknet/external/return/increment/13e3c8024d3012a81a9124b680cd43b23ca5867984f22715079ad99875a01901.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 15,
-                                                "end_line": 70,
+                                                "end_line": 68,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 70
+                                                "start_line": 68
                                             },
                                             "While handling return value of"
                                         ],
@@ -8303,7 +8304,7 @@
                                     "While expanding the reference '__return_value_ptr_start' in:"
                                 ],
                                 "start_col": 6,
-                                "start_line": 70
+                                "start_line": 68
                             },
                             "While handling return value of"
                         ],
@@ -8321,20 +8322,20 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 39,
+                        "end_col": 40,
                         "end_line": 12,
                         "input_file": {
-                            "filename": "autogen/starknet/external/return/increment/adb54f6bab72175c1c54ee4b1895325ce3bf4b9032bc5a52084ebf756d63d09a.cairo"
+                            "filename": "autogen/starknet/external/return/increment/13e3c8024d3012a81a9124b680cd43b23ca5867984f22715079ad99875a01901.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 15,
-                                "end_line": 70,
+                                "end_line": 68,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "start_col": 6,
-                                "start_line": 70
+                                "start_line": 68
                             },
                             "While handling return value of"
                         ],
@@ -8352,20 +8353,20 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 57,
+                        "end_col": 58,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/arg_processor/1b562308a65653425ce06491fa4b4539466f3251a07e73e099d0afe86a48900e.cairo"
+                            "filename": "autogen/starknet/arg_processor/01cba52f8515996bb9d7070bde81ff39281d096d7024a558efcba6e1fd2402cf.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 15,
-                                "end_line": 70,
+                                "end_line": 68,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "start_col": 6,
-                                "start_line": 70
+                                "start_line": 68
                             },
                             "While handling calldata of"
                         ],
@@ -8386,31 +8387,31 @@
                         "end_col": 64,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/external/increment/c7060df96cb0acca1380ae43bf758cab727bfdf73cb5d34a93e24a9742817fda.cairo"
+                            "filename": "autogen/starknet/external/increment/b2c52ca2d2a8fc8791a983086d8716c5eacd0c3d62934914d2286f84b98ff4cb.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 35,
-                                "end_line": 70,
+                                "end_col": 34,
+                                "end_line": 68,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 55,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/increment/fbeebf7e6c5edbed844bfa3456de063adfe5b9764cf84d51277f2022272aca40.cairo"
+                                            "filename": "autogen/starknet/external/increment/697ccb2f083dcbc909723b561a4e2c7f280c20a475a93b120cff6d9c6c6b6d62.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 15,
-                                                "end_line": 70,
+                                                "end_line": 68,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 70
+                                                "start_line": 68
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -8420,7 +8421,7 @@
                                     "While expanding the reference 'syscall_ptr' in:"
                                 ],
                                 "start_col": 16,
-                                "start_line": 70
+                                "start_line": 68
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -8441,31 +8442,31 @@
                         "end_col": 110,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/external/increment/424b26e79f70343cc02557f1fbd25745138efb26a3dc5c8b593ca765b73138b7.cairo"
+                            "filename": "autogen/starknet/external/increment/9684a85e93c782014ca14293edea4eb2502039a5a7b6538ecd39c56faaf12529.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 64,
-                                "end_line": 70,
+                                "end_col": 62,
+                                "end_line": 68,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 82,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/increment/fbeebf7e6c5edbed844bfa3456de063adfe5b9764cf84d51277f2022272aca40.cairo"
+                                            "filename": "autogen/starknet/external/increment/697ccb2f083dcbc909723b561a4e2c7f280c20a475a93b120cff6d9c6c6b6d62.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 15,
-                                                "end_line": 70,
+                                                "end_line": 68,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 70
+                                                "start_line": 68
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -8474,8 +8475,8 @@
                                     },
                                     "While expanding the reference 'pedersen_ptr' in:"
                                 ],
-                                "start_col": 37,
-                                "start_line": 70
+                                "start_col": 36,
+                                "start_line": 68
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -8496,31 +8497,31 @@
                         "end_col": 67,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/external/increment/e651458745e7cd218121c342e0915890767e2f59ddc2e315b8844ad0f47d582e.cairo"
+                            "filename": "autogen/starknet/external/increment/741ea357d6336b0bed7bf0472425acd0311d543883b803388880e60a232040c7.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 81,
-                                "end_line": 70,
+                                "end_col": 79,
+                                "end_line": 68,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 115,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/increment/fbeebf7e6c5edbed844bfa3456de063adfe5b9764cf84d51277f2022272aca40.cairo"
+                                            "filename": "autogen/starknet/external/increment/697ccb2f083dcbc909723b561a4e2c7f280c20a475a93b120cff6d9c6c6b6d62.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 15,
-                                                "end_line": 70,
+                                                "end_line": 68,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 70
+                                                "start_line": 68
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -8529,8 +8530,8 @@
                                     },
                                     "While expanding the reference 'range_check_ptr' in:"
                                 ],
-                                "start_col": 66,
-                                "start_line": 70
+                                "start_col": 64,
+                                "start_line": 68
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -8549,12 +8550,12 @@
                     "hints": [],
                     "inst": {
                         "end_col": 15,
-                        "end_line": 70,
+                        "end_line": 68,
                         "input_file": {
-                            "filename": "contracts/counter.cairo"
+                            "filename": "counter.cairo"
                         },
                         "start_col": 6,
-                        "start_line": 70
+                        "start_line": 68
                     }
                 },
                 "267": {
@@ -8570,31 +8571,31 @@
                         "end_col": 115,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/external/increment/fbeebf7e6c5edbed844bfa3456de063adfe5b9764cf84d51277f2022272aca40.cairo"
+                            "filename": "autogen/starknet/external/increment/697ccb2f083dcbc909723b561a4e2c7f280c20a475a93b120cff6d9c6c6b6d62.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 15,
-                                "end_line": 70,
+                                "end_line": 68,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 98,
                                         "end_line": 2,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/increment/fbeebf7e6c5edbed844bfa3456de063adfe5b9764cf84d51277f2022272aca40.cairo"
+                                            "filename": "autogen/starknet/external/increment/697ccb2f083dcbc909723b561a4e2c7f280c20a475a93b120cff6d9c6c6b6d62.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 15,
-                                                "end_line": 70,
+                                                "end_line": 68,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 70
+                                                "start_line": 68
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -8604,7 +8605,7 @@
                                     "While expanding the reference 'range_check_ptr' in:"
                                 ],
                                 "start_col": 6,
-                                "start_line": 70
+                                "start_line": 68
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -8625,17 +8626,17 @@
                         "end_col": 99,
                         "end_line": 2,
                         "input_file": {
-                            "filename": "autogen/starknet/external/increment/fbeebf7e6c5edbed844bfa3456de063adfe5b9764cf84d51277f2022272aca40.cairo"
+                            "filename": "autogen/starknet/external/increment/697ccb2f083dcbc909723b561a4e2c7f280c20a475a93b120cff6d9c6c6b6d62.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 15,
-                                "end_line": 70,
+                                "end_line": 68,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "start_col": 6,
-                                "start_line": 70
+                                "start_line": 68
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -8656,31 +8657,31 @@
                         "end_col": 55,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/external/increment/fbeebf7e6c5edbed844bfa3456de063adfe5b9764cf84d51277f2022272aca40.cairo"
+                            "filename": "autogen/starknet/external/increment/697ccb2f083dcbc909723b561a4e2c7f280c20a475a93b120cff6d9c6c6b6d62.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 15,
-                                "end_line": 70,
+                                "end_line": 68,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 20,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/increment/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo"
+                                            "filename": "autogen/starknet/external/increment/da17921a4e81c09e730800bbf23bfdbe5e9e6bfaedc59d80fbf62087fa43c27d.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 15,
-                                                "end_line": 70,
+                                                "end_line": 68,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 70
+                                                "start_line": 68
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -8690,7 +8691,7 @@
                                     "While expanding the reference 'syscall_ptr' in:"
                                 ],
                                 "start_col": 6,
-                                "start_line": 70
+                                "start_line": 68
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -8711,31 +8712,31 @@
                         "end_col": 82,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/external/increment/fbeebf7e6c5edbed844bfa3456de063adfe5b9764cf84d51277f2022272aca40.cairo"
+                            "filename": "autogen/starknet/external/increment/697ccb2f083dcbc909723b561a4e2c7f280c20a475a93b120cff6d9c6c6b6d62.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 15,
-                                "end_line": 70,
+                                "end_line": 68,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 33,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/increment/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo"
+                                            "filename": "autogen/starknet/external/increment/da17921a4e81c09e730800bbf23bfdbe5e9e6bfaedc59d80fbf62087fa43c27d.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 15,
-                                                "end_line": 70,
+                                                "end_line": 68,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 70
+                                                "start_line": 68
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -8745,7 +8746,7 @@
                                     "While expanding the reference 'pedersen_ptr' in:"
                                 ],
                                 "start_col": 6,
-                                "start_line": 70
+                                "start_line": 68
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -8766,31 +8767,31 @@
                         "end_col": 21,
                         "end_line": 2,
                         "input_file": {
-                            "filename": "autogen/starknet/external/increment/fbeebf7e6c5edbed844bfa3456de063adfe5b9764cf84d51277f2022272aca40.cairo"
+                            "filename": "autogen/starknet/external/increment/697ccb2f083dcbc909723b561a4e2c7f280c20a475a93b120cff6d9c6c6b6d62.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 15,
-                                "end_line": 70,
+                                "end_line": 68,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 49,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/increment/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo"
+                                            "filename": "autogen/starknet/external/increment/da17921a4e81c09e730800bbf23bfdbe5e9e6bfaedc59d80fbf62087fa43c27d.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 15,
-                                                "end_line": 70,
+                                                "end_line": 68,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 70
+                                                "start_line": 68
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -8800,7 +8801,7 @@
                                     "While expanding the reference 'range_check_ptr' in:"
                                 ],
                                 "start_col": 6,
-                                "start_line": 70
+                                "start_line": 68
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -8821,31 +8822,31 @@
                         "end_col": 35,
                         "end_line": 2,
                         "input_file": {
-                            "filename": "autogen/starknet/external/increment/fbeebf7e6c5edbed844bfa3456de063adfe5b9764cf84d51277f2022272aca40.cairo"
+                            "filename": "autogen/starknet/external/increment/697ccb2f083dcbc909723b561a4e2c7f280c20a475a93b120cff6d9c6c6b6d62.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 15,
-                                "end_line": 70,
+                                "end_line": 68,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 62,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/increment/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo"
+                                            "filename": "autogen/starknet/external/increment/da17921a4e81c09e730800bbf23bfdbe5e9e6bfaedc59d80fbf62087fa43c27d.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 15,
-                                                "end_line": 70,
+                                                "end_line": 68,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 70
+                                                "start_line": 68
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -8855,7 +8856,7 @@
                                     "While expanding the reference 'retdata_size' in:"
                                 ],
                                 "start_col": 6,
-                                "start_line": 70
+                                "start_line": 68
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -8876,31 +8877,31 @@
                         "end_col": 44,
                         "end_line": 2,
                         "input_file": {
-                            "filename": "autogen/starknet/external/increment/fbeebf7e6c5edbed844bfa3456de063adfe5b9764cf84d51277f2022272aca40.cairo"
+                            "filename": "autogen/starknet/external/increment/697ccb2f083dcbc909723b561a4e2c7f280c20a475a93b120cff6d9c6c6b6d62.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 15,
-                                "end_line": 70,
+                                "end_line": 68,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 70,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/increment/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo"
+                                            "filename": "autogen/starknet/external/increment/da17921a4e81c09e730800bbf23bfdbe5e9e6bfaedc59d80fbf62087fa43c27d.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 15,
-                                                "end_line": 70,
+                                                "end_line": 68,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 70
+                                                "start_line": 68
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -8910,7 +8911,7 @@
                                     "While expanding the reference 'retdata' in:"
                                 ],
                                 "start_col": 6,
-                                "start_line": 70
+                                "start_line": 68
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -8928,20 +8929,20 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 71,
+                        "end_col": 72,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/external/increment/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo"
+                            "filename": "autogen/starknet/external/increment/da17921a4e81c09e730800bbf23bfdbe5e9e6bfaedc59d80fbf62087fa43c27d.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 15,
-                                "end_line": 70,
+                                "end_line": 68,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "start_col": 6,
-                                "start_line": 70
+                                "start_line": 68
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -8958,14 +8959,14 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 35,
-                        "end_line": 82,
+                        "end_col": 34,
+                        "end_line": 78,
                         "input_file": {
-                            "filename": "contracts/counter.cairo"
+                            "filename": "counter.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 34,
+                                "end_col": 33,
                                 "end_line": 13,
                                 "input_file": {
                                     "filename": "autogen/starknet/storage_var/counter/decl.cairo"
@@ -8973,12 +8974,12 @@
                                 "parent_location": [
                                     {
                                         "end_col": 33,
-                                        "end_line": 85,
+                                        "end_line": 79,
                                         "input_file": {
-                                            "filename": "contracts/counter.cairo"
+                                            "filename": "counter.cairo"
                                         },
                                         "start_col": 19,
-                                        "start_line": 85
+                                        "start_line": 79
                                     },
                                     "While trying to retrieve the implicit argument 'syscall_ptr' in:"
                                 ],
@@ -8988,7 +8989,7 @@
                             "While expanding the reference 'syscall_ptr' in:"
                         ],
                         "start_col": 16,
-                        "start_line": 82
+                        "start_line": 78
                     }
                 },
                 "277": {
@@ -9000,14 +9001,14 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 64,
-                        "end_line": 82,
+                        "end_col": 62,
+                        "end_line": 78,
                         "input_file": {
-                            "filename": "contracts/counter.cairo"
+                            "filename": "counter.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 63,
+                                "end_col": 61,
                                 "end_line": 13,
                                 "input_file": {
                                     "filename": "autogen/starknet/storage_var/counter/decl.cairo"
@@ -9015,22 +9016,22 @@
                                 "parent_location": [
                                     {
                                         "end_col": 33,
-                                        "end_line": 85,
+                                        "end_line": 79,
                                         "input_file": {
-                                            "filename": "contracts/counter.cairo"
+                                            "filename": "counter.cairo"
                                         },
                                         "start_col": 19,
-                                        "start_line": 85
+                                        "start_line": 79
                                     },
                                     "While trying to retrieve the implicit argument 'pedersen_ptr' in:"
                                 ],
-                                "start_col": 36,
+                                "start_col": 35,
                                 "start_line": 13
                             },
                             "While expanding the reference 'pedersen_ptr' in:"
                         ],
-                        "start_col": 37,
-                        "start_line": 82
+                        "start_col": 36,
+                        "start_line": 78
                     }
                 },
                 "278": {
@@ -9042,14 +9043,14 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 81,
-                        "end_line": 82,
+                        "end_col": 79,
+                        "end_line": 78,
                         "input_file": {
-                            "filename": "contracts/counter.cairo"
+                            "filename": "counter.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 80,
+                                "end_col": 78,
                                 "end_line": 13,
                                 "input_file": {
                                     "filename": "autogen/starknet/storage_var/counter/decl.cairo"
@@ -9057,22 +9058,22 @@
                                 "parent_location": [
                                     {
                                         "end_col": 33,
-                                        "end_line": 85,
+                                        "end_line": 79,
                                         "input_file": {
-                                            "filename": "contracts/counter.cairo"
+                                            "filename": "counter.cairo"
                                         },
                                         "start_col": 19,
-                                        "start_line": 85
+                                        "start_line": 79
                                     },
                                     "While trying to retrieve the implicit argument 'range_check_ptr' in:"
                                 ],
-                                "start_col": 65,
+                                "start_col": 63,
                                 "start_line": 13
                             },
                             "While expanding the reference 'range_check_ptr' in:"
                         ],
-                        "start_col": 66,
-                        "start_line": 82
+                        "start_col": 64,
+                        "start_line": 78
                     }
                 },
                 "279": {
@@ -9085,12 +9086,12 @@
                     "hints": [],
                     "inst": {
                         "end_col": 33,
-                        "end_line": 85,
+                        "end_line": 79,
                         "input_file": {
-                            "filename": "contracts/counter.cairo"
+                            "filename": "counter.cairo"
                         },
                         "start_col": 19,
-                        "start_line": 85
+                        "start_line": 79
                     }
                 },
                 "281": {
@@ -9103,12 +9104,12 @@
                     "hints": [],
                     "inst": {
                         "end_col": 27,
-                        "end_line": 86,
+                        "end_line": 80,
                         "input_file": {
-                            "filename": "contracts/counter.cairo"
+                            "filename": "counter.cairo"
                         },
                         "start_col": 5,
-                        "start_line": 86
+                        "start_line": 80
                     }
                 },
                 "283": {
@@ -9120,7 +9121,7 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 34,
+                        "end_col": 33,
                         "end_line": 13,
                         "input_file": {
                             "filename": "autogen/starknet/storage_var/counter/decl.cairo"
@@ -9128,36 +9129,36 @@
                         "parent_location": [
                             {
                                 "end_col": 33,
-                                "end_line": 85,
+                                "end_line": 79,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
-                                        "end_col": 35,
-                                        "end_line": 21,
+                                        "end_col": 34,
+                                        "end_line": 19,
                                         "input_file": {
                                             "filename": "autogen/starknet/storage_var/counter/decl.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 29,
-                                                "end_line": 88,
+                                                "end_line": 82,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "start_col": 5,
-                                                "start_line": 88
+                                                "start_line": 82
                                             },
                                             "While trying to retrieve the implicit argument 'syscall_ptr' in:"
                                         ],
                                         "start_col": 16,
-                                        "start_line": 21
+                                        "start_line": 19
                                     },
                                     "While expanding the reference 'syscall_ptr' in:"
                                 ],
                                 "start_col": 19,
-                                "start_line": 85
+                                "start_line": 79
                             },
                             "While trying to update the implicit return value 'syscall_ptr' in:"
                         ],
@@ -9174,7 +9175,7 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 63,
+                        "end_col": 61,
                         "end_line": 13,
                         "input_file": {
                             "filename": "autogen/starknet/storage_var/counter/decl.cairo"
@@ -9182,40 +9183,40 @@
                         "parent_location": [
                             {
                                 "end_col": 33,
-                                "end_line": 85,
+                                "end_line": 79,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
-                                        "end_col": 64,
-                                        "end_line": 21,
+                                        "end_col": 62,
+                                        "end_line": 19,
                                         "input_file": {
                                             "filename": "autogen/starknet/storage_var/counter/decl.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 29,
-                                                "end_line": 88,
+                                                "end_line": 82,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "start_col": 5,
-                                                "start_line": 88
+                                                "start_line": 82
                                             },
                                             "While trying to retrieve the implicit argument 'pedersen_ptr' in:"
                                         ],
-                                        "start_col": 37,
-                                        "start_line": 21
+                                        "start_col": 36,
+                                        "start_line": 19
                                     },
                                     "While expanding the reference 'pedersen_ptr' in:"
                                 ],
                                 "start_col": 19,
-                                "start_line": 85
+                                "start_line": 79
                             },
                             "While trying to update the implicit return value 'pedersen_ptr' in:"
                         ],
-                        "start_col": 36,
+                        "start_col": 35,
                         "start_line": 13
                     }
                 },
@@ -9228,7 +9229,7 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 80,
+                        "end_col": 78,
                         "end_line": 13,
                         "input_file": {
                             "filename": "autogen/starknet/storage_var/counter/decl.cairo"
@@ -9236,40 +9237,40 @@
                         "parent_location": [
                             {
                                 "end_col": 33,
-                                "end_line": 85,
+                                "end_line": 79,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
-                                        "end_col": 81,
-                                        "end_line": 21,
+                                        "end_col": 79,
+                                        "end_line": 19,
                                         "input_file": {
                                             "filename": "autogen/starknet/storage_var/counter/decl.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 29,
-                                                "end_line": 88,
+                                                "end_line": 82,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "start_col": 5,
-                                                "start_line": 88
+                                                "start_line": 82
                                             },
                                             "While trying to retrieve the implicit argument 'range_check_ptr' in:"
                                         ],
-                                        "start_col": 66,
-                                        "start_line": 21
+                                        "start_col": 64,
+                                        "start_line": 19
                                     },
                                     "While expanding the reference 'range_check_ptr' in:"
                                 ],
                                 "start_col": 19,
-                                "start_line": 85
+                                "start_line": 79
                             },
                             "While trying to update the implicit return value 'range_check_ptr' in:"
                         ],
-                        "start_col": 65,
+                        "start_col": 63,
                         "start_line": 13
                     }
                 },
@@ -9283,12 +9284,12 @@
                     "hints": [],
                     "inst": {
                         "end_col": 28,
-                        "end_line": 88,
+                        "end_line": 82,
                         "input_file": {
-                            "filename": "contracts/counter.cairo"
+                            "filename": "counter.cairo"
                         },
                         "start_col": 19,
-                        "start_line": 88
+                        "start_line": 82
                     }
                 },
                 "288": {
@@ -9301,12 +9302,12 @@
                     "hints": [],
                     "inst": {
                         "end_col": 29,
-                        "end_line": 88,
+                        "end_line": 82,
                         "input_file": {
-                            "filename": "contracts/counter.cairo"
+                            "filename": "counter.cairo"
                         },
                         "start_col": 5,
-                        "start_line": 88
+                        "start_line": 82
                     }
                 },
                 "290": {
@@ -9319,12 +9320,12 @@
                     "hints": [],
                     "inst": {
                         "end_col": 37,
-                        "end_line": 90,
+                        "end_line": 84,
                         "input_file": {
-                            "filename": "contracts/counter.cairo"
+                            "filename": "counter.cairo"
                         },
                         "start_col": 23,
-                        "start_line": 90
+                        "start_line": 84
                     }
                 },
                 "292": {
@@ -9336,13 +9337,13 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 29,
-                        "end_line": 92,
+                        "end_col": 30,
+                        "end_line": 86,
                         "input_file": {
-                            "filename": "contracts/counter.cairo"
+                            "filename": "counter.cairo"
                         },
                         "start_col": 5,
-                        "start_line": 92
+                        "start_line": 86
                     }
                 },
                 "293": {
@@ -9359,17 +9360,17 @@
                                 "end_col": 38,
                                 "end_line": 3,
                                 "input_file": {
-                                    "filename": "autogen/starknet/external/return/decrement/90f94e6e93a262d25fecd194da011329bc24f5eabb48944f4db091a13c4e5366.cairo"
+                                    "filename": "autogen/starknet/external/return/decrement/9e681566f958be84ac78ad84746d06429698093804cb0e114f18399e5dccba8e.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 15,
-                                        "end_line": 82,
+                                        "end_line": 78,
                                         "input_file": {
-                                            "filename": "contracts/counter.cairo"
+                                            "filename": "counter.cairo"
                                         },
                                         "start_col": 6,
-                                        "start_line": 82
+                                        "start_line": 78
                                     },
                                     "While handling return value of"
                                 ],
@@ -9380,20 +9381,20 @@
                         }
                     ],
                     "inst": {
-                        "end_col": 17,
+                        "end_col": 18,
                         "end_line": 4,
                         "input_file": {
-                            "filename": "autogen/starknet/external/return/decrement/90f94e6e93a262d25fecd194da011329bc24f5eabb48944f4db091a13c4e5366.cairo"
+                            "filename": "autogen/starknet/external/return/decrement/9e681566f958be84ac78ad84746d06429698093804cb0e114f18399e5dccba8e.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 15,
-                                "end_line": 82,
+                                "end_line": 78,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "start_col": 6,
-                                "start_line": 82
+                                "start_line": 78
                             },
                             "While handling return value of"
                         ],
@@ -9411,20 +9412,20 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 46,
+                        "end_col": 47,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/arg_processor/0e9d4c974a6b6ace74b8b3274b87fad1f5800d4af46cff21a4b9883e1a1b0574.cairo"
+                            "filename": "autogen/starknet/arg_processor/95d2b1ea3726b72b3719bdfa0a12258ccf662f010c27f42865683ec83f32a1c9.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 17,
-                                "end_line": 83,
+                                "end_col": 98,
+                                "end_line": 78,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
-                                "start_col": 5,
-                                "start_line": 83
+                                "start_col": 87,
+                                "start_line": 78
                             },
                             "While handling return value 'count'"
                         ],
@@ -9445,31 +9446,31 @@
                         "end_col": 48,
                         "end_line": 2,
                         "input_file": {
-                            "filename": "autogen/starknet/arg_processor/0e9d4c974a6b6ace74b8b3274b87fad1f5800d4af46cff21a4b9883e1a1b0574.cairo"
+                            "filename": "autogen/starknet/arg_processor/95d2b1ea3726b72b3719bdfa0a12258ccf662f010c27f42865683ec83f32a1c9.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 17,
-                                "end_line": 83,
+                                "end_col": 98,
+                                "end_line": 78,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 36,
                                         "end_line": 11,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/return/decrement/90f94e6e93a262d25fecd194da011329bc24f5eabb48944f4db091a13c4e5366.cairo"
+                                            "filename": "autogen/starknet/external/return/decrement/9e681566f958be84ac78ad84746d06429698093804cb0e114f18399e5dccba8e.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 15,
-                                                "end_line": 82,
+                                                "end_line": 78,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 82
+                                                "start_line": 78
                                             },
                                             "While handling return value of"
                                         ],
@@ -9478,8 +9479,8 @@
                                     },
                                     "While expanding the reference '__return_value_ptr' in:"
                                 ],
-                                "start_col": 5,
-                                "start_line": 83
+                                "start_col": 87,
+                                "start_line": 78
                             },
                             "While handling return value 'count'"
                         ],
@@ -9497,34 +9498,34 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 73,
+                        "end_col": 71,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/external/return/decrement/90f94e6e93a262d25fecd194da011329bc24f5eabb48944f4db091a13c4e5366.cairo"
+                            "filename": "autogen/starknet/external/return/decrement/9e681566f958be84ac78ad84746d06429698093804cb0e114f18399e5dccba8e.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 15,
-                                "end_line": 82,
+                                "end_line": 78,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 40,
                                         "end_line": 10,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/return/decrement/90f94e6e93a262d25fecd194da011329bc24f5eabb48944f4db091a13c4e5366.cairo"
+                                            "filename": "autogen/starknet/external/return/decrement/9e681566f958be84ac78ad84746d06429698093804cb0e114f18399e5dccba8e.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 15,
-                                                "end_line": 82,
+                                                "end_line": 78,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 82
+                                                "start_line": 78
                                             },
                                             "While handling return value of"
                                         ],
@@ -9534,11 +9535,11 @@
                                     "While expanding the reference 'range_check_ptr' in:"
                                 ],
                                 "start_col": 6,
-                                "start_line": 82
+                                "start_line": 78
                             },
                             "While handling return value of"
                         ],
-                        "start_col": 58,
+                        "start_col": 56,
                         "start_line": 1
                     }
                 },
@@ -9555,17 +9556,17 @@
                         "end_col": 63,
                         "end_line": 11,
                         "input_file": {
-                            "filename": "autogen/starknet/external/return/decrement/90f94e6e93a262d25fecd194da011329bc24f5eabb48944f4db091a13c4e5366.cairo"
+                            "filename": "autogen/starknet/external/return/decrement/9e681566f958be84ac78ad84746d06429698093804cb0e114f18399e5dccba8e.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 15,
-                                "end_line": 82,
+                                "end_line": 78,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "start_col": 6,
-                                "start_line": 82
+                                "start_line": 78
                             },
                             "While handling return value of"
                         ],
@@ -9586,31 +9587,31 @@
                         "end_col": 35,
                         "end_line": 5,
                         "input_file": {
-                            "filename": "autogen/starknet/external/return/decrement/90f94e6e93a262d25fecd194da011329bc24f5eabb48944f4db091a13c4e5366.cairo"
+                            "filename": "autogen/starknet/external/return/decrement/9e681566f958be84ac78ad84746d06429698093804cb0e114f18399e5dccba8e.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 15,
-                                "end_line": 82,
+                                "end_line": 78,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 38,
                                         "end_line": 12,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/return/decrement/90f94e6e93a262d25fecd194da011329bc24f5eabb48944f4db091a13c4e5366.cairo"
+                                            "filename": "autogen/starknet/external/return/decrement/9e681566f958be84ac78ad84746d06429698093804cb0e114f18399e5dccba8e.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 15,
-                                                "end_line": 82,
+                                                "end_line": 78,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 82
+                                                "start_line": 78
                                             },
                                             "While handling return value of"
                                         ],
@@ -9620,7 +9621,7 @@
                                     "While expanding the reference '__return_value_ptr_start' in:"
                                 ],
                                 "start_col": 6,
-                                "start_line": 82
+                                "start_line": 78
                             },
                             "While handling return value of"
                         ],
@@ -9638,20 +9639,20 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 39,
+                        "end_col": 40,
                         "end_line": 12,
                         "input_file": {
-                            "filename": "autogen/starknet/external/return/decrement/90f94e6e93a262d25fecd194da011329bc24f5eabb48944f4db091a13c4e5366.cairo"
+                            "filename": "autogen/starknet/external/return/decrement/9e681566f958be84ac78ad84746d06429698093804cb0e114f18399e5dccba8e.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 15,
-                                "end_line": 82,
+                                "end_line": 78,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "start_col": 6,
-                                "start_line": 82
+                                "start_line": 78
                             },
                             "While handling return value of"
                         ],
@@ -9669,20 +9670,20 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 57,
+                        "end_col": 58,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/arg_processor/1b562308a65653425ce06491fa4b4539466f3251a07e73e099d0afe86a48900e.cairo"
+                            "filename": "autogen/starknet/arg_processor/01cba52f8515996bb9d7070bde81ff39281d096d7024a558efcba6e1fd2402cf.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 15,
-                                "end_line": 82,
+                                "end_line": 78,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "start_col": 6,
-                                "start_line": 82
+                                "start_line": 78
                             },
                             "While handling calldata of"
                         ],
@@ -9703,31 +9704,31 @@
                         "end_col": 64,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/external/decrement/c7060df96cb0acca1380ae43bf758cab727bfdf73cb5d34a93e24a9742817fda.cairo"
+                            "filename": "autogen/starknet/external/decrement/b2c52ca2d2a8fc8791a983086d8716c5eacd0c3d62934914d2286f84b98ff4cb.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 35,
-                                "end_line": 82,
+                                "end_col": 34,
+                                "end_line": 78,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 55,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/decrement/58b175dbe66406ba3118784bf312a6131e4de96f0bac6e7c3bd3a7617ae5dc2f.cairo"
+                                            "filename": "autogen/starknet/external/decrement/a716bcdc5921c838874dce3287d2988ac85ceac2c928df9be07d5e9a5cd28ad3.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 15,
-                                                "end_line": 82,
+                                                "end_line": 78,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 82
+                                                "start_line": 78
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -9737,7 +9738,7 @@
                                     "While expanding the reference 'syscall_ptr' in:"
                                 ],
                                 "start_col": 16,
-                                "start_line": 82
+                                "start_line": 78
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -9758,31 +9759,31 @@
                         "end_col": 110,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/external/decrement/424b26e79f70343cc02557f1fbd25745138efb26a3dc5c8b593ca765b73138b7.cairo"
+                            "filename": "autogen/starknet/external/decrement/9684a85e93c782014ca14293edea4eb2502039a5a7b6538ecd39c56faaf12529.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 64,
-                                "end_line": 82,
+                                "end_col": 62,
+                                "end_line": 78,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 82,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/decrement/58b175dbe66406ba3118784bf312a6131e4de96f0bac6e7c3bd3a7617ae5dc2f.cairo"
+                                            "filename": "autogen/starknet/external/decrement/a716bcdc5921c838874dce3287d2988ac85ceac2c928df9be07d5e9a5cd28ad3.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 15,
-                                                "end_line": 82,
+                                                "end_line": 78,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 82
+                                                "start_line": 78
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -9791,8 +9792,8 @@
                                     },
                                     "While expanding the reference 'pedersen_ptr' in:"
                                 ],
-                                "start_col": 37,
-                                "start_line": 82
+                                "start_col": 36,
+                                "start_line": 78
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -9813,31 +9814,31 @@
                         "end_col": 67,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/external/decrement/e651458745e7cd218121c342e0915890767e2f59ddc2e315b8844ad0f47d582e.cairo"
+                            "filename": "autogen/starknet/external/decrement/741ea357d6336b0bed7bf0472425acd0311d543883b803388880e60a232040c7.cairo"
                         },
                         "parent_location": [
                             {
-                                "end_col": 81,
-                                "end_line": 82,
+                                "end_col": 79,
+                                "end_line": 78,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 115,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/decrement/58b175dbe66406ba3118784bf312a6131e4de96f0bac6e7c3bd3a7617ae5dc2f.cairo"
+                                            "filename": "autogen/starknet/external/decrement/a716bcdc5921c838874dce3287d2988ac85ceac2c928df9be07d5e9a5cd28ad3.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 15,
-                                                "end_line": 82,
+                                                "end_line": 78,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 82
+                                                "start_line": 78
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -9846,8 +9847,8 @@
                                     },
                                     "While expanding the reference 'range_check_ptr' in:"
                                 ],
-                                "start_col": 66,
-                                "start_line": 82
+                                "start_col": 64,
+                                "start_line": 78
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -9866,12 +9867,12 @@
                     "hints": [],
                     "inst": {
                         "end_col": 15,
-                        "end_line": 82,
+                        "end_line": 78,
                         "input_file": {
-                            "filename": "contracts/counter.cairo"
+                            "filename": "counter.cairo"
                         },
                         "start_col": 6,
-                        "start_line": 82
+                        "start_line": 78
                     }
                 },
                 "308": {
@@ -9887,31 +9888,31 @@
                         "end_col": 115,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/external/decrement/58b175dbe66406ba3118784bf312a6131e4de96f0bac6e7c3bd3a7617ae5dc2f.cairo"
+                            "filename": "autogen/starknet/external/decrement/a716bcdc5921c838874dce3287d2988ac85ceac2c928df9be07d5e9a5cd28ad3.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 15,
-                                "end_line": 82,
+                                "end_line": 78,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 98,
                                         "end_line": 2,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/decrement/58b175dbe66406ba3118784bf312a6131e4de96f0bac6e7c3bd3a7617ae5dc2f.cairo"
+                                            "filename": "autogen/starknet/external/decrement/a716bcdc5921c838874dce3287d2988ac85ceac2c928df9be07d5e9a5cd28ad3.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 15,
-                                                "end_line": 82,
+                                                "end_line": 78,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 82
+                                                "start_line": 78
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -9921,7 +9922,7 @@
                                     "While expanding the reference 'range_check_ptr' in:"
                                 ],
                                 "start_col": 6,
-                                "start_line": 82
+                                "start_line": 78
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -9942,17 +9943,17 @@
                         "end_col": 99,
                         "end_line": 2,
                         "input_file": {
-                            "filename": "autogen/starknet/external/decrement/58b175dbe66406ba3118784bf312a6131e4de96f0bac6e7c3bd3a7617ae5dc2f.cairo"
+                            "filename": "autogen/starknet/external/decrement/a716bcdc5921c838874dce3287d2988ac85ceac2c928df9be07d5e9a5cd28ad3.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 15,
-                                "end_line": 82,
+                                "end_line": 78,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "start_col": 6,
-                                "start_line": 82
+                                "start_line": 78
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -9973,31 +9974,31 @@
                         "end_col": 55,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/external/decrement/58b175dbe66406ba3118784bf312a6131e4de96f0bac6e7c3bd3a7617ae5dc2f.cairo"
+                            "filename": "autogen/starknet/external/decrement/a716bcdc5921c838874dce3287d2988ac85ceac2c928df9be07d5e9a5cd28ad3.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 15,
-                                "end_line": 82,
+                                "end_line": 78,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 20,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/decrement/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo"
+                                            "filename": "autogen/starknet/external/decrement/da17921a4e81c09e730800bbf23bfdbe5e9e6bfaedc59d80fbf62087fa43c27d.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 15,
-                                                "end_line": 82,
+                                                "end_line": 78,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 82
+                                                "start_line": 78
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -10007,7 +10008,7 @@
                                     "While expanding the reference 'syscall_ptr' in:"
                                 ],
                                 "start_col": 6,
-                                "start_line": 82
+                                "start_line": 78
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -10028,31 +10029,31 @@
                         "end_col": 82,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/external/decrement/58b175dbe66406ba3118784bf312a6131e4de96f0bac6e7c3bd3a7617ae5dc2f.cairo"
+                            "filename": "autogen/starknet/external/decrement/a716bcdc5921c838874dce3287d2988ac85ceac2c928df9be07d5e9a5cd28ad3.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 15,
-                                "end_line": 82,
+                                "end_line": 78,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 33,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/decrement/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo"
+                                            "filename": "autogen/starknet/external/decrement/da17921a4e81c09e730800bbf23bfdbe5e9e6bfaedc59d80fbf62087fa43c27d.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 15,
-                                                "end_line": 82,
+                                                "end_line": 78,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 82
+                                                "start_line": 78
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -10062,7 +10063,7 @@
                                     "While expanding the reference 'pedersen_ptr' in:"
                                 ],
                                 "start_col": 6,
-                                "start_line": 82
+                                "start_line": 78
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -10083,31 +10084,31 @@
                         "end_col": 21,
                         "end_line": 2,
                         "input_file": {
-                            "filename": "autogen/starknet/external/decrement/58b175dbe66406ba3118784bf312a6131e4de96f0bac6e7c3bd3a7617ae5dc2f.cairo"
+                            "filename": "autogen/starknet/external/decrement/a716bcdc5921c838874dce3287d2988ac85ceac2c928df9be07d5e9a5cd28ad3.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 15,
-                                "end_line": 82,
+                                "end_line": 78,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 49,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/decrement/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo"
+                                            "filename": "autogen/starknet/external/decrement/da17921a4e81c09e730800bbf23bfdbe5e9e6bfaedc59d80fbf62087fa43c27d.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 15,
-                                                "end_line": 82,
+                                                "end_line": 78,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 82
+                                                "start_line": 78
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -10117,7 +10118,7 @@
                                     "While expanding the reference 'range_check_ptr' in:"
                                 ],
                                 "start_col": 6,
-                                "start_line": 82
+                                "start_line": 78
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -10138,31 +10139,31 @@
                         "end_col": 35,
                         "end_line": 2,
                         "input_file": {
-                            "filename": "autogen/starknet/external/decrement/58b175dbe66406ba3118784bf312a6131e4de96f0bac6e7c3bd3a7617ae5dc2f.cairo"
+                            "filename": "autogen/starknet/external/decrement/a716bcdc5921c838874dce3287d2988ac85ceac2c928df9be07d5e9a5cd28ad3.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 15,
-                                "end_line": 82,
+                                "end_line": 78,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 62,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/decrement/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo"
+                                            "filename": "autogen/starknet/external/decrement/da17921a4e81c09e730800bbf23bfdbe5e9e6bfaedc59d80fbf62087fa43c27d.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 15,
-                                                "end_line": 82,
+                                                "end_line": 78,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 82
+                                                "start_line": 78
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -10172,7 +10173,7 @@
                                     "While expanding the reference 'retdata_size' in:"
                                 ],
                                 "start_col": 6,
-                                "start_line": 82
+                                "start_line": 78
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -10193,31 +10194,31 @@
                         "end_col": 44,
                         "end_line": 2,
                         "input_file": {
-                            "filename": "autogen/starknet/external/decrement/58b175dbe66406ba3118784bf312a6131e4de96f0bac6e7c3bd3a7617ae5dc2f.cairo"
+                            "filename": "autogen/starknet/external/decrement/a716bcdc5921c838874dce3287d2988ac85ceac2c928df9be07d5e9a5cd28ad3.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 15,
-                                "end_line": 82,
+                                "end_line": 78,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "parent_location": [
                                     {
                                         "end_col": 70,
                                         "end_line": 1,
                                         "input_file": {
-                                            "filename": "autogen/starknet/external/decrement/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo"
+                                            "filename": "autogen/starknet/external/decrement/da17921a4e81c09e730800bbf23bfdbe5e9e6bfaedc59d80fbf62087fa43c27d.cairo"
                                         },
                                         "parent_location": [
                                             {
                                                 "end_col": 15,
-                                                "end_line": 82,
+                                                "end_line": 78,
                                                 "input_file": {
-                                                    "filename": "contracts/counter.cairo"
+                                                    "filename": "counter.cairo"
                                                 },
                                                 "start_col": 6,
-                                                "start_line": 82
+                                                "start_line": 78
                                             },
                                             "While constructing the external wrapper for:"
                                         ],
@@ -10227,7 +10228,7 @@
                                     "While expanding the reference 'retdata' in:"
                                 ],
                                 "start_col": 6,
-                                "start_line": 82
+                                "start_line": 78
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -10245,20 +10246,20 @@
                     "flow_tracking_data": null,
                     "hints": [],
                     "inst": {
-                        "end_col": 71,
+                        "end_col": 72,
                         "end_line": 1,
                         "input_file": {
-                            "filename": "autogen/starknet/external/decrement/4ba2b119ceb30fe10f4cca3c9d73ef620c0fb5eece91b99a99d71217bba1001c.cairo"
+                            "filename": "autogen/starknet/external/decrement/da17921a4e81c09e730800bbf23bfdbe5e9e6bfaedc59d80fbf62087fa43c27d.cairo"
                         },
                         "parent_location": [
                             {
                                 "end_col": 15,
-                                "end_line": 82,
+                                "end_line": 78,
                                 "input_file": {
-                                    "filename": "contracts/counter.cairo"
+                                    "filename": "counter.cairo"
                                 },
                                 "start_col": 6,
-                                "start_line": 82
+                                "start_line": 78
                             },
                             "While constructing the external wrapper for:"
                         ],
@@ -10593,7 +10594,7 @@
                 "type": "struct"
             },
             "__main__.counter.addr.Return": {
-                "cairo_type": "(res : felt)",
+                "cairo_type": "(res: felt)",
                 "type": "type_definition"
             },
             "__main__.counter.addr.SIZEOF_LOCALS": {
@@ -10639,7 +10640,7 @@
                 "type": "struct"
             },
             "__main__.counter.read.Return": {
-                "cairo_type": "(count : felt)",
+                "cairo_type": "(count: felt)",
                 "type": "type_definition"
             },
             "__main__.counter.read.SIZEOF_LOCALS": {
@@ -10730,7 +10731,7 @@
                 "type": "struct"
             },
             "__main__.decrement.Return": {
-                "cairo_type": "(count : felt)",
+                "cairo_type": "(count: felt)",
                 "type": "type_definition"
             },
             "__main__.decrement.SIZEOF_LOCALS": {
@@ -10774,7 +10775,7 @@
                 "type": "struct"
             },
             "__main__.get_count.Return": {
-                "cairo_type": "(count : felt)",
+                "cairo_type": "(count: felt)",
                 "type": "type_definition"
             },
             "__main__.get_count.SIZEOF_LOCALS": {
@@ -10814,7 +10815,7 @@
                 "type": "struct"
             },
             "__main__.get_rand.Return": {
-                "cairo_type": "(val : felt)",
+                "cairo_type": "(val: felt)",
                 "type": "type_definition"
             },
             "__main__.get_rand.SIZEOF_LOCALS": {
@@ -10858,7 +10859,7 @@
                 "type": "struct"
             },
             "__main__.increment.Return": {
-                "cairo_type": "(count : felt)",
+                "cairo_type": "(count: felt)",
                 "type": "type_definition"
             },
             "__main__.increment.SIZEOF_LOCALS": {
@@ -10919,7 +10920,7 @@
                 "type": "struct"
             },
             "__main__.rand.addr.Return": {
-                "cairo_type": "(res : felt)",
+                "cairo_type": "(res: felt)",
                 "type": "type_definition"
             },
             "__main__.rand.addr.SIZEOF_LOCALS": {
@@ -10965,7 +10966,7 @@
                 "type": "struct"
             },
             "__main__.rand.read.Return": {
-                "cairo_type": "(val : felt)",
+                "cairo_type": "(val: felt)",
                 "type": "type_definition"
             },
             "__main__.rand.read.SIZEOF_LOCALS": {
@@ -11133,7 +11134,7 @@
                 "type": "struct"
             },
             "__wrappers__.constructor.Return": {
-                "cairo_type": "(syscall_ptr : felt*, pedersen_ptr : starkware.cairo.common.cairo_builtins.HashBuiltin*, range_check_ptr : felt, size : felt, retdata : felt*)",
+                "cairo_type": "(syscall_ptr: felt*, pedersen_ptr: starkware.cairo.common.cairo_builtins.HashBuiltin*, range_check_ptr: felt, size: felt, retdata: felt*)",
                 "type": "type_definition"
             },
             "__wrappers__.constructor.SIZEOF_LOCALS": {
@@ -11168,7 +11169,7 @@
                 "type": "struct"
             },
             "__wrappers__.decrement.Return": {
-                "cairo_type": "(syscall_ptr : felt*, pedersen_ptr : starkware.cairo.common.cairo_builtins.HashBuiltin*, range_check_ptr : felt, size : felt, retdata : felt*)",
+                "cairo_type": "(syscall_ptr: felt*, pedersen_ptr: starkware.cairo.common.cairo_builtins.HashBuiltin*, range_check_ptr: felt, size: felt, retdata: felt*)",
                 "type": "type_definition"
             },
             "__wrappers__.decrement.SIZEOF_LOCALS": {
@@ -11192,7 +11193,7 @@
                         "offset": 1
                     },
                     "ret_value": {
-                        "cairo_type": "(count : felt)",
+                        "cairo_type": "(count: felt)",
                         "offset": 0
                     }
                 },
@@ -11206,7 +11207,7 @@
                 "type": "struct"
             },
             "__wrappers__.decrement_encode_return.Return": {
-                "cairo_type": "(range_check_ptr : felt, data_len : felt, data : felt*)",
+                "cairo_type": "(range_check_ptr: felt, data_len: felt, data: felt*)",
                 "type": "type_definition"
             },
             "__wrappers__.decrement_encode_return.SIZEOF_LOCALS": {
@@ -11237,7 +11238,7 @@
                 "type": "struct"
             },
             "__wrappers__.get_count.Return": {
-                "cairo_type": "(syscall_ptr : felt*, pedersen_ptr : starkware.cairo.common.cairo_builtins.HashBuiltin*, range_check_ptr : felt, size : felt, retdata : felt*)",
+                "cairo_type": "(syscall_ptr: felt*, pedersen_ptr: starkware.cairo.common.cairo_builtins.HashBuiltin*, range_check_ptr: felt, size: felt, retdata: felt*)",
                 "type": "type_definition"
             },
             "__wrappers__.get_count.SIZEOF_LOCALS": {
@@ -11261,7 +11262,7 @@
                         "offset": 1
                     },
                     "ret_value": {
-                        "cairo_type": "(count : felt)",
+                        "cairo_type": "(count: felt)",
                         "offset": 0
                     }
                 },
@@ -11275,7 +11276,7 @@
                 "type": "struct"
             },
             "__wrappers__.get_count_encode_return.Return": {
-                "cairo_type": "(range_check_ptr : felt, data_len : felt, data : felt*)",
+                "cairo_type": "(range_check_ptr: felt, data_len: felt, data: felt*)",
                 "type": "type_definition"
             },
             "__wrappers__.get_count_encode_return.SIZEOF_LOCALS": {
@@ -11306,7 +11307,7 @@
                 "type": "struct"
             },
             "__wrappers__.get_rand.Return": {
-                "cairo_type": "(syscall_ptr : felt*, pedersen_ptr : starkware.cairo.common.cairo_builtins.HashBuiltin*, range_check_ptr : felt, size : felt, retdata : felt*)",
+                "cairo_type": "(syscall_ptr: felt*, pedersen_ptr: starkware.cairo.common.cairo_builtins.HashBuiltin*, range_check_ptr: felt, size: felt, retdata: felt*)",
                 "type": "type_definition"
             },
             "__wrappers__.get_rand.SIZEOF_LOCALS": {
@@ -11330,7 +11331,7 @@
                         "offset": 1
                     },
                     "ret_value": {
-                        "cairo_type": "(val : felt)",
+                        "cairo_type": "(val: felt)",
                         "offset": 0
                     }
                 },
@@ -11344,7 +11345,7 @@
                 "type": "struct"
             },
             "__wrappers__.get_rand_encode_return.Return": {
-                "cairo_type": "(range_check_ptr : felt, data_len : felt, data : felt*)",
+                "cairo_type": "(range_check_ptr: felt, data_len: felt, data: felt*)",
                 "type": "type_definition"
             },
             "__wrappers__.get_rand_encode_return.SIZEOF_LOCALS": {
@@ -11375,7 +11376,7 @@
                 "type": "struct"
             },
             "__wrappers__.increment.Return": {
-                "cairo_type": "(syscall_ptr : felt*, pedersen_ptr : starkware.cairo.common.cairo_builtins.HashBuiltin*, range_check_ptr : felt, size : felt, retdata : felt*)",
+                "cairo_type": "(syscall_ptr: felt*, pedersen_ptr: starkware.cairo.common.cairo_builtins.HashBuiltin*, range_check_ptr: felt, size: felt, retdata: felt*)",
                 "type": "type_definition"
             },
             "__wrappers__.increment.SIZEOF_LOCALS": {
@@ -11399,7 +11400,7 @@
                         "offset": 1
                     },
                     "ret_value": {
-                        "cairo_type": "(count : felt)",
+                        "cairo_type": "(count: felt)",
                         "offset": 0
                     }
                 },
@@ -11413,7 +11414,7 @@
                 "type": "struct"
             },
             "__wrappers__.increment_encode_return.Return": {
-                "cairo_type": "(range_check_ptr : felt, data_len : felt, data : felt*)",
+                "cairo_type": "(range_check_ptr: felt, data_len: felt, data: felt*)",
                 "type": "type_definition"
             },
             "__wrappers__.increment_encode_return.SIZEOF_LOCALS": {
@@ -11444,7 +11445,7 @@
                 "type": "struct"
             },
             "__wrappers__.set_rand.Return": {
-                "cairo_type": "(syscall_ptr : felt*, pedersen_ptr : starkware.cairo.common.cairo_builtins.HashBuiltin*, range_check_ptr : felt, size : felt, retdata : felt*)",
+                "cairo_type": "(syscall_ptr: felt*, pedersen_ptr: starkware.cairo.common.cairo_builtins.HashBuiltin*, range_check_ptr: felt, size: felt, retdata: felt*)",
                 "type": "type_definition"
             },
             "__wrappers__.set_rand.SIZEOF_LOCALS": {
@@ -11479,7 +11480,7 @@
                 "type": "struct"
             },
             "__wrappers__.set_rand_signed.Return": {
-                "cairo_type": "(syscall_ptr : felt*, pedersen_ptr : starkware.cairo.common.cairo_builtins.HashBuiltin*, range_check_ptr : felt, size : felt, retdata : felt*)",
+                "cairo_type": "(syscall_ptr: felt*, pedersen_ptr: starkware.cairo.common.cairo_builtins.HashBuiltin*, range_check_ptr: felt, size: felt, retdata: felt*)",
                 "type": "type_definition"
             },
             "__wrappers__.set_rand_signed.SIZEOF_LOCALS": {
@@ -11493,6 +11494,14 @@
             "__wrappers__.set_rand_signed_encode_return.memcpy": {
                 "destination": "starkware.cairo.common.memcpy.memcpy",
                 "type": "alias"
+            },
+            "starkware.cairo.common.bool.FALSE": {
+                "type": "const",
+                "value": 0
+            },
+            "starkware.cairo.common.bool.TRUE": {
+                "type": "const",
+                "value": 1
             },
             "starkware.cairo.common.cairo_builtins.BitwiseBuiltin": {
                 "full_name": "starkware.cairo.common.cairo_builtins.BitwiseBuiltin",
@@ -11567,6 +11576,25 @@
                 "size": 3,
                 "type": "struct"
             },
+            "starkware.cairo.common.cairo_builtins.KeccakBuiltin": {
+                "full_name": "starkware.cairo.common.cairo_builtins.KeccakBuiltin",
+                "members": {
+                    "input": {
+                        "cairo_type": "starkware.cairo.common.keccak_state.KeccakBuiltinState",
+                        "offset": 0
+                    },
+                    "output": {
+                        "cairo_type": "starkware.cairo.common.keccak_state.KeccakBuiltinState",
+                        "offset": 8
+                    }
+                },
+                "size": 16,
+                "type": "struct"
+            },
+            "starkware.cairo.common.cairo_builtins.KeccakBuiltinState": {
+                "destination": "starkware.cairo.common.keccak_state.KeccakBuiltinState",
+                "type": "alias"
+            },
             "starkware.cairo.common.cairo_builtins.SignatureBuiltin": {
                 "full_name": "starkware.cairo.common.cairo_builtins.SignatureBuiltin",
                 "members": {
@@ -11618,6 +11646,53 @@
             },
             "starkware.cairo.common.hash.HashBuiltin": {
                 "destination": "starkware.cairo.common.cairo_builtins.HashBuiltin",
+                "type": "alias"
+            },
+            "starkware.cairo.common.keccak_state.KeccakBuiltinState": {
+                "full_name": "starkware.cairo.common.keccak_state.KeccakBuiltinState",
+                "members": {
+                    "s0": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    },
+                    "s1": {
+                        "cairo_type": "felt",
+                        "offset": 1
+                    },
+                    "s2": {
+                        "cairo_type": "felt",
+                        "offset": 2
+                    },
+                    "s3": {
+                        "cairo_type": "felt",
+                        "offset": 3
+                    },
+                    "s4": {
+                        "cairo_type": "felt",
+                        "offset": 4
+                    },
+                    "s5": {
+                        "cairo_type": "felt",
+                        "offset": 5
+                    },
+                    "s6": {
+                        "cairo_type": "felt",
+                        "offset": 6
+                    },
+                    "s7": {
+                        "cairo_type": "felt",
+                        "offset": 7
+                    }
+                },
+                "size": 8,
+                "type": "struct"
+            },
+            "starkware.cairo.common.math.FALSE": {
+                "destination": "starkware.cairo.common.bool.FALSE",
+                "type": "alias"
+            },
+            "starkware.cairo.common.math.TRUE": {
+                "destination": "starkware.cairo.common.bool.TRUE",
                 "type": "alias"
             },
             "starkware.cairo.common.math.assert_not_zero": {
@@ -11784,7 +11859,7 @@
                         "cairo_type": "felt",
                         "offset": 2
                     },
-                    "reserved": {
+                    "deploy_from_zero": {
                         "cairo_type": "felt",
                         "offset": 5
                     },
@@ -12301,6 +12376,10 @@
                         "cairo_type": "felt",
                         "offset": 2
                     },
+                    "nonce": {
+                        "cairo_type": "felt",
+                        "offset": 7
+                    },
                     "signature": {
                         "cairo_type": "felt*",
                         "offset": 4
@@ -12318,7 +12397,7 @@
                         "offset": 0
                     }
                 },
-                "size": 7,
+                "size": 8,
                 "type": "struct"
             },
             "starkware.starknet.common.syscalls.get_caller_address": {
@@ -12344,7 +12423,7 @@
                 "type": "struct"
             },
             "starkware.starknet.common.syscalls.get_caller_address.Return": {
-                "cairo_type": "(caller_address : felt)",
+                "cairo_type": "(caller_address: felt)",
                 "type": "type_definition"
             },
             "starkware.starknet.common.syscalls.get_caller_address.SIZEOF_LOCALS": {
@@ -12397,7 +12476,7 @@
                 "type": "struct"
             },
             "starkware.starknet.common.syscalls.get_tx_info.Return": {
-                "cairo_type": "(tx_info : starkware.starknet.common.syscalls.TxInfo*)",
+                "cairo_type": "(tx_info: starkware.starknet.common.syscalls.TxInfo*)",
                 "type": "type_definition"
             },
             "starkware.starknet.common.syscalls.get_tx_info.SIZEOF_LOCALS": {
@@ -12455,7 +12534,7 @@
                 "type": "struct"
             },
             "starkware.starknet.common.syscalls.storage_read.Return": {
-                "cairo_type": "(value : felt)",
+                "cairo_type": "(value: felt)",
                 "type": "type_definition"
             },
             "starkware.starknet.common.syscalls.storage_read.SIZEOF_LOCALS": {

--- a/rpc/types/transaction.go
+++ b/rpc/types/transaction.go
@@ -33,7 +33,7 @@ func (tx TransactionHash) MarshalJSON() ([]byte, error) {
 }
 
 type CommonTransaction struct {
-	TransactionHash Hash            `json:"transaction_hash"`
+	TransactionHash Hash            `json:"transaction_hash,omitempty"`
 	Type            TransactionType `json:"type,omitempty"`
 	// MaxFee maximal fee that can be charged for including the transaction
 	MaxFee string `json:"max_fee,omitempty"`
@@ -77,7 +77,7 @@ func (tx InvokeTxnV1) Hash() Hash {
 type InvokeTxn interface{}
 
 type L1HandlerTxn struct {
-	TransactionHash Hash            `json:"transaction_hash"`
+	TransactionHash Hash            `json:"transaction_hash,omitempty"`
 	Type            TransactionType `json:"type,omitempty"`
 	// Version of the transaction scheme
 	Version NumAsHex `json:"version"`
@@ -283,3 +283,4 @@ func remarshal(v interface{}, dst interface{}) error {
 
 	return nil
 }
+

--- a/rpc/write_test.go
+++ b/rpc/write_test.go
@@ -1,0 +1,92 @@
+package rpc
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/dontpanicdao/caigo/rpc/types"
+)
+
+// TestChainID checks the chainId matches the one for the environment
+func TestDeclareTransaction(t *testing.T) {
+	testConfig := beforeEach(t)
+
+	type testSetType struct {
+		Filename          string
+		ExpectedClassHash string
+	}
+	testSet := map[string][]testSetType{
+		"devnet":  {},
+		"mainnet": {},
+		"mock":    {},
+		"testnet": {{
+			Filename:          "./tests/counter.json",
+			ExpectedClassHash: "0x71ee80b6ec623ffe1adb80a0f0cd1a3012b633d7312fe604816ce7aa75cf209",
+		}},
+	}[testEnv]
+
+	for _, test := range testSet {
+		content, err := os.ReadFile(test.Filename)
+		if err != nil {
+			t.Fatal("should read file with success, instead:", err)
+		}
+		v := map[string]interface{}{}
+		if err := json.Unmarshal(content, &v); err != nil {
+			t.Fatal("should parse file with success, instead:", err)
+		}
+
+		program := ""
+		if data, ok := v["program"]; ok {
+			dataProgram, err := json.Marshal(data)
+			if err != nil {
+				t.Fatal("should read file, instead:", err)
+			}
+			if program, err = encodeProgram(dataProgram); err != nil {
+				t.Fatal("should encode file, instead:", err)
+			}
+		}
+		entryPointsByType := types.EntryPointsByType{}
+		if data, ok := v["entry_points_by_type"]; ok {
+			dataEntryPointsByType, err := json.Marshal(data)
+			if err != nil {
+				t.Fatal("should marshall entryPointsByType, instead:", err)
+			}
+			err = json.Unmarshal(dataEntryPointsByType, &entryPointsByType)
+			if err != nil {
+				t.Fatal("should unmarshall entryPointsByType, instead:", err)
+			}
+		}
+		var abiPointer *types.ABI
+		if data, ok := v["abi"]; ok {
+			if abis, ok := data.([]interface{}); ok {
+				abiPointer, err = guessABI(abis)
+				if err != nil {
+					t.Fatal("should read ABI, instead:", err)
+				}
+			}
+		}
+
+		contractClass := types.ContractClass{
+			EntryPointsByType: entryPointsByType,
+			Program:           program,
+			Abi:               abiPointer,
+		}
+		version := "0x0"
+
+		spy := NewSpy(testConfig.client.c)
+		testConfig.client.c = spy
+		dec, err := testConfig.client.AddDeclareTransaction(context.Background(), contractClass, version)
+		if err != nil {
+			t.Fatal("declare should succeed, instead:", err)
+		}
+		if dec.ClassHash != test.ExpectedClassHash {
+			t.Fatalf("classHash does not match expected, current: %s", dec.ClassHash)
+		}
+		if diff, err := spy.Compare(dec, false); err != nil || diff != "FullMatch" {
+			spy.Compare(dec, true)
+			t.Fatal("expecting to match", err)
+		}
+	}
+}


### PR DESCRIPTION
This PR:
- upgrade the demo contract to cairo 0.10
- fixes AddDeclareTransaction
- add a function to guess the ABI types
- provides a test with the ABI entry

The API does not look compliant with json-rpc v0.2.0 but it has been tested with Pathfinder 0.3.4 with success