### PR TITLE
rpcv8 handle ErrEntrypointNotFound in starknet_call

### DIFF
--- a/account/account.go
+++ b/account/account.go
@@ -175,7 +175,7 @@ func (account *Account) SignDeclareTransaction(ctx context.Context, tx *rpc.Decl
 // - error: an error if any
 func (account *Account) TransactionHashDeployAccount(tx rpc.DeployAccountType, contractAddress *felt.Felt) (*felt.Felt, error) {
 
-	// https://docs.starknet.io/documentation/architecture_and_concepts/Network_Architecture/transactions/#deploy_account_transaction
+	// https://docs.starknet.io/architecture-and-concepts/network-architecture/transactions/#deploy_account_transaction
 	switch txn := tx.(type) {
 	case rpc.DeployAccountTxn:
 		calldata := []*felt.Felt{txn.ClassHash, txn.ContractAddressSalt}
@@ -187,7 +187,7 @@ func (account *Account) TransactionHashDeployAccount(tx rpc.DeployAccountType, c
 			return nil, err
 		}
 
-		// https://docs.starknet.io/documentation/architecture_and_concepts/Network_Architecture/transactions/#deploy_account_hash_calculation
+		// https://docs.starknet.io/architecture-and-concepts/network-architecture/transactions/#v1_deprecated_hash_calculation_3
 		return hash.CalculateTransactionHashCommon(
 			PREFIX_DEPLOY_ACCOUNT,
 			versionFelt,
@@ -219,7 +219,7 @@ func (account *Account) TransactionHashDeployAccount(tx rpc.DeployAccountType, c
 		if err != nil {
 			return nil, err
 		}
-		// https://docs.starknet.io/documentation/architecture_and_concepts/Network_Architecture/transactions/#deploy_account_hash_calculation
+		// https://docs.starknet.io/architecture-and-concepts/network-architecture/transactions/#v3_hash_calculation_3
 		return crypto.PoseidonArray(
 			PREFIX_DEPLOY_ACCOUNT,
 			txnVersionFelt,
@@ -253,7 +253,7 @@ func (account *Account) TransactionHashDeployAccount(tx rpc.DeployAccountType, c
 // If the transaction type is unsupported, the function returns an error.
 func (account *Account) TransactionHashInvoke(tx rpc.InvokeTxnType) (*felt.Felt, error) {
 
-	// https://docs.starknet.io/documentation/architecture_and_concepts/Network_Architecture/transactions/#v0_hash_calculation
+	// https://docs.starknet.io/architecture-and-concepts/network-architecture/transactions/#v0_deprecated_hash_calculation
 	switch txn := tx.(type) {
 	case rpc.InvokeTxnV0:
 		if txn.Version == "" || len(txn.Calldata) == 0 || txn.MaxFee == nil || txn.EntryPointSelector == nil {

--- a/account/account.go
+++ b/account/account.go
@@ -16,8 +16,8 @@ import (
 
 var (
 	ErrNotAllParametersSet   = errors.New("not all neccessary parameters have been set")
-	ErrTxnTypeUnSupported    = errors.New("unsupported transction type")
-	ErrTxnVersionUnSupported = errors.New("unsupported transction version")
+	ErrTxnTypeUnSupported    = errors.New("unsupported transaction type")
+	ErrTxnVersionUnSupported = errors.New("unsupported transaction version")
 	ErrFeltToBigInt          = errors.New("felt to BigInt error")
 )
 

--- a/docs/developers.md
+++ b/docs/developers.md
@@ -1,8 +1,8 @@
 # A few words for developers
 
-This document points some things you might want to know when onboarding on
+This document points out some things you might want to know when onboarding on
 starknet.go. For now, we have listed a number of questions that we would like you
-know before you contribute:
+to know before you contribute:
 
 <!-- - What version of `rpc` should I use -->
 - What is the difference between `rpc` and `gateway`?
@@ -12,7 +12,7 @@ know before you contribute:
 
 ## What is the difference between `rpc` and `gateway`?
 
-starknet.go provides an access to Starknet through several interfaces:
+starknet.go provides access to Starknet through several interfaces:
 - the `gateway` remains a primary access to Starknet. It is managed by
   Starkware and is stable. It evolves with the protocol features and is
   actually split in 2: the gateway allows to run transactions, and the feeder
@@ -22,12 +22,12 @@ starknet.go provides an access to Starknet through several interfaces:
   node like [eqlabs/pathfinder](https://github.com/eqlabs/pathfinder). This
   access has several benefits, including the fact that it will implement a
   peer-to-peer connection and is based on `openrpc` 2.0. As a result, the
-  protocol definition is better standardize and starknet.go uses the
+  protocol definition is better standardized and starknet.go uses the
   [go-ethereum/rpc](https://pkg.go.dev/github.com/ethereum/go-ethereum/rpc)
   client to access Starknet.
 
 If you wonder which one to use, the short answer is it depends. However, starknet.go
-provide an access to both and tries to share a common interface between the 2.
+provides access to both and tries to share a common interface between the 2.
 Be careful that when you are doing something on the project, you should pay
 attention to the 2 interfaces, even if the implementations are specific.
 

--- a/hash/hash.go
+++ b/hash/hash.go
@@ -58,7 +58,7 @@ func CalculateTransactionHashCommon(
 // - *felt.Felt: a pointer to a felt.Felt object that represents the calculated hash.
 // - error: an error object if there was an error during the hash calculation.
 func ClassHash(contract rpc.ContractClass) *felt.Felt {
-	// https://docs.starknet.io/documentation/architecture_and_concepts/Smart_Contracts/class-hash/
+	// https://docs.starknet.io/architecture-and-concepts/smart-contracts/class-hash/
 
 	Version := "CONTRACT_CLASS_V" + contract.ContractClassVersion
 	ContractClassVersionHash := new(felt.Felt).SetBytes([]byte(Version))
@@ -68,7 +68,7 @@ func ClassHash(contract rpc.ContractClass) *felt.Felt {
 	SierraProgamHash := curve.PoseidonArray(contract.SierraProgram...)
 	ABIHash := curve.StarknetKeccak([]byte(contract.ABI))
 
-	// https://docs.starknet.io/documentation/architecture_and_concepts/Network_Architecture/transactions/#deploy_account_hash_calculation
+	// https://docs.starknet.io/architecture-and-concepts/smart-contracts/class-hash/#computing_the_cairo_1_class_hash
 	return curve.PoseidonArray(ContractClassVersionHash, ExternalHash, L1HandleHash, ConstructorHash, ABIHash, SierraProgamHash)
 }
 

--- a/rpc/call.go
+++ b/rpc/call.go
@@ -22,7 +22,7 @@ func (provider *Provider) Call(ctx context.Context, request FunctionCall, blockI
 
 	var result []*felt.Felt
 	if err := do(ctx, provider.c, "starknet_call", &result, request, blockID); err != nil {
-		return nil, tryUnwrapToRPCErr(err, ErrContractNotFound, ErrContractError, ErrBlockNotFound)
+		return nil, tryUnwrapToRPCErr(err, ErrContractNotFound, ErrContractError, ErrBlockNotFound, ErrEntrypointNotFound)
 	}
 	return result, nil
 }

--- a/rpc/call_test.go
+++ b/rpc/call_test.go
@@ -79,7 +79,7 @@ func TestCall(t *testing.T) {
 					Calldata:           []*felt.Felt{},
 				},
 				BlockID:       WithBlockTag("latest"),
-				ExpectedError: ErrContractError,
+				ExpectedError: ErrEntrypointNotFound,
 			},
 			{
 				name: "BlockNotFound",

--- a/rpc/call_test.go
+++ b/rpc/call_test.go
@@ -2,6 +2,7 @@ package rpc
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/NethermindEth/juno/core/felt"
@@ -27,6 +28,7 @@ func TestCall(t *testing.T) {
 	testConfig := beforeEach(t)
 
 	type testSetType struct {
+		name                  string
 		FunctionCall          FunctionCall
 		BlockID               BlockID
 		ExpectedPatternResult *felt.Felt
@@ -35,6 +37,7 @@ func TestCall(t *testing.T) {
 	testSet := map[string][]testSetType{
 		"devnet": {
 			{
+				name: "Ok",
 				FunctionCall: FunctionCall{
 					// ContractAddress of predeployed devnet Feetoken
 					ContractAddress:    utils.TestHexToFelt(t, DevNetETHAddress),
@@ -47,6 +50,7 @@ func TestCall(t *testing.T) {
 		},
 		"mock": {
 			{
+				name: "Ok",
 				FunctionCall: FunctionCall{
 					ContractAddress:    utils.TestHexToFelt(t, "0xdeadbeef"),
 					EntryPointSelector: utils.GetSelectorFromNameFelt("decimals"),
@@ -58,6 +62,7 @@ func TestCall(t *testing.T) {
 		},
 		"testnet": {
 			{
+				name: "Ok",
 				FunctionCall: FunctionCall{
 					ContractAddress:    utils.TestHexToFelt(t, "0x025633c6142D9CA4126e3fD1D522Faa6e9f745144aba728c0B3FEE38170DF9e7"),
 					EntryPointSelector: utils.GetSelectorFromNameFelt("name"),
@@ -67,6 +72,7 @@ func TestCall(t *testing.T) {
 				ExpectedPatternResult: utils.TestHexToFelt(t, "0x506f736974696f6e"),
 			},
 			{
+				name: "ContractError",
 				FunctionCall: FunctionCall{
 					ContractAddress:    utils.TestHexToFelt(t, "0x025633c6142D9CA4126e3fD1D522Faa6e9f745144aba728c0B3FEE38170DF9e7"),
 					EntryPointSelector: utils.GetSelectorFromNameFelt("RANDOM_STRINGGG"),
@@ -76,6 +82,7 @@ func TestCall(t *testing.T) {
 				ExpectedError: ErrContractError,
 			},
 			{
+				name: "BlockNotFound",
 				FunctionCall: FunctionCall{
 					ContractAddress:    utils.TestHexToFelt(t, "0x025633c6142D9CA4126e3fD1D522Faa6e9f745144aba728c0B3FEE38170DF9e7"),
 					EntryPointSelector: utils.GetSelectorFromNameFelt("name"),
@@ -85,6 +92,7 @@ func TestCall(t *testing.T) {
 				ExpectedError: ErrBlockNotFound,
 			},
 			{
+				name: "ContractNotFound",
 				FunctionCall: FunctionCall{
 					ContractAddress:    utils.RANDOM_FELT,
 					EntryPointSelector: utils.GetSelectorFromNameFelt("name"),
@@ -96,6 +104,7 @@ func TestCall(t *testing.T) {
 		},
 		"mainnet": {
 			{
+				name: "Ok",
 				FunctionCall: FunctionCall{
 					ContractAddress:    utils.TestHexToFelt(t, "0x06a09ccb1caaecf3d9683efe335a667b2169a409d19c589ba1eb771cd210af75"),
 					EntryPointSelector: utils.GetSelectorFromNameFelt("decimals"),
@@ -108,14 +117,16 @@ func TestCall(t *testing.T) {
 	}[testEnv]
 
 	for _, test := range testSet {
-		require := require.New(t)
-		output, err := testConfig.provider.Call(context.Background(), FunctionCall(test.FunctionCall), test.BlockID)
-		if test.ExpectedError != nil {
-			require.EqualError(test.ExpectedError, err.Error())
-		} else {
-			require.NoError(err)
-			require.NotEmpty(output, "should return an output")
-			require.Equal(test.ExpectedPatternResult, output[0])
-		}
+		t.Run(fmt.Sprintf("Network: %s, Test: %s", testEnv, test.name), func(t *testing.T) {
+			require := require.New(t)
+			output, err := testConfig.provider.Call(context.Background(), FunctionCall(test.FunctionCall), test.BlockID)
+			if err != nil {
+				require.EqualError(test.ExpectedError, err.Error())
+			} else {
+				require.NoError(err)
+				require.NotEmpty(output, "should return an output")
+				require.Equal(test.ExpectedPatternResult, output[0])
+			}
+		})
 	}
 }

--- a/rpc/errors.go
+++ b/rpc/errors.go
@@ -90,6 +90,10 @@ var (
 		Code:    20,
 		Message: "Contract not found",
 	}
+	ErrEntrypointNotFound = &RPCError{
+		Code:    21,
+		Message: "Requested entrypoint does not exist in the contract",
+	}
 	ErrBlockNotFound = &RPCError{
 		Code:    24,
 		Message: "Block not found",


### PR DESCRIPTION
`Starknet_call` can now return [ENTRYPOINT_NOT_FOUND](https://github.com/starkware-libs/starknet-specs/blob/v0.8.0-rc3/api/starknet_api_openrpc.json#L602), which is returned when the caller tries to directly call a function that doesn't exist 