### PR TITLE
Update SpecVersion to stop returning InternalError for nil errors

### DIFF
--- a/rpc/version.go
+++ b/rpc/version.go
@@ -8,5 +8,8 @@ import "context"
 func (provider *Provider) SpecVersion(ctx context.Context) (string, error) {
 	var result string
 	err := do(ctx, provider.c, "starknet_specVersion", &result)
-	return result, Err(InternalError, err)
+	if err != nil {
+		return "", Err(InternalError, err)
+	}
+	return result, nil
 }

--- a/rpc/version_test.go
+++ b/rpc/version_test.go
@@ -20,7 +20,7 @@ func TestSpecVersion(t *testing.T) {
 		"mainnet": {},
 		"mock":    {},
 		"testnet": {{
-			ExpectedResp: "0.6.0",
+			ExpectedResp: "0.7.0",
 		}},
 	}[testEnv]
 


### PR DESCRIPTION
add check for nil error in function SpecVersion, instead of returning a wrapped error every time.