### PR TITLE
Allow to have 2 parallel implementations of RPC API

### DIFF
--- a/rpc/client.go
+++ b/rpc/client.go
@@ -8,6 +8,14 @@ import (
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
+type APIv010 struct {
+	client *Client
+}
+
+type APIv020 struct {
+	client *Client
+}
+
 // SyncResponse is the Starknet RPC type returned by the Syncing method.
 type SyncResponse struct {
 	StartingBlockHash string `json:"starting_block_hash"`
@@ -45,6 +53,13 @@ func DialContext(ctx context.Context, rawurl string) (*Client, error) {
 		return nil, err
 	}
 	return NewClient(c), nil
+}
+
+// NewAPIv010
+func NewAPIv010(c *rpc.Client) *APIv010 {
+	return &APIv010{
+		client: &Client{c: c},
+	}
 }
 
 // NewClient creates a *Client from an existing `go-ethereum/rpc` *Client.

--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -16,8 +16,9 @@ import (
 
 // testConfiguration is a type that is used to configure tests
 type testConfiguration struct {
-	client *Client
-	base   string
+	apiv010 *APIv010
+	client  *Client
+	base    string
 }
 
 var (
@@ -66,6 +67,9 @@ func beforeEach(t *testing.T) *testConfiguration {
 		testConfig.client = &Client{
 			c: &rpcMock{},
 		}
+		testConfig.apiv010 = &APIv010{
+			client: testConfig.client,
+		}
 		return &testConfig
 	}
 
@@ -79,6 +83,9 @@ func beforeEach(t *testing.T) *testConfiguration {
 		t.Fatal("connect should succeed, instead:", err)
 	}
 	testConfig.client = client
+	testConfig.apiv010 = &APIv010{
+		client: testConfig.client,
+	}
 	t.Cleanup(func() {
 		testConfig.client.Close()
 	})

--- a/rpc/types/transaction.go
+++ b/rpc/types/transaction.go
@@ -183,7 +183,7 @@ type NumAsHex string
 // FunctionCall function call information
 type FunctionCall struct {
 	ContractAddress    Hash   `json:"contract_address"`
-	EntryPointSelector string `json:"entry_point_selector"`
+	EntryPointSelector string `json:"entry_point_selector,omitempty"`
 
 	// CallData The parameters passed to the function
 	CallData []string `json:"calldata"`
@@ -283,4 +283,3 @@ func remarshal(v interface{}, dst interface{}) error {
 
 	return nil
 }
-

--- a/rpc/write.go
+++ b/rpc/write.go
@@ -29,22 +29,22 @@ type AddInvokeTransactionOutput struct {
 }
 
 // AddInvokeTransaction estimates the fee for a given StarkNet transaction.
-func (sc *Client) AddInvokeTransaction(ctx context.Context, broadcastedInvokeTxn types.BroadcastedInvokeTxn) (*AddInvokeTransactionOutput, error) {
+func (api *APIv010) AddInvokeTransaction(ctx context.Context, call types.FunctionCall, signature []string, maxFee string, version string) (*AddInvokeTransactionOutput, error) {
 	// TODO: We might have to gzip/base64 the program and provide helpers to call
 	// this API
 	var output AddInvokeTransactionOutput
-	if err := sc.do(ctx, "starknet_addInvokeTransaction", &output, broadcastedInvokeTxn); err != nil {
+	if err := api.client.do(ctx, "starknet_addInvokeTransaction", &output, call, signature, maxFee); err != nil {
 		return nil, err
 	}
 	return &output, nil
 }
 
 // AddDeclareTransaction submits a new class declaration transaction.
-func (sc *Client) AddDeclareTransaction(ctx context.Context, contractClass types.ContractClass, version string) (*AddDeclareTransactionOutput, error) {
+func (api *APIv010) AddDeclareTransaction(ctx context.Context, contractClass types.ContractClass, version string) (*AddDeclareTransactionOutput, error) {
 	// TODO: We might have to gzip/base64 the program and provide helpers to call
 	// this API
 	var result AddDeclareTransactionOutput
-	if err := sc.do(ctx, "starknet_addDeclareTransaction", &result, contractClass, version); err != nil {
+	if err := api.client.do(ctx, "starknet_addDeclareTransaction", &result, contractClass, version); err != nil {
 		return nil, err
 	}
 	return &result, nil
@@ -55,9 +55,9 @@ func (sc *Client) AddDeclareTransaction(ctx context.Context, contractClass types
 // replaced by AddDeclareTransaction to declare a class, followed by
 // AddInvokeTransaction to instantiate the contract. For now, it remains the only
 // way to deploy an account without being charged for it.
-func (sc *Client) AddDeployTransaction(ctx context.Context, salt string, inputs []string, contractClass types.ContractClass) (*AddDeployTransactionOutput, error) {
+func (api *APIv010) AddDeployTransaction(ctx context.Context, salt string, inputs []string, contractClass types.ContractClass) (*AddDeployTransactionOutput, error) {
 	var result AddDeployTransactionOutput
-	if err := sc.do(ctx, "starknet_addDeployTransaction", &result, salt, inputs, contractClass); err != nil {
+	if err := api.client.do(ctx, "starknet_addDeployTransaction", &result, salt, inputs, contractClass); err != nil {
 		return nil, err
 	}
 	return &result, nil

--- a/rpc/write_test.go
+++ b/rpc/write_test.go
@@ -77,7 +77,7 @@ func TestDeclareTransaction(t *testing.T) {
 
 		spy := NewSpy(testConfig.client.c)
 		testConfig.client.c = spy
-		dec, err := testConfig.client.AddDeclareTransaction(context.Background(), contractClass, version)
+		dec, err := testConfig.apiv010.AddDeclareTransaction(context.Background(), contractClass, version)
 		if err != nil {
 			t.Fatal("declare should succeed, instead:", err)
 		}
@@ -162,7 +162,7 @@ func TestDeployTransaction(t *testing.T) {
 
 		spy := NewSpy(testConfig.client.c)
 		testConfig.client.c = spy
-		dec, err := testConfig.client.AddDeployTransaction(context.Background(), test.Salt, test.ConstructorCall, contractClass)
+		dec, err := testConfig.apiv010.AddDeployTransaction(context.Background(), test.Salt, test.ConstructorCall, contractClass)
 		if err != nil {
 			t.Fatal("declare should succeed, instead:", err)
 		}
@@ -173,5 +173,91 @@ func TestDeployTransaction(t *testing.T) {
 			spy.Compare(dec, true)
 			t.Fatal("expecting to match", err)
 		}
+	}
+}
+
+// TestInvokeTransaction tests starknet_addDeployTransaction
+func TesInvokeTransaction(t *testing.T) {
+	// testConfig := beforeEach(t)
+
+	type testSetType struct {
+		AccountPrivateKeyEnvVar string
+		AccountPublicKey        string
+		AccountAddress          string
+		ContractAddress         string
+		ContractEntryPoint      string
+		ContractCallData        []string
+	}
+	testSet := map[string][]testSetType{
+		"devnet":  {},
+		"mainnet": {},
+		"mock":    {},
+		"testnet": {{
+			AccountPrivateKeyEnvVar: "ACCOUNT_PRIVATE_KEY",
+			AccountPublicKey:        "0x783318b2cc1067e5c06d374d2bb9a0382c39aabd009b165d7a268b882971d6",
+			AccountAddress:          "0x19e63006d7df131737f5222283da28de2d9e2f0ee92fdc4c4c712d1659826b0",
+			ContractAddress:         "0x37a2490365294ef4bc896238642b9bcb0203f86e663f11688bb86c5e803c167",
+			ContractEntryPoint:      "incrementCounter",
+			ContractCallData:        []string{"0x1"},
+		}},
+	}[testEnv]
+
+	for _, test := range testSet {
+		privateKey := os.Getenv(test.AccountPrivateKeyEnvVar)
+		if privateKey == "" {
+			t.Fatal("should have a private key for the account")
+		}
+		// 	caigo.GetSelectorFromName()
+		// 	program := ""
+		// 	if data, ok := v["program"]; ok {
+		// 		dataProgram, err := json.Marshal(data)
+		// 		if err != nil {
+		// 			t.Fatal("should read file, instead:", err)
+		// 		}
+		// 		if program, err = encodeProgram(dataProgram); err != nil {
+		// 			t.Fatal("should encode file, instead:", err)
+		// 		}
+		// 	}
+		// 	entryPointsByType := types.EntryPointsByType{}
+		// 	if data, ok := v["entry_points_by_type"]; ok {
+		// 		dataEntryPointsByType, err := json.Marshal(data)
+		// 		if err != nil {
+		// 			t.Fatal("should marshall entryPointsByType, instead:", err)
+		// 		}
+		// 		err = json.Unmarshal(dataEntryPointsByType, &entryPointsByType)
+		// 		if err != nil {
+		// 			t.Fatal("should unmarshall entryPointsByType, instead:", err)
+		// 		}
+		// 	}
+		// 	var abiPointer *types.ABI
+		// 	if data, ok := v["abi"]; ok {
+		// 		if abis, ok := data.([]interface{}); ok {
+		// 			abiPointer, err = guessABI(abis)
+		// 			if err != nil {
+		// 				t.Fatal("should read ABI, instead:", err)
+		// 			}
+		// 		}
+		// 	}
+
+		// 	contractClass := types.ContractClass{
+		// 		EntryPointsByType: entryPointsByType,
+		// 		Program:           program,
+		// 		Abi:               abiPointer,
+		// 	}
+
+		// 	spy := NewSpy(testConfig.client.c)
+		// 	testConfig.client.c = spy
+		// 	dec, err := testConfig.client.AddDeployTransaction(context.Background(), test.Salt, test.ConstructorCall, contractClass)
+		// 	if err != nil {
+		// 		t.Fatal("declare should succeed, instead:", err)
+		// 	}
+		// 	if dec.ContractAddress != test.ExpectedContractAddress {
+		// 		t.Fatalf("contractAddress does not match expected, current: %s", dec.ContractAddress)
+		// 	}
+		// 	if diff, err := spy.Compare(dec, false); err != nil || diff != "FullMatch" {
+		// 		spy.Compare(dec, true)
+		// 		t.Fatal("expecting to match", err)
+		// 	}
+		// }
 	}
 }


### PR DESCRIPTION
Pathfinder will provide 2 implementation in parallel of the json-rpc: v0.1.0 and v0.2.0. To anticipate that move and allow to maintain the 2 API that rely on the same verbs bit different payload, this PR creates 2 structs, each one providing a separalet interface.