### PR TITLE
chore: Fix Typo in Error Message for Unsupported Transaction Type

### DIFF
--- a/account/account.go
+++ b/account/account.go
@@ -16,8 +16,8 @@ import (
 
 var (
 	ErrNotAllParametersSet   = errors.New("not all neccessary parameters have been set")
-	ErrTxnTypeUnSupported    = errors.New("unsupported transction type")
-	ErrTxnVersionUnSupported = errors.New("unsupported transction version")
+	ErrTxnTypeUnSupported    = errors.New("unsupported transaction type")
+	ErrTxnVersionUnSupported = errors.New("unsupported transaction version")
 	ErrFeltToBigInt          = errors.New("felt to BigInt error")
 )
 


### PR DESCRIPTION
Noticed a typo in the error message for unsupported transaction types.he word "transction" was missing an 'a'.
I've corrected it to "**transaction**" to ensure clarity.
