### PR TITLE
Rpcv03 get class

### DIFF
--- a/rpc/contract.go
+++ b/rpc/contract.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Class gets the contract class definition associated with the given hash.
-func (provider *Provider) Class(ctx context.Context, blockID BlockID, classHash string) (ClassOutput, error) {
+func (provider *Provider) Class(ctx context.Context, blockID BlockID, classHash *felt.Felt) (ClassOutput, error) {
 	var rawClass map[string]any
 	if err := do(ctx, provider.c, "starknet_getClass", &rawClass, blockID, classHash); err != nil {
 		switch {

--- a/rpc/contract.go
+++ b/rpc/contract.go
@@ -66,8 +66,8 @@ func typecastClassOutput(rawClass *map[string]any) (ClassOutput, error) {
 }
 
 // ClassHashAt gets the contract class hash for the contract deployed at the given address.
-func (provider *Provider) ClassHashAt(ctx context.Context, blockID BlockID, contractAddress *felt.Felt) (*string, error) {
-	var result string
+func (provider *Provider) ClassHashAt(ctx context.Context, blockID BlockID, contractAddress *felt.Felt) (*felt.Felt, error) {
+	var result *felt.Felt
 	if err := do(ctx, provider.c, "starknet_getClassHashAt", &result, blockID, contractAddress); err != nil {
 		switch {
 		case errors.Is(err, ErrContractNotFound):
@@ -77,7 +77,7 @@ func (provider *Provider) ClassHashAt(ctx context.Context, blockID BlockID, cont
 		}
 		return nil, err
 	}
-	return &result, nil
+	return result, nil
 }
 
 // StorageAt gets the value of the storage at the given address and key.

--- a/rpc/contract_test.go
+++ b/rpc/contract_test.go
@@ -72,25 +72,25 @@ func TestClassHashAt(t *testing.T) {
 
 	type testSetType struct {
 		ContractHash      *felt.Felt
-		ExpectedClassHash string
+		ExpectedClassHash *felt.Felt
 	}
 	testSet := map[string][]testSetType{
 		"mock": {
 			{
 				ContractHash:      utils.TestHexToFelt(t, "0xdeadbeef"),
-				ExpectedClassHash: "0xdeadbeef",
+				ExpectedClassHash: utils.TestHexToFelt(t, "0xdeadbeef"),
 			},
 		},
 		"testnet": {
 			{
 				ContractHash:      utils.TestHexToFelt(t, "0x315e364b162653e5c7b23efd34f8da27ba9c069b68e3042b7d76ce1df890313"),
-				ExpectedClassHash: "0x493af3546940eb96471cf95ae3a5aa1286217b07edd1e12d00143010ca904b1",
+				ExpectedClassHash: utils.TestHexToFelt(t, "0x493af3546940eb96471cf95ae3a5aa1286217b07edd1e12d00143010ca904b1"),
 			},
 		},
 		"mainnet": {
 			{
 				ContractHash:      utils.TestHexToFelt(t, "0x3b4be7def2fc08589348966255e101824928659ebb724855223ff3a8c831efa"),
-				ExpectedClassHash: "0x4c53698c9a42341e4123632e87b752d6ae470ddedeb8b0063eaa2deea387eeb",
+				ExpectedClassHash: utils.TestHexToFelt(t, "0x4c53698c9a42341e4123632e87b752d6ae470ddedeb8b0063eaa2deea387eeb"),
 			},
 		},
 	}[testEnv]
@@ -114,9 +114,7 @@ func TestClassHashAt(t *testing.T) {
 		if classhash == nil {
 			t.Fatalf("should return a class, instead %v", classhash)
 		}
-		if *classhash != test.ExpectedClassHash {
-			t.Fatalf("class expect %s, got %s", test.ExpectedClassHash, *classhash)
-		}
+		require.Equal(t, test.ExpectedClassHash, classhash)
 	}
 }
 

--- a/rpc/contract_test.go
+++ b/rpc/contract_test.go
@@ -126,7 +126,7 @@ func TestClass(t *testing.T) {
 
 	type testSetType struct {
 		BlockID                       BlockID
-		ClassHash                     string
+		ClassHash                     *felt.Felt
 		ExpectedProgram               string
 		ExpectedEntryPointConstructor SierraEntryPoint
 	}
@@ -134,19 +134,19 @@ func TestClass(t *testing.T) {
 		"mock": {
 			{
 				BlockID:         WithBlockTag("pending"),
-				ClassHash:       "0xdeadbeef",
+				ClassHash:       utils.TestHexToFelt(t, "0xdeadbeef"),
 				ExpectedProgram: "H4sIAAAAAAAA",
 			},
 		},
 		"testnet": {
 			{
 				BlockID:         WithBlockTag("pending"),
-				ClassHash:       "0x493af3546940eb96471cf95ae3a5aa1286217b07edd1e12d00143010ca904b1",
+				ClassHash:       utils.TestHexToFelt(t, "0x493af3546940eb96471cf95ae3a5aa1286217b07edd1e12d00143010ca904b1"),
 				ExpectedProgram: "H4sIAAAAAAAA",
 			},
 			{
 				BlockID:                       WithBlockHash(utils.TestHexToFelt(t, "0x464fc8c86a6452536a2e27cb301815e5f8b16a2f6872ba4f3d83701fbe99fb3")),
-				ClassHash:                     "0x011fbe1adeb2afdf5b545f583f8b5a64fb35905f987d249193ad8185f6fcf571",
+				ClassHash:                     utils.TestHexToFelt(t, "0x011fbe1adeb2afdf5b545f583f8b5a64fb35905f987d249193ad8185f6fcf571"),
 				ExpectedEntryPointConstructor: SierraEntryPoint{FunctionIdx: 16, Selector: utils.TestHexToFelt(t, "0x28ffe4ff0f226a9107253e17a904099aa4f63a02a5621de0576e5aa71bc5194")},
 			},
 		},

--- a/rpc/mock_test.go
+++ b/rpc/mock_test.go
@@ -287,7 +287,10 @@ func mock_starknet_getClassHashAt(result interface{}, method string, args ...int
 	if len(args) != 2 {
 		return errWrongArgs
 	}
-	classHash := "0xdeadbeef"
+	classHash, err := utils.HexToFelt("0xdeadbeef")
+	if err != nil {
+		return err
+	}
 	outputContent, _ := json.Marshal(classHash)
 	json.Unmarshal(outputContent, r)
 	return nil

--- a/rpc/mock_test.go
+++ b/rpc/mock_test.go
@@ -307,8 +307,8 @@ func mock_starknet_getClass(result interface{}, method string, args ...interface
 		fmt.Printf("expecting BlockID, instead %T\n", args[1])
 		return errWrongArgs
 	}
-	classHash, ok := args[1].(string)
-	if !ok || !strings.HasPrefix(classHash, "0x") {
+	classHash, ok := args[1].(*felt.Felt)
+	if !ok || !strings.HasPrefix(classHash.String(), "0x") {
 		fmt.Printf("%T\n", args[1])
 		return errWrongArgs
 	}

--- a/rpc/provider.go
+++ b/rpc/provider.go
@@ -32,7 +32,7 @@ type api interface {
 	BlockWithTxs(ctx context.Context, blockID BlockID) (interface{}, error)
 	Call(ctx context.Context, call FunctionCall, block BlockID) ([]*felt.Felt, error)
 	ChainID(ctx context.Context) (string, error)
-	Class(ctx context.Context, blockID BlockID, classHash string) (ClassOutput, error)
+	Class(ctx context.Context, blockID BlockID, classHash *felt.Felt) (ClassOutput, error)
 	ClassAt(ctx context.Context, blockID BlockID, contractAddress *felt.Felt) (ClassOutput, error)
 	ClassHashAt(ctx context.Context, blockID BlockID, contractAddress *felt.Felt) (*string, error)
 	EstimateFee(ctx context.Context, requests []BroadcastedTransaction, blockID BlockID) ([]FeeEstimate, error)

--- a/rpc/provider.go
+++ b/rpc/provider.go
@@ -34,7 +34,7 @@ type api interface {
 	ChainID(ctx context.Context) (string, error)
 	Class(ctx context.Context, blockID BlockID, classHash *felt.Felt) (ClassOutput, error)
 	ClassAt(ctx context.Context, blockID BlockID, contractAddress *felt.Felt) (ClassOutput, error)
-	ClassHashAt(ctx context.Context, blockID BlockID, contractAddress *felt.Felt) (*string, error)
+	ClassHashAt(ctx context.Context, blockID BlockID, contractAddress *felt.Felt) (*felt.Felt, error)
 	EstimateFee(ctx context.Context, requests []BroadcastedTransaction, blockID BlockID) ([]FeeEstimate, error)
 	Events(ctx context.Context, input EventsInput) (*EventChunk, error)
 	Nonce(ctx context.Context, blockID BlockID, contractAddress *felt.Felt) (*string, error)


### PR DESCRIPTION
Fixes some small issues required for https://github.com/NethermindEth/starknet.go/issues/212

Namely, Class and ClassHashAt should use/return felts instead of strings