### PR TITLE
fix outdated documentation links

### DIFF
--- a/account/account.go
+++ b/account/account.go
@@ -187,7 +187,7 @@ func (account *Account) TransactionHashDeployAccount(tx rpc.DeployAccountType, c
 			return nil, err
 		}
 
-		// https://docs.starknet.io/architecture-and-concepts/network-architecture/transactions/#deploy_account_transaction
+		// https://docs.starknet.io/architecture-and-concepts/network-architecture/transactions/#v1_deprecated_hash_calculation_3
 		return hash.CalculateTransactionHashCommon(
 			PREFIX_DEPLOY_ACCOUNT,
 			versionFelt,
@@ -253,7 +253,7 @@ func (account *Account) TransactionHashDeployAccount(tx rpc.DeployAccountType, c
 // If the transaction type is unsupported, the function returns an error.
 func (account *Account) TransactionHashInvoke(tx rpc.InvokeTxnType) (*felt.Felt, error) {
 
-	// https://docs.starknet.io/architecture-and-concepts/network-architecture/transactions/#v0_unsupported_hash_calculation
+	// https://docs.starknet.io/architecture-and-concepts/network-architecture/transactions/#v0_deprecated_hash_calculation
 	switch txn := tx.(type) {
 	case rpc.InvokeTxnV0:
 		if txn.Version == "" || len(txn.Calldata) == 0 || txn.MaxFee == nil || txn.EntryPointSelector == nil {

--- a/account/account.go
+++ b/account/account.go
@@ -187,7 +187,7 @@ func (account *Account) TransactionHashDeployAccount(tx rpc.DeployAccountType, c
 			return nil, err
 		}
 
-		// https://docs.starknet.io/architecture-and-concepts/network-architecture/transactions/#v1_deprecated_hash_calculation
+		// https://docs.starknet.io/architecture-and-concepts/network-architecture/transactions/#deploy_account_transaction
 		return hash.CalculateTransactionHashCommon(
 			PREFIX_DEPLOY_ACCOUNT,
 			versionFelt,

--- a/account/account.go
+++ b/account/account.go
@@ -219,7 +219,7 @@ func (account *Account) TransactionHashDeployAccount(tx rpc.DeployAccountType, c
 		if err != nil {
 			return nil, err
 		}
-		// https://docs.starknet.io/documentation/architecture_and_concepts/Network_Architecture/transactions/#deploy_account_hash_calculation
+		// https://docs.starknet.io/architecture-and-concepts/network-architecture/transactions/#v3_hash_calculation_3
 		return crypto.PoseidonArray(
 			PREFIX_DEPLOY_ACCOUNT,
 			txnVersionFelt,
@@ -253,7 +253,7 @@ func (account *Account) TransactionHashDeployAccount(tx rpc.DeployAccountType, c
 // If the transaction type is unsupported, the function returns an error.
 func (account *Account) TransactionHashInvoke(tx rpc.InvokeTxnType) (*felt.Felt, error) {
 
-	// https://docs.starknet.io/documentation/architecture_and_concepts/Network_Architecture/transactions/#v0_hash_calculation
+	// https://docs.starknet.io/architecture-and-concepts/network-architecture/transactions/#v0_unsupported_hash_calculation
 	switch txn := tx.(type) {
 	case rpc.InvokeTxnV0:
 		if txn.Version == "" || len(txn.Calldata) == 0 || txn.MaxFee == nil || txn.EntryPointSelector == nil {

--- a/account/account.go
+++ b/account/account.go
@@ -175,7 +175,7 @@ func (account *Account) SignDeclareTransaction(ctx context.Context, tx *rpc.Decl
 // - error: an error if any
 func (account *Account) TransactionHashDeployAccount(tx rpc.DeployAccountType, contractAddress *felt.Felt) (*felt.Felt, error) {
 
-	// https://docs.starknet.io/documentation/architecture_and_concepts/Network_Architecture/transactions/#deploy_account_transaction
+	// https://docs.starknet.io/architecture-and-concepts/network-architecture/transactions/#deploy_account_transaction
 	switch txn := tx.(type) {
 	case rpc.DeployAccountTxn:
 		calldata := []*felt.Felt{txn.ClassHash, txn.ContractAddressSalt}
@@ -187,7 +187,7 @@ func (account *Account) TransactionHashDeployAccount(tx rpc.DeployAccountType, c
 			return nil, err
 		}
 
-		// https://docs.starknet.io/documentation/architecture_and_concepts/Network_Architecture/transactions/#deploy_account_hash_calculation
+		// https://docs.starknet.io/architecture-and-concepts/network-architecture/transactions/#v1_deprecated_hash_calculation
 		return hash.CalculateTransactionHashCommon(
 			PREFIX_DEPLOY_ACCOUNT,
 			versionFelt,

--- a/hash/hash.go
+++ b/hash/hash.go
@@ -68,7 +68,7 @@ func ClassHash(contract rpc.ContractClass) *felt.Felt {
 	SierraProgamHash := curve.PoseidonArray(contract.SierraProgram...)
 	ABIHash := curve.StarknetKeccak([]byte(contract.ABI))
 
-	// https://docs.starknet.io/architecture-and-concepts/network-architecture/transactions/#deploy_account_hash_calculation
+	// https://docs.starknet.io/architecture-and-concepts/network-architecture/transactions/#v3_hash_calculation_3
 	return curve.PoseidonArray(ContractClassVersionHash, ExternalHash, L1HandleHash, ConstructorHash, ABIHash, SierraProgamHash)
 }
 

--- a/hash/hash.go
+++ b/hash/hash.go
@@ -58,7 +58,7 @@ func CalculateTransactionHashCommon(
 // - *felt.Felt: a pointer to a felt.Felt object that represents the calculated hash.
 // - error: an error object if there was an error during the hash calculation.
 func ClassHash(contract rpc.ContractClass) *felt.Felt {
-	// https://docs.starknet.io/documentation/architecture_and_concepts/Smart_Contracts/class-hash/
+	// https://docs.starknet.io/architecture-and-concepts/smart-contracts/class-hash/
 
 	Version := "CONTRACT_CLASS_V" + contract.ContractClassVersion
 	ContractClassVersionHash := new(felt.Felt).SetBytes([]byte(Version))
@@ -68,7 +68,7 @@ func ClassHash(contract rpc.ContractClass) *felt.Felt {
 	SierraProgamHash := curve.PoseidonArray(contract.SierraProgram...)
 	ABIHash := curve.StarknetKeccak([]byte(contract.ABI))
 
-	// https://docs.starknet.io/documentation/architecture_and_concepts/Network_Architecture/transactions/#deploy_account_hash_calculation
+	// https://docs.starknet.io/architecture-and-concepts/network-architecture/transactions/#deploy_account_hash_calculation
 	return curve.PoseidonArray(ContractClassVersionHash, ExternalHash, L1HandleHash, ConstructorHash, ABIHash, SierraProgamHash)
 }
 

--- a/hash/hash.go
+++ b/hash/hash.go
@@ -68,7 +68,7 @@ func ClassHash(contract rpc.ContractClass) *felt.Felt {
 	SierraProgamHash := curve.PoseidonArray(contract.SierraProgram...)
 	ABIHash := curve.StarknetKeccak([]byte(contract.ABI))
 
-	// https://docs.starknet.io/architecture-and-concepts/network-architecture/transactions/#v3_hash_calculation_3
+	// https://docs.starknet.io/architecture-and-concepts/smart-contracts/class-hash/#computing_the_cairo_1_class_hash
 	return curve.PoseidonArray(ContractClassVersionHash, ExternalHash, L1HandleHash, ConstructorHash, ABIHash, SierraProgamHash)
 }
 


### PR DESCRIPTION
Hey! I’ve updated some outdated links in `account.go` and `hash.go` to point to the latest Starknet documentation. Some of the previous links referred to deprecated or renamed sections—now everything is correct.
