### PR TITLE
UnmarshalJson contractClass

### DIFF
--- a/hash/hash.go
+++ b/hash/hash.go
@@ -85,7 +85,11 @@ func ClassHash(contract rpc.ContractClass) (*felt.Felt, error) {
 	ExternalHash := hashEntryPointByType(contract.EntryPointsByType.External)
 	L1HandleHash := hashEntryPointByType(contract.EntryPointsByType.L1Handler)
 	SierraProgamHash := curve.Curve.PoseidonArray(contract.SierraProgram...)
-	ABIHash, err := curve.Curve.StarknetKeccak([]byte(contract.ABI))
+	abiBytes, err := contract.AbiBytes()
+	if err != nil {
+		return nil, err
+	}
+	ABIHash, err := curve.Curve.StarknetKeccak(abiBytes)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
https://github.com/keep-starknet-strange/madara/blob/main/configs/genesis-assets/ArgentAccountCairoOne.json#L11359
Now the `abi` type of the current cairo1 json file is not `string`, we should let it can be unmarshaled, so I provide this PR.