### PR TITLE
chore: fix misleading comment for StrToHex function

### DIFF
--- a/utils/keccak.go
+++ b/utils/keccak.go
@@ -46,7 +46,7 @@ func StrToBig(str string) *big.Int {
 	return b
 }
 
-// StrToBig generates a hexadecimal from a string/number representation.
+// StrToHex converts a string/number representation to a hexadecimal string.
 //
 // Parameters:
 // - str: The string to convert to a hexadecimal


### PR DESCRIPTION
I noticed a discrepancy in the comment for the `StrToHex` function. The comment states that the function generates hexadecimal from a string/number, but the function name (`StrToHex`) suggests it only converts a string to hex.

This could be confusing for anyone reading the code. I’ve updated the comment to clarify that the function specifically converts a string to hexadecimal, aligning it with the function name and its actual behavior.