### PR TITLE
fix ci by reverting to earlier devnet

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
 
     services:
       devnet:
-        image: shardlabs/starknet-devnet:latest
+        image: shardlabs/starknet-devnet:0.3.4
         ports:
           - 5050:5050
 


### PR DESCRIPTION
The reason the CI is failing is because devnet has been updated to v0.3.5 with now implements rpc v0.2 instead of rpc v0.1. This PR reverts to v0.3.4 to fix the tests for now. We should be able to upgrade