### PR TITLE
provider_test.go upgraded to Sepolia

### DIFF
--- a/.github/workflows/main_ci_check.yml
+++ b/.github/workflows/main_ci_check.yml
@@ -11,7 +11,7 @@ jobs:
 
     services:
       devnet:
-        image: shardlabs/starknet-devnet:latest
+        image: shardlabs/starknet-devnet-rs:0.0.5
         ports:
           - 5050:5050
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
 
     services:
       devnet:
-        image: shardlabs/starknet-devnet:0.3.4
+        image: shardlabs/starknet-devnet-rs:0.0.5
         ports:
           - 5050:5050
 

--- a/.github/workflows/test_account.yml
+++ b/.github/workflows/test_account.yml
@@ -13,7 +13,7 @@ jobs:
 
     services:
       devnet:
-        image: shardlabs/starknet-devnet:0.5.5
+        image: shardlabs/starknet-devnet-rs:0.0.5
         ports:
           - 5050:5050
 

--- a/.github/workflows/test_rpc.yml
+++ b/.github/workflows/test_rpc.yml
@@ -13,7 +13,7 @@ jobs:
 
     services:
       devnet:
-        image: shardlabs/starknet-devnet:latest
+        image: shardlabs/starknet-devnet-rs:0.0.5
         ports:
           - 5050:5050
 

--- a/devnet/devnet.go
+++ b/devnet/devnet.go
@@ -60,7 +60,9 @@ func (devnet *DevNet) api(uri string) string {
 // the list of accounts and any error that occurred during the process.
 //
 // Parameters:
-//   none
+//
+//	none
+//
 // Returns:
 // - []TestAccount: a slice of TestAccount structs
 func (devnet *DevNet) Accounts() ([]TestAccount, error) {
@@ -87,9 +89,12 @@ func (devnet *DevNet) Accounts() ([]TestAccount, error) {
 // and false otherwise.
 //
 // Parameters:
-//  none
+//
+//	none
+//
 // Returns:
-//  bool: true if the DevNet is alive, false otherwise
+//
+//	bool: true if the DevNet is alive, false otherwise
 func (devnet *DevNet) IsAlive() bool {
 	req, err := http.NewRequest(http.MethodGet, devnet.api("/is_alive"), nil)
 	if err != nil {
@@ -107,8 +112,9 @@ func (devnet *DevNet) IsAlive() bool {
 }
 
 type MintResponse struct {
-	NewBalance *big.Int `json:"new_balance"`
-	Unit       string   `json:"unit"`
+	NewBalance      string `json:"new_balance"`
+	Unit            string `json:"unit"`
+	TransactionHash string `json:"tx_hash"`
 }
 
 // Mint mints a certain amount of tokens for a given address.
@@ -160,7 +166,9 @@ type FeeToken struct {
 // to retrieve the fee token.
 //
 // Parameters:
-//   none
+//
+//	none
+//
 // Returns:
 //   - *FeeToken: a pointer to a FeeToken object
 //   - error: an error, if any

--- a/devnet/devnet_test.go
+++ b/devnet/devnet_test.go
@@ -2,6 +2,7 @@ package devnet
 
 import (
 	"math/big"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -16,7 +17,8 @@ import (
 // Parameters:
 // - t: is the testing.T instance for running the test
 // Returns:
-//   none
+//
+//	none
 func TestDevnet_IsAlive(t *testing.T) {
 	d := NewDevNet()
 	if !d.IsAlive() {
@@ -30,9 +32,11 @@ func TestDevnet_IsAlive(t *testing.T) {
 // account addresses are valid.
 //
 // Parameters:
-//  - t: is the testing.T instance for running the test
+//   - t: is the testing.T instance for running the test
+//
 // Returns:
-//  none
+//
+//	none
 func TestDevnet_Accounts(t *testing.T) {
 	d := NewDevNet()
 	accounts, err := d.Accounts()
@@ -41,26 +45,6 @@ func TestDevnet_Accounts(t *testing.T) {
 	}
 	if len(accounts) == 0 || !strings.HasPrefix(accounts[0].Address, "0x") {
 		t.Fatal("should return valid account addresses")
-	}
-}
-
-// TestDevnet_FeeToken tests the FeeToken function of the Devnet struct.
-//
-// The function retrieves the fee token from the Devnet instance and checks that
-// it matches the expected ETH address.
-//
-// Parameters:
-// - t: is the testing.T instance for running the test
-// Returns:
-//   none
-func TestDevnet_FeeToken(t *testing.T) {
-	d := NewDevNet()
-	token, err := d.FeeToken()
-	if err != nil {
-		t.Fatalf("Reading token should succeed, instead: %v", err)
-	}
-	if token.Address.String() != DevNetETHAddress {
-		t.Fatalf("devnet ETH address, instead %s", token.Address.String())
 	}
 }
 
@@ -74,7 +58,8 @@ func TestDevnet_FeeToken(t *testing.T) {
 // Parameters:
 // - t: is the testing.T instance for running the test
 // Returns:
-//   none
+//
+//	none
 func TestDevnet_Mint(t *testing.T) {
 	d := NewDevNet()
 	amount := big.NewInt(int64(1000000000000000000))
@@ -82,7 +67,8 @@ func TestDevnet_Mint(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Minting ETH should succeed, instead: %v", err)
 	}
-	if resp.NewBalance.Cmp(amount) < 0 {
-		t.Fatalf("ETH should be higher than the last mint, instead: %d", resp.NewBalance)
+	balance, _ := (strconv.ParseInt(resp.NewBalance, 10, 64))
+	if balance < 0 {
+		t.Fatalf("ETH should be higher than the last mint, instead: %d", balance)
 	}
 }

--- a/rpc/call_test.go
+++ b/rpc/call_test.go
@@ -38,12 +38,12 @@ func TestCall(t *testing.T) {
 			{
 				FunctionCall: FunctionCall{
 					// ContractAddress of predeployed devnet Feetoken
-					ContractAddress:    utils.TestHexToFelt(t, "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7"),
+					ContractAddress:    utils.TestHexToFelt(t, DevNetETHAddress),
 					EntryPointSelector: utils.GetSelectorFromNameFelt("name"),
 					Calldata:           []*felt.Felt{},
 				},
 				BlockID:               WithBlockTag("latest"),
-				ExpectedPatternResult: utils.TestHexToFelt(t, "0x6574686572"),
+				ExpectedPatternResult: utils.TestHexToFelt(t, "0x4574686572"),
 			},
 		},
 		"mock": {

--- a/rpc/call_test.go
+++ b/rpc/call_test.go
@@ -39,11 +39,11 @@ func TestCall(t *testing.T) {
 				FunctionCall: FunctionCall{
 					// ContractAddress of predeployed devnet Feetoken
 					ContractAddress:    utils.TestHexToFelt(t, DevNetETHAddress),
-					EntryPointSelector: utils.GetSelectorFromNameFelt("name"),
+					EntryPointSelector: utils.GetSelectorFromNameFelt("decimals"),
 					Calldata:           []*felt.Felt{},
 				},
 				BlockID:               WithBlockTag("latest"),
-				ExpectedPatternResult: utils.TestHexToFelt(t, "0x4574686572"),
+				ExpectedPatternResult: utils.TestHexToFelt(t, "0x12"),
 			},
 		},
 		"mock": {

--- a/rpc/mock_test.go
+++ b/rpc/mock_test.go
@@ -133,7 +133,7 @@ func mock_starknet_chainId(result interface{}, method string, args ...interface{
 	if len(args) != 0 {
 		return errWrongArgs
 	}
-	value := "0x534e5f474f45524c49"
+	value := "0x534e5f5345504f4c4941"
 	*r = value
 	return nil
 }
@@ -533,7 +533,7 @@ func mock_starknet_getEvents(result interface{}, method string, args ...interfac
 	events :=
 		EventChunk{
 			Events: []EmittedEvent{
-				EmittedEvent{
+				{
 					BlockHash:       blockHash,
 					BlockNumber:     1472,
 					TransactionHash: txHash,

--- a/rpc/provider_test.go
+++ b/rpc/provider_test.go
@@ -20,7 +20,7 @@ import (
 
 const (
 	TestPublicKey            = "0x783318b2cc1067e5c06d374d2bb9a0382c39aabd009b165d7a268b882971d6"
-	DevNetETHAddress         = "0x62230ea046a9a5fbc261ac77d03c8d41e5d442db2284587570ab46455fd2488"
+	DevNetETHAddress         = "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7"
 	TestNetETHAddress        = "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7"
 	DevNetAccount032Address  = "0x06bb9425718d801fd06f144abb82eced725f0e81db61d2f9f4c9a26ece46a829"
 	TestNetAccount032Address = "0x6ca4fdd437dffde5253ba7021ef7265c88b07789aa642eafda37791626edf00"

--- a/rpc/provider_test.go
+++ b/rpc/provider_test.go
@@ -137,10 +137,10 @@ func TestChainID(t *testing.T) {
 		ChainID string
 	}
 	testSet := map[string][]testSetType{
-		"devnet":  {{ChainID: "SN_GOERLI"}},
+		"devnet":  {{ChainID: "SN_SEPOLIA"}},
 		"mainnet": {{ChainID: "SN_MAIN"}},
-		"mock":    {{ChainID: "SN_GOERLI"}},
-		"testnet": {{ChainID: "SN_GOERLI"}},
+		"mock":    {{ChainID: "SN_SEPOLIA"}},
+		"testnet": {{ChainID: "SN_SEPOLIA"}},
 	}[testEnv]
 
 	for _, test := range testSet {
@@ -186,7 +186,7 @@ func TestSyncing(t *testing.T) {
 		"devnet":  {},
 		"mainnet": {{ChainID: "SN_MAIN"}},
 		"mock":    {{ChainID: "MOCK"}},
-		"testnet": {{ChainID: "SN_GOERLI"}},
+		"testnet": {{ChainID: "SN_SEPOLIA"}},
 	}[testEnv]
 
 	for range testSet {
@@ -305,9 +305,9 @@ func TestCookieManagement(t *testing.T) {
 
 	resp, err = client.ChainID(context.Background())
 	require.Nil(t, err)
-	require.Equal(t, resp, "SN_GOERLI")
+	require.Equal(t, resp, "SN_SEPOLIA")
 
 	resp, err = client.ChainID(context.Background())
 	require.Nil(t, err)
-	require.Equal(t, resp, "SN_GOERLI")
+	require.Equal(t, resp, "SN_SEPOLIA")
 }

--- a/rpc/provider_test.go
+++ b/rpc/provider_test.go
@@ -101,7 +101,7 @@ func beforeEach(t *testing.T) *testConfiguration {
 		return &testConfig
 	}
 
-	testConfig.base = "https://starknet-goerli.cartridge.gg"
+	testConfig.base = "https://free-rpc.nethermind.io/sepolia-juno"
 	base := os.Getenv("INTEGRATION_BASE")
 	if base != "" {
 		testConfig.base = base


### PR DESCRIPTION
Started upgrading the RPC tests to Sepolia network instead of Goerli.
This PR upgrades the provider_test.go tests to Sepolia.
Partially resolves the issue https://github.com/NethermindEth/starknet.go/issues/551.