### PR TITLE
pedersen x range bug fix

### DIFF
--- a/curve/curve.go
+++ b/curve/curve.go
@@ -590,7 +590,7 @@ func (sc StarkCurve) PedersenHash(elems []*big.Int) (hash *big.Int, err error) {
 	for i, elem := range elems {
 		x := new(big.Int).Set(elem)
 
-		if x.Cmp(big.NewInt(0)) != -1 && x.Cmp(sc.P) != -1 {
+		if x.Cmp(big.NewInt(0)) == -1 || x.Cmp(sc.P) >= 0 {
 			return ptx, fmt.Errorf("invalid x: %v", x)
 		}
 


### PR DESCRIPTION
There seems to be a bug in the pedersen hash func 

ref: https://github.com/starkware-libs/cairo-lang/blob/de741b92657f245a50caab99cfaef093152fd8be/src/starkware/crypto/signature/fast_pedersen_hash.py#L27