### PR TITLE
raise failing fmtCall example

### DIFF
--- a/account/account_test.go
+++ b/account/account_test.go
@@ -273,6 +273,31 @@ func TestFmtCallData(t *testing.T) {
 					"0x0",
 				}),
 			},
+			{
+				// Note: This test fails.
+				// https://goerli.voyager.online/tx/0x6fdae8a037508ececc5684406cdd66101d56004bf461c9ee7a3b7f5cf5bb799
+				CairoVersion: 0,
+				ChainID:      "SN_GOERLI",
+				FnCall: rpc.FunctionCall{
+					ContractAddress:    utils.TestHexToFelt(t, "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7"),
+					EntryPointSelector: utils.GetSelectorFromNameFelt("approve"),
+					Calldata: []*felt.Felt{
+						utils.TestHexToFelt(t, "0x043784df59268c02b716e20bf77797bd96c68c2f100b2a634e448c35e3ad363e"),
+						utils.TestHexToFelt(t, "0x21"),
+					},
+				},
+				ExpectedCallData: utils.TestHexArrToFelt(t, []string{
+					"0x1",
+					"0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+					"0x0219209e083275171774dab1df80982e9df2096516f06319c5c6d71ae0a8480c",
+					"0x0",
+					"0x03",
+					"0x03",
+					"0x043784df59268c02b716e20bf77797bd96c68c2f100b2a634e448c35e3ad363e",
+					"0x21",
+					"0x0",
+				}),
+			},
 		},
 		"testnet": {},
 		"mainnet": {},
@@ -284,8 +309,9 @@ func TestFmtCallData(t *testing.T) {
 		require.NoError(t, err)
 
 		fmtCallData, err := acnt.FmtCalldata([]rpc.FunctionCall{test.FnCall})
+		errMsg := fmt.Sprintf("Expected call data : %v, \n Computed call data : %v", test.ExpectedCallData, fmtCallData)
 		require.NoError(t, err)
-		require.Equal(t, fmtCallData, test.ExpectedCallData)
+		require.Equal(t, fmtCallData, test.ExpectedCallData, errMsg)
 	}
 }
 


### PR DESCRIPTION
https://github.com/NethermindEth/starknet.go/issues/501

`approve(sender,amount)` is called on StarkGate: ETH Token using a wallet (Bravos Cairo 0 account). However, the SDK computes the incorrect call data format.

The call data formatting logic is in [FmtCallData()](https://github.com/NethermindEth/starknet.go/blob/main/account/account.go#L897)

// https://goerli.voyager.online/tx/0x6fdae8a037508ececc5684406cdd66101d56004bf461c9ee7a3b7f5cf5bb799

```
Expected call data :
[
0x1 
0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7 0x219209e083275171774dab1df80982e9df2096516f06319c5c6d71ae0a8480c 
0x0 
0x3 
0x3 
0x43784df59268c02b716e20bf77797bd96c68c2f100b2a634e448c35e3ad363e 
0x21 
0x0
], 
```

// See the new test       	            	 
```
Computed call data :
[
0x1 
0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7 
0x219209e083275171774dab1df80982e9df2096516f06319c5c6d71ae0a8480c 
0x0 
0x2 
0x2 
0x43784df59268c02b716e20bf77797bd96c68c2f100b2a634e448c35e3ad363e 
0x21]
```