### PR TITLE
Adds GetStorageProof method

### DIFF
--- a/mocks/mock_rpc_provider.go
+++ b/mocks/mock_rpc_provider.go
@@ -296,6 +296,21 @@ func (mr *MockRpcProviderMockRecorder) Events(ctx, input any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Events", reflect.TypeOf((*MockRpcProvider)(nil).Events), ctx, input)
 }
 
+// GetStorageProof mocks base method.
+func (m *MockRpcProvider) GetStorageProof(ctx context.Context, storageProofInput rpc.StorageProofInput) (*rpc.StorageProofResult, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetStorageProof", ctx, storageProofInput)
+	ret0, _ := ret[0].(*rpc.StorageProofResult)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetStorageProof indicates an expected call of GetStorageProof.
+func (mr *MockRpcProviderMockRecorder) GetStorageProof(ctx, storageProofInput any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStorageProof", reflect.TypeOf((*MockRpcProvider)(nil).GetStorageProof), ctx, storageProofInput)
+}
+
 // GetTransactionStatus mocks base method.
 func (m *MockRpcProvider) GetTransactionStatus(ctx context.Context, transactionHash *felt.Felt) (*rpc.TxnStatusResp, error) {
 	m.ctrl.T.Helper()

--- a/rpc/contract.go
+++ b/rpc/contract.go
@@ -160,3 +160,20 @@ func (provider *Provider) EstimateMessageFee(ctx context.Context, msg MsgFromL1,
 	}
 	return &raw, nil
 }
+
+// Get merkle paths in one of the state tries: global state, classes, individual contract
+//
+// Parameters:
+// - ctx: The context of the function call
+// - storageProofInput: an input containing at least one of the fields filled
+// Returns:
+// - *StorageProofResult: the proofs of the field passed in the input
+// - error: an error if any occurred during the execution
+func (provider *Provider) GetStorageProof(ctx context.Context, storageProofInput StorageProofInput) (*StorageProofResult, error) {
+	var raw StorageProofResult
+	if err := do(ctx, provider.c, "starknet_getStorageProof", &raw, storageProofInput); err != nil {
+
+		return nil, tryUnwrapToRPCErr(err)
+	}
+	return &raw, nil
+}

--- a/rpc/contract.go
+++ b/rpc/contract.go
@@ -161,7 +161,8 @@ func (provider *Provider) EstimateMessageFee(ctx context.Context, msg MsgFromL1,
 	return &raw, nil
 }
 
-// Get merkle paths in one of the state tries: global state, classes, individual contract
+// Get merkle paths in one of the state tries: global state, classes, individual contract.
+// A single request can query for any mix of the three types of storage proofs (classes, contracts, and storage)
 //
 // Parameters:
 // - ctx: The context of the function call
@@ -173,7 +174,7 @@ func (provider *Provider) GetStorageProof(ctx context.Context, storageProofInput
 	var raw StorageProofResult
 	if err := do(ctx, provider.c, "starknet_getStorageProof", &raw, storageProofInput); err != nil {
 
-		return nil, tryUnwrapToRPCErr(err)
+		return nil, tryUnwrapToRPCErr(err, ErrBlockNotFound, ErrStorageProofNotSupported)
 	}
 	return &raw, nil
 }

--- a/rpc/contract_test.go
+++ b/rpc/contract_test.go
@@ -683,3 +683,7 @@ func TestEstimateFee(t *testing.T) {
 		}
 	}
 }
+
+func TestGetStorageProof(t *testing.T) {
+	t.Skip("TODO: create a test before merge")
+}

--- a/rpc/errors.go
+++ b/rpc/errors.go
@@ -138,6 +138,10 @@ var (
 		Code:    41,
 		Message: "Transaction execution error",
 	}
+	ErrStorageProofNotSupported = &RPCError{
+		Code:    42,
+		Message: "the node doesn't support storage proofs for blocks that are too far in the past",
+	}
 	ErrInvalidContractClass = &RPCError{
 		Code:    50,
 		Message: "Invalid contract class",

--- a/rpc/provider.go
+++ b/rpc/provider.go
@@ -59,6 +59,7 @@ type RpcProvider interface {
 	EstimateMessageFee(ctx context.Context, msg MsgFromL1, blockID BlockID) (*FeeEstimation, error)
 	Events(ctx context.Context, input EventsInput) (*EventChunk, error)
 	BlockWithReceipts(ctx context.Context, blockID BlockID) (interface{}, error)
+	GetStorageProof(ctx context.Context, storageProofInput StorageProofInput) (*StorageProofResult, error)
 	GetTransactionStatus(ctx context.Context, transactionHash *felt.Felt) (*TxnStatusResp, error)
 	Nonce(ctx context.Context, blockID BlockID, contractAddress *felt.Felt) (*felt.Felt, error)
 	SimulateTransactions(ctx context.Context, blockID BlockID, txns []BroadcastTxn, simulationFlags []SimulationFlag) ([]SimulatedTransaction, error)

--- a/rpc/types_contract.go
+++ b/rpc/types_contract.go
@@ -74,6 +74,46 @@ type ContractClass struct {
 	ABI string `json:"abi,omitempty"`
 }
 
+// You must provide one of these fields
+type StorageProofInput struct {
+	// A list of the class hashes for which we want to prove membership in the classes trie
+	ClassHashes []*felt.Felt `json:"class_hashes,omitempty"`
+	// A list of contracts for which we want to prove membership in the global state trie
+	ContractAddresses []*felt.Felt `json:"contract_addresses,omitempty"`
+	// A list of (contract_address, storage_keys) pairs
+	ContractsStorageKeys []ContractStorageKeys `json:"contracts_storage_keys,omitempty"`
+}
+
+type StorageProofResult struct {
+	ClassesProof           NodeHashToNode   `json:"classes_proof,omitempty"`
+	ContractsProof         NodeHashToNode   `json:"contracts_proof,omitempty"`
+	ContractsStorageProofs []NodeHashToNode `json:"contracts_storage_proofs,omitempty"`
+}
+
+type ContractStorageKeys struct {
+	ContractAddress *felt.Felt   `json:"contract_address"`
+	StorageKeys     []*felt.Felt `json:"storage_keys"`
+}
+
+// A node_hash -> node mapping of all the nodes in the union of the paths between the requested leaves and the root (for each node present, its sibling is also present)
+type NodeHashToNode struct {
+	NodeHash *felt.Felt `json:"node_hash"`
+	Node     MerkleNode `json:"node"`
+}
+
+type MerkleNode struct {
+	Path   uint       `json:"path"`
+	Length uint       `json:"length"`
+	Value  *felt.Felt `json:"value"`
+	// the hash of the child nodes, if not present then the node is a leaf
+	ChildrenHashes ChildrenHashes `json:"children_hashes,omitempty"`
+}
+
+type ChildrenHashes struct {
+	Left  *felt.Felt `json:"left"`
+	Right *felt.Felt `json:"right"`
+}
+
 // UnmarshalJSON unmarshals the JSON content into the DeprecatedContractClass struct.
 //
 // It takes a byte array `content` as a parameter and returns an error if there is any.


### PR DESCRIPTION
https://github.com/NethermindEth/starknet.go/issues/623

This PR aims to implement some RPC v0.8.0 updates to starknet.go. The ones addressed by this PR are:

Methods
starknet_getStorageProof

Components
MERKLE_NODE
NODE_HASH_TO_NODE_MAPPING

Errors
STORAGE_PROOF_NOT_SUPPORTED

Note: As the RPC v0.8.0 has not yet been released, we can't fully test these changes as the nodes haven't implemented them yet. They will be updated before merging into main