### PR TITLE
provide support for new Goerli2 chain ID SN_GOERLI2 in gateway provider

### DIFF
--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -17,9 +17,11 @@ const (
 	DEPLOY_ACCOUNT string = "DEPLOY_ACCOUNT"
 	DECLARE        string = "DECLARE"
 	GOERLI_ID      string = "SN_GOERLI"
+	GOERLI2_ID     string = "SN_GOERLI2"
 	MAINNET_ID     string = "SN_MAIN"
 	LOCAL_BASE     string = "http://localhost:5050"
 	GOERLI_BASE    string = "https://alpha4.starknet.io"
+	GOERLI2_BASE   string = "https://alpha4-2.starknet.io"
 	MAINNET_BASE   string = "https://alpha-mainnet.starknet.io"
 )
 
@@ -62,6 +64,11 @@ func NewClient(opts ...Option) *Gateway {
 		gopts.chainID = GOERLI_ID
 		if gopts.baseUrl == "" {
 			gopts.baseUrl = LOCAL_BASE
+		}
+	case strings.Contains(id, "goerli2"):
+		gopts.chainID = GOERLI2_ID
+		if gopts.baseUrl == "" {
+			gopts.baseUrl = GOERLI2_BASE
 		}
 	default:
 		gopts.chainID = GOERLI_ID


### PR DESCRIPTION
Following the upgrade of the StarkNet testnets today, the Goerli2 network has a new chain ID SN_GOERLI2. This pull request allows caigo clients to connect to accounts deployed on Goerli2.

Prior to the StarkNet upgrade a caigo client could connect to Goerli2 as follows:
```
 gw := gateway.NewProvider(gateway.WithBaseURL("https://alpha4-2.starknet.io"))
 account, err := caigo.NewGatewayAccount(<account private key>, <account address>, gw, caigo.AccountVersion1)
``` 
But since the upgrade the returned account has all transactions rejected with the message “Signature (…, …), is invalid, with respect to the public key …, and the message hash …”.

With this pull request clients can successfully connect as follows:
```
 gw := gateway.NewProvider(gateway.WithChain("SN_GOERLI2"))
 account, err := caigo.NewGatewayAccount(<account private key>, <account address>, gw, caigo.AccountVersion1)
```
Passing any string which contains "goerli2" in either upper or lower case as the chain ID will work. 