### PR TITLE
docs: changed the link to shield stars

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,14 @@
     <a href="https://github.com/nethermindeth/starknet.go/actions/workflows/test.yml">
         <img src="https://github.com/nethermindeth/starknet.go/actions/workflows/test.yml/badge.svg?branch=main" alt="test">
     </a>
-    <a href="https://github.com/nethermindeth/starknet.go">
+    <a href="https://github.com/NethermindEth/starknet.go/stargazers">
       <img src="https://img.shields.io/github/stars/nethermindeth/starknet.go?style=social"/>
     </a>
 </p>
 
 </p>
 <p align="center">
-  <a href="https://twitter.com/NethermindStark">
+  <a href="https://x.com/NethermindStark">
     <img src="https://img.shields.io/twitter/follow/NethermindStark?style=social"/>
   </a>
   <a href="https://t.me/StarknetGo">


### PR DESCRIPTION
In my opinion, the new link is more suitable here