### PR TITLE
Creates a description for the multi-call feature

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -28,6 +28,8 @@ To run an example:
   R: See [deployContractUDC](./deployContractUDC/main.go).
 1. How to send an invoke transaction?  
   R: See [simpleInvoke](./simpleInvoke/main.go).
+1. How to make multiple function calls in the same transaction?
+  R: See [simpleInvoke](./simpleInvoke/main.go), line 92.
 1. How to get the transaction status?  
   R: See [simpleInvoke](./simpleInvoke/main.go), line 131.
 1. How to deploy an ERC20 token?  
@@ -38,4 +40,3 @@ To run an example:
   R: See [simpleCall](./simpleCall/main.go).
 1. How to sign and verify a typed data?  
   R: See [typedData](./typedData/main.go).
-

--- a/examples/simpleInvoke/main.go
+++ b/examples/simpleInvoke/main.go
@@ -88,6 +88,10 @@ func main() {
 	}
 
 	// Building the Calldata with the help of FmtCalldata where we pass in the FnCall struct along with the Cairo version
+	//
+	// note: in Starknet, you can pass multiple function calls in the same transaction, even if they are from different contracts.
+	// To do this, just group all the function calls in the same slice and pass it to FmtCalldata
+	// e.g. : InvokeTx.Calldata, err = accnt.FmtCalldata([]rpc.FunctionCall{funcCall, anotherFuncCall, yetAnotherFuncCallFromDifferentContract})
 	InvokeTx.Calldata, err = accnt.FmtCalldata([]rpc.FunctionCall{FnCall})
 	if err != nil {
 		panic(err)

--- a/examples/simpleInvoke/main.go
+++ b/examples/simpleInvoke/main.go
@@ -89,8 +89,8 @@ func main() {
 
 	// Building the Calldata with the help of FmtCalldata where we pass in the FnCall struct along with the Cairo version
 	//
-	// note: in Starknet, you can pass multiple function calls in the same transaction, even if they are from different contracts.
-	// To do this, just group all the function calls in the same slice and pass it to FmtCalldata
+	// note: in Starknet, you can execute multiple function calls in the same transaction, even if they are from different contracts.
+	// To do this in Starknet.go, just group all the function calls in the same slice and pass it to FmtCalldata
 	// e.g. : InvokeTx.Calldata, err = accnt.FmtCalldata([]rpc.FunctionCall{funcCall, anotherFuncCall, yetAnotherFuncCallFromDifferentContract})
 	InvokeTx.Calldata, err = accnt.FmtCalldata([]rpc.FunctionCall{FnCall})
 	if err != nil {


### PR DESCRIPTION
Starknet.go is capable of sending multiple function calls in a single transaction, but this feature is not documented.
This PR aims to describe it in the 'examples' and the FAQ