### PR TITLE
RPCv07 rc2 getTransactionReceipt

### DIFF
--- a/account/account.go
+++ b/account/account.go
@@ -37,7 +37,7 @@ type AccountInterface interface {
 	SignDeployAccountTransaction(ctx context.Context, tx *rpc.DeployAccountTxn, precomputeAddress *felt.Felt) error
 	SignDeclareTransaction(ctx context.Context, tx *rpc.DeclareTxnV2) error
 	PrecomputeAddress(deployerAddress *felt.Felt, salt *felt.Felt, classHash *felt.Felt, constructorCalldata []*felt.Felt) (*felt.Felt, error)
-	WaitForTransactionReceipt(ctx context.Context, transactionHash *felt.Felt, pollInterval time.Duration) (*rpc.TransactionReceipt, *rpc.RPCError)
+	WaitForTransactionReceipt(ctx context.Context, transactionHash *felt.Felt, pollInterval time.Duration) (*rpc.TransactionReceiptWithBlockInfo, *rpc.RPCError)
 }
 
 var _ AccountInterface = &Account{}
@@ -525,14 +525,14 @@ func (account *Account) PrecomputeAddress(deployerAddress *felt.Felt, salt *felt
 // It returns:
 // - *rpc.TransactionReceipt: the transaction receipt
 // - error: an error
-func (account *Account) WaitForTransactionReceipt(ctx context.Context, transactionHash *felt.Felt, pollInterval time.Duration) (*rpc.TransactionReceipt, *rpc.RPCError) {
+func (account *Account) WaitForTransactionReceipt(ctx context.Context, transactionHash *felt.Felt, pollInterval time.Duration) (*rpc.TransactionReceiptWithBlockInfo, *rpc.RPCError) {
 	t := time.NewTicker(pollInterval)
 	for {
 		select {
 		case <-ctx.Done():
 			return nil, rpc.Err(rpc.InternalError, ctx.Err())
 		case <-t.C:
-			receipt, rpcErr := account.TransactionReceipt(ctx, transactionHash)
+			receiptWithBlockInfo, rpcErr := account.TransactionReceipt(ctx, transactionHash)
 			if rpcErr != nil {
 				if rpcErr.Message == rpc.ErrHashNotFound.Message {
 					continue
@@ -540,7 +540,7 @@ func (account *Account) WaitForTransactionReceipt(ctx context.Context, transacti
 					return nil, rpcErr
 				}
 			}
-			return &receipt, nil
+			return receiptWithBlockInfo, nil
 		}
 	}
 }
@@ -835,7 +835,7 @@ func (account *Account) TraceBlockTransactions(ctx context.Context, blockID rpc.
 // - transactionHash: The hash of the transaction.
 // Returns:
 // - rpc.Transactiontype: rpc.TransactionReceipt, error.
-func (account *Account) TransactionReceipt(ctx context.Context, transactionHash *felt.Felt) (rpc.TransactionReceipt, *rpc.RPCError) {
+func (account *Account) TransactionReceipt(ctx context.Context, transactionHash *felt.Felt) (*rpc.TransactionReceiptWithBlockInfo, *rpc.RPCError) {
 	return account.provider.TransactionReceipt(ctx, transactionHash)
 }
 

--- a/account/account_test.go
+++ b/account/account_test.go
@@ -949,7 +949,7 @@ func TestWaitForTransactionReceiptMOCK(t *testing.T) {
 		ShouldCallTransactionReceipt bool
 		Hash                         *felt.Felt
 		ExpectedErr                  *rpc.RPCError
-		ExpectedReceipt              rpc.TransactionReceipt
+		ExpectedReceipt              *rpc.TransactionReceiptWithBlockInfo
 	}
 	testSet := map[string][]testSetType{
 		"mock": {
@@ -964,10 +964,13 @@ func TestWaitForTransactionReceiptMOCK(t *testing.T) {
 				Timeout:                      time.Duration(1000),
 				Hash:                         new(felt.Felt).SetUint64(2),
 				ShouldCallTransactionReceipt: true,
-				ExpectedReceipt: rpc.InvokeTransactionReceipt{
-					TransactionHash: new(felt.Felt).SetUint64(2),
-					ExecutionStatus: rpc.TxnExecutionStatusSUCCEEDED,
+				ExpectedReceipt: &rpc.TransactionReceiptWithBlockInfo{
+					TransactionReceipt: rpc.InvokeTransactionReceipt{
+						TransactionHash: new(felt.Felt).SetUint64(2),
+						ExecutionStatus: rpc.TxnExecutionStatusSUCCEEDED,
+					},
 				},
+
 				ExpectedErr: nil,
 			},
 			{
@@ -991,7 +994,7 @@ func TestWaitForTransactionReceiptMOCK(t *testing.T) {
 		if test.ExpectedErr != nil {
 			require.Equal(t, test.ExpectedErr, err)
 		} else {
-			require.Equal(t, test.ExpectedReceipt.GetExecutionStatus(), (*resp).GetExecutionStatus())
+			require.Equal(t, test.ExpectedReceipt.GetExecutionStatus(), (resp.TransactionReceipt).GetExecutionStatus())
 		}
 
 	}

--- a/mocks/mock_rpc_provider.go
+++ b/mocks/mock_rpc_provider.go
@@ -447,10 +447,10 @@ func (mr *MockRpcProviderMockRecorder) TransactionByHash(ctx, hash any) *gomock.
 }
 
 // TransactionReceipt mocks base method.
-func (m *MockRpcProvider) TransactionReceipt(ctx context.Context, transactionHash *felt.Felt) (rpc.TransactionReceipt, *rpc.RPCError) {
+func (m *MockRpcProvider) TransactionReceipt(ctx context.Context, transactionHash *felt.Felt) (*rpc.TransactionReceiptWithBlockInfo, *rpc.RPCError) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TransactionReceipt", ctx, transactionHash)
-	ret0, _ := ret[0].(rpc.TransactionReceipt)
+	ret0, _ := ret[0].(*rpc.TransactionReceiptWithBlockInfo)
 	ret1, _ := ret[1].(*rpc.RPCError)
 	return ret0, ret1
 }

--- a/rpc/provider.go
+++ b/rpc/provider.go
@@ -66,7 +66,7 @@ type RpcProvider interface {
 	TraceBlockTransactions(ctx context.Context, blockID BlockID) ([]Trace, *RPCError)
 	TransactionByBlockIdAndIndex(ctx context.Context, blockID BlockID, index uint64) (Transaction, *RPCError)
 	TransactionByHash(ctx context.Context, hash *felt.Felt) (Transaction, *RPCError)
-	TransactionReceipt(ctx context.Context, transactionHash *felt.Felt) (TransactionReceipt, *RPCError)
+	TransactionReceipt(ctx context.Context, transactionHash *felt.Felt) (*TransactionReceiptWithBlockInfo, *RPCError)
 	TraceTransaction(ctx context.Context, transactionHash *felt.Felt) (TxnTrace, *RPCError)
 }
 

--- a/rpc/transaction.go
+++ b/rpc/transaction.go
@@ -107,13 +107,13 @@ func (provider *Provider) TransactionByBlockIdAndIndex(ctx context.Context, bloc
 // Returns:
 // - TransactionReceipt: the transaction receipt
 // - error: an error if any
-func (provider *Provider) TransactionReceipt(ctx context.Context, transactionHash *felt.Felt) (TransactionReceipt, *RPCError) {
-	var receipt UnknownTransactionReceipt
+func (provider *Provider) TransactionReceipt(ctx context.Context, transactionHash *felt.Felt) (*TransactionReceiptWithBlockInfo, *RPCError) {
+	var receipt TransactionReceiptWithBlockInfo
 	err := do(ctx, provider.c, "starknet_getTransactionReceipt", &receipt, transactionHash)
 	if err != nil {
 		return nil, tryUnwrapToRPCErr(err, ErrHashNotFound)
 	}
-	return receipt.TransactionReceipt, nil
+	return &receipt, nil
 }
 
 // GetTransactionStatus gets the transaction status (possibly reflecting that the tx is still in the mempool, or dropped from it)

--- a/rpc/transaction_test.go
+++ b/rpc/transaction_test.go
@@ -2,12 +2,10 @@ package rpc
 
 import (
 	"context"
-	"regexp"
 	"testing"
 
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/starknet.go/utils"
-	"github.com/google/go-cmp/cmp"
 	"github.com/test-go/testify/require"
 )
 
@@ -165,19 +163,12 @@ func TestTransactionByBlockIdAndIndex(t *testing.T) {
 	}
 }
 
-// TestTransactionReceipt_MatchesCapturedTransaction tests if the transaction receipt matches the captured transaction.
-//
-// Parameters:
-// - t: the testing object for running the test cases
-// Returns:
-//
-//	none
-func TestTransactionReceipt_MatchesCapturedTransaction(t *testing.T) {
+func TestTransactionReceipt(t *testing.T) {
 	testConfig := beforeEach(t)
 
 	type testSetType struct {
-		TxnHash            *felt.Felt
-		ExpectedTxnReceipt TransactionReceipt
+		TxnHash      *felt.Felt
+		ExpectedResp TransactionReceiptWithBlockInfo
 	}
 	var receiptTxn310370_0 = InvokeTransactionReceipt(CommonTransactionReceipt{
 		TransactionHash: utils.TestHexToFelt(t, "0x40c82f79dd2bc1953fc9b347a3e7ab40fe218ed5740bf4e120f74e8a3c9ac99"),
@@ -185,8 +176,6 @@ func TestTransactionReceipt_MatchesCapturedTransaction(t *testing.T) {
 		Type:            "INVOKE",
 		ExecutionStatus: TxnExecutionStatusSUCCEEDED,
 		FinalityStatus:  TxnFinalityStatusAcceptedOnL1,
-		BlockHash:       utils.TestHexToFelt(t, "0x6c2fe3db009a2e008c2d65fca14204f3405cb74742fcf685f02473acaf70c72"),
-		BlockNumber:     310370,
 		MessagesSent:    []MsgToL1{},
 		Events: []Event{
 			{
@@ -224,8 +213,6 @@ func TestTransactionReceipt_MatchesCapturedTransaction(t *testing.T) {
 		Type:            "INVOKE",
 		ExecutionStatus: TxnExecutionStatusSUCCEEDED,
 		FinalityStatus:  TxnFinalityStatusAcceptedOnL2,
-		BlockHash:       utils.TestHexToFelt(t, "0x50e864db6b81ce69fbeb70e6a7284ee2febbb9a2e707415de7adab83525e9cd"),
-		BlockNumber:     319132,
 		MessagesSent:    []MsgToL1{},
 		Events: []Event{
 			{
@@ -261,154 +248,33 @@ func TestTransactionReceipt_MatchesCapturedTransaction(t *testing.T) {
 		"mock": {},
 		"testnet": {
 			{
-				TxnHash:            utils.TestHexToFelt(t, "0x40c82f79dd2bc1953fc9b347a3e7ab40fe218ed5740bf4e120f74e8a3c9ac99"),
-				ExpectedTxnReceipt: receiptTxn310370_0,
+				TxnHash: utils.TestHexToFelt(t, "0x40c82f79dd2bc1953fc9b347a3e7ab40fe218ed5740bf4e120f74e8a3c9ac99"),
+				ExpectedResp: TransactionReceiptWithBlockInfo{
+					TransactionReceipt: receiptTxn310370_0,
+					BlockNumber:        310370,
+					BlockHash:          utils.TestHexToFelt(t, "0x6c2fe3db009a2e008c2d65fca14204f3405cb74742fcf685f02473acaf70c72"),
+				},
 			},
 		},
 		"mainnet": {},
 		"integration": {
 			{
-				TxnHash:            utils.TestHexToFelt(t, "0x49728601e0bb2f48ce506b0cbd9c0e2a9e50d95858aa41463f46386dca489fd"),
-				ExpectedTxnReceipt: receiptTxnIntegration,
+				TxnHash: utils.TestHexToFelt(t, "0x49728601e0bb2f48ce506b0cbd9c0e2a9e50d95858aa41463f46386dca489fd"),
+				ExpectedResp: TransactionReceiptWithBlockInfo{
+					TransactionReceipt: receiptTxnIntegration,
+					BlockNumber:        319132,
+					BlockHash:          utils.TestHexToFelt(t, "0x50e864db6b81ce69fbeb70e6a7284ee2febbb9a2e707415de7adab83525e9cd"),
+				},
 			},
 		}}[testEnv]
 
 	for _, test := range testSet {
 		spy := NewSpy(testConfig.provider.c)
 		testConfig.provider.c = spy
-		txReceiptInterface, err := testConfig.provider.TransactionReceipt(context.Background(), test.TxnHash)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if txReceiptInterface == nil {
-			t.Fatal("transaction receipt should exist")
-		}
-		txnReceipt, ok := txReceiptInterface.(InvokeTransactionReceipt)
-		if !ok {
-			t.Fatalf("transaction receipt should be InvokeTransactionReceipt, instead %T", txReceiptInterface)
-		}
-		if !cmp.Equal(test.ExpectedTxnReceipt, txnReceipt) {
-			t.Fatalf("the expected transaction blocks to match, instead: %s", cmp.Diff(test.ExpectedTxnReceipt, txnReceipt))
-		}
-	}
-}
-
-// TestTransactionReceipt_MatchesStatus tests if the transaction receipt matches the given execution status.
-//
-// It initializes a test configuration and defines a test set containing transaction hash and execution status pairs.
-// For each test in the test set, it creates a spy and sets the provider of the test configuration to the spy.
-// Then, it retrieves the transaction receipt for the given transaction hash using the provider.
-// If the transaction receipt does not exist, it fails the test.
-// It asserts that the transaction receipt is of type InvokeTransactionReceipt.
-// Finally, it checks if the execution status of the transaction receipt matches the expected execution status using a regular expression.
-//
-// Parameters:
-// - t: the testing object for running the test cases
-// Returns:
-//
-//	none
-func TestTransactionReceipt_MatchesStatus(t *testing.T) {
-	testConfig := beforeEach(t)
-
-	type testSetType struct {
-		TxnHash         *felt.Felt
-		ExecutionStatus string
-	}
-	testSet := map[string][]testSetType{
-		"mock": {},
-		"testnet": {
-			{
-				TxnHash:         utils.TestHexToFelt(t, "0x650667fb0f17e63e1c9d1040e750d160f3dbfebcab990e7d4382f33468b1b59"),
-				ExecutionStatus: "(SUCCEEDED|REVERTED)",
-			},
-		},
-		"mainnet": {},
-	}[testEnv]
-
-	for _, test := range testSet {
-		spy := NewSpy(testConfig.provider.c, false)
-		testConfig.provider.c = spy
-		txReceiptInterface, err := testConfig.provider.TransactionReceipt(context.Background(), test.TxnHash)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if txReceiptInterface == nil {
-			t.Fatal("transaction receipt should exist")
-		}
-		txnReceipt, ok := txReceiptInterface.(InvokeTransactionReceipt)
-		if !ok {
-			t.Fatalf("transaction receipt should be InvokeTransactionReceipt, instead %T", txReceiptInterface)
-		}
-		if ok, err := regexp.MatchString(test.ExecutionStatus, string(txnReceipt.ExecutionStatus)); err != nil || !ok {
-			t.Fatal("error checking transaction status", ok, err, txnReceipt.ExecutionStatus)
-		}
-	}
-}
-
-// TestDeployOrDeclareReceipt is a test function that verifies the functionality of the DeployOrDeclareReceipt method.
-//
-// It tests the behavior of the DeployOrDeclareReceipt method by creating a test configuration, defining a test set,
-// and executing the test set for the specified test environment. It makes assertions to ensure that the expected
-// transaction receipt matches the actual transaction receipt returned by the method.
-//
-// The function takes no parameters and does not return any values.
-//
-// Parameters:
-// - t: the testing object for running the test cases
-// Returns:
-//
-//	none
-func TestDeployOrDeclareReceipt(t *testing.T) {
-	testConfig := beforeEach(t)
-
-	type testSetType struct {
-		TxnHash            *felt.Felt
-		ExpectedTxnReceipt TransactionReceipt
-	}
-
-	var receiptTxn300114_3 = DeclareTransactionReceipt(
-		CommonTransactionReceipt{
-			TransactionHash:    utils.TestHexToFelt(t, "0x46a9f52a96b2d226407929e04cb02507e531f7c78b9196fc8c910351d8c33f3"),
-			ActualFee:          FeePayment{Amount: utils.TestHexToFelt(t, "0x0"), Unit: UnitWei},
-			FinalityStatus:     TxnFinalityStatusAcceptedOnL1,
-			ExecutionStatus:    TxnExecutionStatusSUCCEEDED,
-			BlockHash:          utils.TestHexToFelt(t, "0x184268bfbce24766fa53b65c9c8b30b295e145e8281d543a015b46308e27fdf"),
-			BlockNumber:        300114,
-			Type:               "DECLARE",
-			MessagesSent:       []MsgToL1{},
-			Events:             []Event{},
-			ExecutionResources: ExecutionResources{Steps: 0},
-		})
-
-	testSet := map[string][]testSetType{
-		"mock": {},
-		"testnet": {
-			{
-				TxnHash:            utils.TestHexToFelt(t, "0x46a9f52a96b2d226407929e04cb02507e531f7c78b9196fc8c910351d8c33f3"),
-				ExpectedTxnReceipt: receiptTxn300114_3,
-			},
-		},
-		"mainnet": {},
-	}[testEnv]
-
-	for _, test := range testSet {
-		spy := NewSpy(testConfig.provider.c)
-		testConfig.provider.c = spy
-		txReceiptInterface, err := testConfig.provider.TransactionReceipt(context.Background(), test.TxnHash)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if txReceiptInterface == nil {
-			t.Fatal("transaction receipt should exist")
-		}
-		txnDeclareReceipt, ok := txReceiptInterface.(DeclareTransactionReceipt)
-		if !ok {
-			t.Fatalf("transaction receipt should be Deploy or Declare, instead %T", txReceiptInterface)
-		}
-		if !cmp.Equal(test.ExpectedTxnReceipt, txnDeclareReceipt) {
-			t.Fatalf("the expected transaction blocks to match, instead: %s", cmp.Diff(test.ExpectedTxnReceipt, txnDeclareReceipt))
-		}
+		txReceiptWithBlockInfo, err := testConfig.provider.TransactionReceipt(context.Background(), test.TxnHash)
+		require.Nil(t, err)
+		require.Equal(t, txReceiptWithBlockInfo.BlockNumber, test.ExpectedResp.BlockNumber)
+		require.Equal(t, txReceiptWithBlockInfo.BlockHash, test.ExpectedResp.BlockHash)
 
 	}
 }
@@ -435,7 +301,7 @@ func TestGetTransactionStatus(t *testing.T) {
 
 	for _, test := range testSet {
 		resp, err := testConfig.provider.GetTransactionStatus(context.Background(), test.TxnHash)
-		require.NoError(t, err)
+		require.Nil(t, err)
 		require.Equal(t, *resp, test.ExpectedResp)
 	}
 }

--- a/rpc/types_transaction_receipt.go
+++ b/rpc/types_transaction_receipt.go
@@ -28,8 +28,6 @@ type CommonTransactionReceipt struct {
 	ActualFee       FeePayment         `json:"actual_fee"`
 	ExecutionStatus TxnExecutionStatus `json:"execution_status"`
 	FinalityStatus  TxnFinalityStatus  `json:"finality_status"`
-	BlockHash       *felt.Felt         `json:"block_hash"`
-	BlockNumber     uint64             `json:"block_number"`
 	Type            TransactionType    `json:"type,omitempty"`
 	MessagesSent    []MsgToL1          `json:"messages_sent"`
 	RevertReason    string             `json:"revert_reason,omitempty"`
@@ -271,108 +269,6 @@ func (tr L1HandlerTransactionReceipt) GetExecutionStatus() TxnExecutionStatus {
 	return tr.ExecutionStatus
 }
 
-type PendingL1HandlerTransactionReceipt struct {
-	Type TransactionType `json:"type"`
-	// The message hash as it appears on the L1 core contract
-	MsgHash NumAsHex `json:"message_hash"`
-	PendingCommonTransactionReceiptProperties
-}
-
-func (tr PendingL1HandlerTransactionReceipt) Hash() *felt.Felt {
-	return tr.TransactionHash
-}
-
-func (tr PendingL1HandlerTransactionReceipt) GetExecutionStatus() TxnExecutionStatus {
-	return tr.ExecutionStatus
-}
-
-type PendingDeclareTransactionReceipt struct {
-	Type TransactionType `json:"type"`
-	PendingCommonTransactionReceiptProperties
-}
-
-func (tr PendingDeclareTransactionReceipt) Hash() *felt.Felt {
-	return tr.TransactionHash
-}
-
-func (tr PendingDeclareTransactionReceipt) GetExecutionStatus() TxnExecutionStatus {
-	return tr.ExecutionStatus
-}
-
-type PendingDeployAccountTransactionReceipt struct {
-	Type TransactionType `json:"type"`
-	// The address of the deployed contract
-	ContractAddress *felt.Felt `json:"contract_address"`
-	PendingCommonTransactionReceiptProperties
-}
-
-// Hash returns the transaction hash of the pending deploy transaction receipt.
-//
-// Parameters:
-//
-//	none
-//
-// Returns:
-// - *felt.Felt: the transaction hash
-func (tr PendingDeployAccountTransactionReceipt) Hash() *felt.Felt {
-	return tr.TransactionHash
-}
-
-// GetExecutionStatus returns the execution status of the pending deploy transaction receipt.
-//
-// Parameters:
-//
-//	none
-//
-// Returns:
-// - TxnExecutionStatus: the execution status
-func (tr PendingDeployAccountTransactionReceipt) GetExecutionStatus() TxnExecutionStatus {
-	return tr.ExecutionStatus
-}
-
-type PendingInvokeTransactionReceipt struct {
-	Type TransactionType `json:"type"`
-	PendingCommonTransactionReceiptProperties
-}
-
-// Hash returns the transaction hash of the pending deploy transaction receipt.
-//
-// Parameters:
-//
-//	none
-//
-// Returns:
-// - *felt.Felt: the transaction hash
-func (tr PendingInvokeTransactionReceipt) Hash() *felt.Felt {
-	return tr.TransactionHash
-}
-
-// GetExecutionStatus returns the execution status of the pending deploy transaction receipt.
-//
-// Parameters:
-//
-//	none
-//
-// Returns:
-// - TxnExecutionStatus: the execution status
-func (tr PendingInvokeTransactionReceipt) GetExecutionStatus() TxnExecutionStatus {
-	return tr.ExecutionStatus
-}
-
-type PendingCommonTransactionReceiptProperties struct {
-	// TransactionHash The hash identifying the transaction
-	TransactionHash *felt.Felt `json:"transaction_hash"`
-	// ActualFee The fee that was charged by the sequencer
-	ActualFee       FeePayment         `json:"actual_fee"`
-	MessagesSent    []MsgToL1          `json:"messages_sent"`
-	ExecutionStatus TxnExecutionStatus `json:"execution_status"`
-	FinalityStatus  TxnFinalityStatus  `json:"finality_status"`
-	RevertReason    string             `json:"revert_reason"`
-	// Events The events emitted as part of this transaction
-	Events             []Event            `json:"events"`
-	ExecutionResources ExecutionResources `json:"execution_resources"`
-}
-
 type ExecutionResources struct {
 	// The number of Cairo steps used
 	Steps int `json:"steps"`
@@ -404,30 +300,6 @@ func (er *ExecutionResources) Validate() bool {
 		return false
 	}
 	return true
-}
-
-// Hash returns the transaction hash of the PendingCommonTransactionReceiptProperties.
-//
-// Parameters:
-//
-//	none
-//
-// Returns:
-// - *felt.Felt: the transaction hash
-func (tr PendingCommonTransactionReceiptProperties) Hash() *felt.Felt {
-	return tr.TransactionHash
-}
-
-// GetExecutionStatus returns the execution status of the pending common transaction receipt properties.
-//
-// Parameters:
-//
-//	none
-//
-// Returns:
-// - TxnExecutionStatus: the execution status
-func (tr PendingCommonTransactionReceiptProperties) GetExecutionStatus() TxnExecutionStatus {
-	return tr.ExecutionStatus
 }
 
 type TransactionReceipt interface {
@@ -502,28 +374,6 @@ func unmarshalTransactionReceipt(t interface{}) (TransactionReceipt, error) {
 			return nil, fmt.Errorf("unknown transaction type: %v", t)
 		}
 
-		// Pending doesn't have a block number
-		if casted["block_hash"] == nil {
-			switch TransactionType(typ.(string)) {
-			case TransactionType_Invoke:
-				var txn PendingInvokeTransactionReceipt
-				remarshal(casted, &txn)
-				return txn, nil
-			case TransactionType_DeployAccount:
-				var txn PendingDeployAccountTransactionReceipt
-				remarshal(casted, &txn)
-				return txn, nil
-			case TransactionType_L1Handler:
-				var txn PendingL1HandlerTransactionReceipt
-				remarshal(casted, &txn)
-				return txn, nil
-			case TransactionType_Declare:
-				var txn PendingDeclareTransactionReceipt
-				remarshal(casted, &txn)
-				return txn, nil
-			}
-		}
-
 		switch TransactionType(typ.(string)) {
 		case TransactionType_Invoke:
 			var txn InvokeTransactionReceipt
@@ -564,4 +414,10 @@ const (
 type TxnStatusResp struct {
 	ExecutionStatus TxnExecutionStatus `json:"execution_status,omitempty"`
 	FinalityStatus  TxnStatus          `json:"finality_status"`
+}
+
+type TransactionReceiptWithBlockInfo struct {
+	TransactionReceipt
+	BlockHash   *felt.Felt `json:"block_hash,omitempty"`
+	BlockNumber uint       `json:"block_number,omitempty"`
 }


### PR DESCRIPTION
Pending receipts removed
blockhash and blockNumber removed from receipts
getTransactionReceipt returns a concrete new type, TXN_RECEIPT_WITH_BLOCK_INFO
Unneeded tests removed (duplicates existing test)