### PR TITLE
Fix function call calldata length for Cairo 0

### DIFF
--- a/account/account.go
+++ b/account/account.go
@@ -922,7 +922,7 @@ func FmtCalldataCairo0(fnCalls []rpc.FunctionCall) []*felt.Felt {
 			fnCall.ContractAddress,
 			fnCall.EntryPointSelector,
 			new(felt.Felt).SetUint64(uint64(len(concatCallData))),
-			new(felt.Felt).SetUint64(uint64(len(fnCall.Calldata))+1),
+			new(felt.Felt).SetUint64(uint64(len(fnCall.Calldata))),
 		)
 		concatCallData = append(concatCallData, fnCall.Calldata...)
 	}

--- a/account/account_test.go
+++ b/account/account_test.go
@@ -222,7 +222,7 @@ func TestFmtCallData(t *testing.T) {
 					"0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
 					"0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
 					"0x0",
-					"0x3",
+					"0x2",
 					"0x3",
 					"0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
 					"0x1",


### PR DESCRIPTION
Calldata length for each function call was set
incorrectly in `FmtCalldataCairo0`, resulting in error

```
ASSERT_EQ instruction failed: 0:17 != 0:18
```