### PR TITLE
Thiagodeev/rpcv08 final adjustments v3

### DIFF
--- a/account/account.go
+++ b/account/account.go
@@ -569,10 +569,11 @@ func (account *Account) WaitForTransactionReceipt(ctx context.Context, transacti
 }
 
 // SendTransaction can send Invoke, Declare, and Deploy transactions. It provides a unified way to send different transactions.
+// It can only send v3 transactions.
 //
 // Parameters:
 //   - ctx: the context.Context object for the transaction.
-//   - txn: the Broadcast Transaction to be sent.
+//   - txn: the Broadcast V3 Transaction to be sent.
 //
 // Returns:
 //   - *rpc.TransactionResponse: the transaction response.
@@ -619,7 +620,7 @@ func (account *Account) SendTransaction(ctx context.Context, txn rpc.BroadcastTx
 		}
 		return &rpc.TransactionResponse{TransactionHash: resp.TransactionHash, ContractAddress: resp.ContractAddress}, nil
 	default:
-		return nil, errors.New("unsupported transaction type")
+		return nil, fmt.Errorf("unsupported transaction type: should be a v3 transaction, instead got %T", tx)
 	}
 }
 

--- a/account/account.go
+++ b/account/account.go
@@ -176,7 +176,7 @@ func (account *Account) BuildAndSendDeclareTxn(
 	if err != nil {
 		return nil, err
 	}
-	err = account.SignDeclareTransaction(ctx, &broadcastDeclareTxnV3)
+	err = account.SignDeclareTransaction(ctx, broadcastDeclareTxnV3)
 	if err != nil {
 		return nil, err
 	}
@@ -190,7 +190,7 @@ func (account *Account) BuildAndSendDeclareTxn(
 	broadcastDeclareTxnV3.ResourceBounds = utils.FeeEstToResBoundsMap(txnFee, multiplier)
 
 	// signing the txn again with the estimated fee, as the fee value is used in the txn hash calculation
-	err = account.SignDeclareTransaction(ctx, &broadcastDeclareTxnV3)
+	err = account.SignDeclareTransaction(ctx, broadcastDeclareTxnV3)
 	if err != nil {
 		return nil, err
 	}
@@ -331,11 +331,12 @@ func signInvokeTransaction[T any](ctx context.Context, account *Account, invokeT
 // SignDeployAccountTransaction signs a deploy account transaction.
 //
 // Parameters:
-// - ctx: the context.Context for the function execution
-// - tx: the *rpc.DeployAccountTxnV3 pointer representing the transaction to be signed
-// - precomputeAddress: the precomputed address for the transaction
+//   - ctx: the context.Context for the function execution
+//   - tx: the *rpc.DeployAccountTxnV3 pointer representing the transaction to be signed
+//   - precomputeAddress: the precomputed address for the transaction
+//
 // Returns:
-// - error: an error if any
+//   - error: an error if any
 func (account *Account) SignDeployAccountTransaction(ctx context.Context, tx rpc.DeployAccountType, precomputeAddress *felt.Felt) error {
 	switch deployAcc := tx.(type) {
 	case *rpc.DeployAccountTxn:
@@ -371,7 +372,7 @@ func signDeployAccountTransaction[T any](ctx context.Context, account *Account, 
 	return signature, nil
 }
 
-// SignDeclareTransaction signs a DeclareTxnV2 transaction using the provided Account.
+// SignDeclareTransaction signs a declare transaction using the provided Account.
 //
 // Parameters:
 // - ctx: the context.Context

--- a/account/account.go
+++ b/account/account.go
@@ -255,7 +255,7 @@ func (account *Account) BuildAndEstimateDeployAccountTxn(
 		return nil, nil, err
 	}
 
-	return &broadcastDepAccTxnV3, precomputedAddress, nil
+	return broadcastDepAccTxnV3, precomputedAddress, nil
 }
 
 // Sign signs the given felt message using the account's private key.
@@ -891,20 +891,41 @@ func (account *Account) WaitForTransactionReceipt(ctx context.Context, transacti
 //   - error: an error if any.
 func (account *Account) SendTransaction(ctx context.Context, txn rpc.BroadcastTxn) (*rpc.TransactionResponse, error) {
 	switch tx := txn.(type) {
-	case rpc.BroadcastInvokeTxnType:
+	// broadcast invoke v3, pointer and struct
+	case *rpc.BroadcastInvokeTxnV3:
 		resp, err := account.Provider.AddInvokeTransaction(ctx, tx)
 		if err != nil {
 			return nil, err
 		}
 		return &rpc.TransactionResponse{TransactionHash: resp.TransactionHash}, nil
-	case rpc.BroadcastDeclareTxnType:
+	case rpc.BroadcastInvokeTxnV3:
+		resp, err := account.Provider.AddInvokeTransaction(ctx, &tx)
+		if err != nil {
+			return nil, err
+		}
+		return &rpc.TransactionResponse{TransactionHash: resp.TransactionHash}, nil
+	// broadcast declare v3, pointer and struct
+	case *rpc.BroadcastDeclareTxnV3:
 		resp, err := account.Provider.AddDeclareTransaction(ctx, tx)
 		if err != nil {
 			return nil, err
 		}
 		return &rpc.TransactionResponse{TransactionHash: resp.TransactionHash, ClassHash: resp.ClassHash}, nil
-	case rpc.BroadcastAddDeployTxnType:
+	case rpc.BroadcastDeclareTxnV3:
+		resp, err := account.Provider.AddDeclareTransaction(ctx, &tx)
+		if err != nil {
+			return nil, err
+		}
+		return &rpc.TransactionResponse{TransactionHash: resp.TransactionHash, ClassHash: resp.ClassHash}, nil
+	// broadcast deploy account v3, pointer and struct
+	case *rpc.BroadcastDeployAccountTxnV3:
 		resp, err := account.Provider.AddDeployAccountTransaction(ctx, tx)
+		if err != nil {
+			return nil, err
+		}
+		return &rpc.TransactionResponse{TransactionHash: resp.TransactionHash, ContractAddress: resp.ContractAddress}, nil
+	case rpc.BroadcastDeployAccountTxnV3:
+		resp, err := account.Provider.AddDeployAccountTransaction(ctx, &tx)
 		if err != nil {
 			return nil, err
 		}

--- a/account/account.go
+++ b/account/account.go
@@ -120,6 +120,7 @@ func (account *Account) BuildAndSendInvokeTxn(ctx context.Context, functionCalls
 		return nil, err
 	}
 	txnFee := estimateFee[0]
+	fillEmptyFeeEstimation(ctx, &txnFee, account.Provider)
 	broadcastInvokeTxnV3.ResourceBounds = utils.FeeEstToResBoundsMap(txnFee, multiplier)
 
 	// signing the txn again with the estimated fee, as the fee value is used in the txn hash calculation
@@ -178,6 +179,7 @@ func (account *Account) BuildAndSendDeclareTxn(
 		return nil, err
 	}
 	txnFee := estimateFee[0]
+	fillEmptyFeeEstimation(ctx, &txnFee, account.Provider)
 	broadcastDeclareTxnV3.ResourceBounds = utils.FeeEstToResBoundsMap(txnFee, multiplier)
 
 	// signing the txn again with the estimated fee, as the fee value is used in the txn hash calculation
@@ -238,6 +240,7 @@ func (account *Account) BuildAndEstimateDeployAccountTxn(
 		return nil, nil, err
 	}
 	txnFee := estimateFee[0]
+	fillEmptyFeeEstimation(ctx, &txnFee, account.Provider)
 	broadcastDepAccTxnV3.ResourceBounds = utils.FeeEstToResBoundsMap(txnFee, multiplier)
 
 	// signing the txn again with the estimated fee, as the fee value is used in the txn hash calculation
@@ -713,5 +716,24 @@ func makeResourceBoundsMapWithZeroValues() rpc.ResourceBoundsMapping {
 			MaxAmount:       "0x0",
 			MaxPricePerUnit: "0x0",
 		},
+	}
+}
+
+// When there's no transaction in the pending block, the L1DataGasConsumed and L1DataGasPrice fields are comming empty.
+// This is causing the transaction to fail with the error:
+// "55 Account validation failed: Max L1DataGas amount (0) is lower than the minimal gas amount: 128"
+// This function fills the empty fields.
+//
+// TODO: remove this function once the issue is fixed in the RPC
+func fillEmptyFeeEstimation(ctx context.Context, feeEstimation *rpc.FeeEstimation, provider rpc.RpcProvider) {
+	if feeEstimation.L1DataGasConsumed.IsZero() {
+		// default value for L1DataGasConsumed in most cases
+		feeEstimation.L1DataGasConsumed = new(felt.Felt).SetUint64(224)
+	}
+	if feeEstimation.L1DataGasPrice.IsZero() {
+		// getting the L1DataGasPrice from the latest block as reference
+		result, _ := provider.BlockWithTxHashes(ctx, rpc.WithBlockTag("latest"))
+		block := result.(*rpc.BlockTxHashes)
+		feeEstimation.L1DataGasPrice = block.L1DataGasPrice.PriceInFRI
 	}
 }

--- a/account/account.go
+++ b/account/account.go
@@ -60,13 +60,14 @@ type Account struct {
 // NewAccount creates a new Account instance.
 //
 // Parameters:
-// - provider: is the provider of type rpc.RpcProvider
-// - accountAddress: is the account address of type *felt.Felt
-// - publicKey: is the public key of type string
-// - keystore: is the keystore of type Keystore
+//   - provider: is the provider of type rpc.RpcProvider
+//   - accountAddress: is the account address of type *felt.Felt
+//   - publicKey: is the public key of type string
+//   - keystore: is the keystore of type Keystore
+//
 // It returns:
-// - *Account: a pointer to newly created Account
-// - error: an error if any
+//   - *Account: a pointer to newly created Account
+//   - error: an error if any
 func NewAccount(provider rpc.RpcProvider, accountAddress *felt.Felt, publicKey string, keystore Keystore, cairoVersion int) (*Account, error) {
 	account := &Account{
 		Provider:       provider,
@@ -261,11 +262,12 @@ func (account *Account) BuildAndEstimateDeployAccountTxn(
 // Sign signs the given felt message using the account's private key.
 //
 // Parameters:
-// - ctx: is the context used for the signing operation
-// - msg: is the felt message to be signed
+//   - ctx: is the context used for the signing operation
+//   - msg: is the felt message to be signed
+//
 // Returns:
-// - []*felt.Felt: an array of signed felt messages
-// - error: an error, if any
+//   - []*felt.Felt: an array of signed felt messages
+//   - error: an error, if any
 func (account *Account) Sign(ctx context.Context, msg *felt.Felt) ([]*felt.Felt, error) {
 	msgBig := internalUtils.FeltToBigInt(msg)
 
@@ -314,7 +316,7 @@ func (account *Account) SignInvokeTransaction(ctx context.Context, invokeTx rpc.
 	return nil
 }
 
-// TODO: make func description
+// signInvokeTransaction is a generic helper function that signs an invoke transaction.
 func signInvokeTransaction[T any](ctx context.Context, account *Account, invokeTx *T) ([]*felt.Felt, error) {
 	txHash, err := account.TransactionHashInvoke(invokeTx)
 	if err != nil {
@@ -358,7 +360,7 @@ func (account *Account) SignDeployAccountTransaction(ctx context.Context, tx rpc
 	return nil
 }
 
-// TODO: make func description
+// signDeployAccountTransaction is a generic helper function that signs a deploy account transaction.
 func signDeployAccountTransaction[T any](ctx context.Context, account *Account, tx *T, precomputeAddress *felt.Felt) ([]*felt.Felt, error) {
 	txHash, err := account.TransactionHashDeployAccount(*tx, precomputeAddress)
 	if err != nil {
@@ -375,10 +377,11 @@ func signDeployAccountTransaction[T any](ctx context.Context, account *Account, 
 // SignDeclareTransaction signs a declare transaction using the provided Account.
 //
 // Parameters:
-// - ctx: the context.Context
-// - tx: the pointer to a Declare or BroadcastDeclare txn
+//   - ctx: the context.Context
+//   - tx: the pointer to a Declare or BroadcastDeclare txn
+//
 // Returns:
-// - error: an error if any
+//   - error: an error if any
 func (account *Account) SignDeclareTransaction(ctx context.Context, tx rpc.DeclareTxnType) error {
 	switch declare := tx.(type) {
 	case *rpc.DeclareTxnV1:
@@ -412,7 +415,7 @@ func (account *Account) SignDeclareTransaction(ctx context.Context, tx rpc.Decla
 	return nil
 }
 
-// TODO: make func description
+// signDeclareTransaction is a generic helper function that signs a declare transaction.
 func signDeclareTransaction[T any](ctx context.Context, account *Account, tx *T) ([]*felt.Felt, error) {
 	txHash, err := account.TransactionHashDeclare(*tx)
 	if err != nil {
@@ -429,11 +432,12 @@ func signDeclareTransaction[T any](ctx context.Context, account *Account, tx *T)
 // TransactionHashDeployAccount calculates the transaction hash for a deploy account transaction.
 //
 // Parameters:
-// - tx: The deploy account transaction to calculate the hash for
-// - contractAddress: The contract address as parameters as a *felt.Felt
+//   - tx: The deploy account transaction to calculate the hash for. Can be of type DeployAccountTxn or DeployAccountTxnV3.
+//   - contractAddress: The contract address as parameters as a *felt.Felt
+//
 // Returns:
-// - *felt.Felt: the calculated transaction hash
-// - error: an error if any
+//   - *felt.Felt: the calculated transaction hash
+//   - error: an error if any
 func (account *Account) TransactionHashDeployAccount(tx rpc.DeployAccountType, contractAddress *felt.Felt) (*felt.Felt, error) {
 
 	// https://docs.starknet.io/architecture-and-concepts/network-architecture/transactions/#deploy_account_transaction
@@ -453,7 +457,16 @@ func (account *Account) TransactionHashDeployAccount(tx rpc.DeployAccountType, c
 	}
 }
 
-// TODO: descriptions for all these functions
+// TransactionHashDeployAccountV1 calculates the transaction hash for a deploy account V1 transaction.
+//
+// Parameters:
+//   - txn: The deploy account V1 transaction to calculate the hash for
+//   - contractAddress: The contract address as parameters as a *felt.Felt
+//   - chainId: The chain ID as a *felt.Felt
+//
+// Returns:
+//   - *felt.Felt: the calculated transaction hash
+//   - error: an error if any
 func TransactionHashDeployAccountV1(txn *rpc.DeployAccountTxn, contractAddress, chainId *felt.Felt) (*felt.Felt, error) {
 	// https://docs.starknet.io/architecture-and-concepts/network-architecture/transactions/#v1_deprecated_hash_calculation_3
 	calldata := []*felt.Felt{txn.ClassHash, txn.ContractAddressSalt}
@@ -477,6 +490,16 @@ func TransactionHashDeployAccountV1(txn *rpc.DeployAccountTxn, contractAddress, 
 	), nil
 }
 
+// TransactionHashDeployAccountV3 calculates the transaction hash for a deploy account V3 transaction.
+//
+// Parameters:
+//   - txn: The deploy account V3 transaction to calculate the hash for
+//   - contractAddress: The contract address as parameters as a *felt.Felt
+//   - chainId: The chain ID as a *felt.Felt
+//
+// Returns:
+//   - *felt.Felt: the calculated transaction hash
+//   - error: an error if any
 func TransactionHashDeployAccountV3(txn *rpc.DeployAccountTxnV3, contractAddress, chainId *felt.Felt) (*felt.Felt, error) {
 	// https://docs.starknet.io/architecture-and-concepts/network-architecture/transactions/#v3_hash_calculation_3
 	if txn.Version == "" || txn.ResourceBounds == (rpc.ResourceBoundsMapping{}) || txn.Nonce == nil || txn.PayMasterData == nil {
@@ -517,11 +540,12 @@ func TransactionHashDeployAccountV3(txn *rpc.DeployAccountTxnV3, contractAddress
 // TransactionHashInvoke calculates the transaction hash for the given invoke transaction.
 //
 // Parameters:
-// - tx: The invoke transaction to calculate the hash for. Can be of type InvokeTxnV0, InvokeTxnV1, or InvokeTxnV3.
+//   - tx: The invoke transaction to calculate the hash for. Can be of type InvokeTxnV0, InvokeTxnV1, or InvokeTxnV3.
+//
 // Returns:
-// - *felt.Felt: The calculated transaction hash as a *felt.Felt
-// - error: an error, if any
-
+//   - *felt.Felt: The calculated transaction hash as a *felt.Felt
+//   - error: an error, if any
+//
 // If the transaction type is unsupported, the function returns an error.
 func (account *Account) TransactionHashInvoke(tx rpc.InvokeTxnType) (*felt.Felt, error) {
 	switch txn := tx.(type) {
@@ -545,7 +569,15 @@ func (account *Account) TransactionHashInvoke(tx rpc.InvokeTxnType) (*felt.Felt,
 	}
 }
 
-// TODO: descriptions for all these functions
+// TransactionHashInvokeV0 calculates the transaction hash for a invoke V0 transaction.
+//
+// Parameters:
+//   - txn: The invoke V0 transaction to calculate the hash for
+//   - chainId: The chain ID as a *felt.Felt
+//
+// Returns:
+//   - *felt.Felt: the calculated transaction hash
+//   - error: an error if any
 func TransactionHashInvokeV0(txn *rpc.InvokeTxnV0, chainId *felt.Felt) (*felt.Felt, error) {
 	// https://docs.starknet.io/architecture-and-concepts/network-architecture/transactions/#v0_deprecated_hash_calculation
 	if txn.Version == "" || len(txn.Calldata) == 0 || txn.MaxFee == nil || txn.EntryPointSelector == nil {
@@ -569,6 +601,15 @@ func TransactionHashInvokeV0(txn *rpc.InvokeTxnV0, chainId *felt.Felt) (*felt.Fe
 	), nil
 }
 
+// TransactionHashInvokeV1 calculates the transaction hash for a invoke V1 transaction.
+//
+// Parameters:
+//   - txn: The invoke V1 transaction to calculate the hash for
+//   - chainId: The chain ID as a *felt.Felt
+//
+// Returns:
+//   - *felt.Felt: the calculated transaction hash
+//   - error: an error if any
 func TransactionHashInvokeV1(txn *rpc.InvokeTxnV1, chainId *felt.Felt) (*felt.Felt, error) {
 	// https://docs.starknet.io/architecture-and-concepts/network-architecture/transactions/#v1_deprecated_hash_calculation
 	if txn.Version == "" || len(txn.Calldata) == 0 || txn.Nonce == nil || txn.MaxFee == nil || txn.SenderAddress == nil {
@@ -592,6 +633,15 @@ func TransactionHashInvokeV1(txn *rpc.InvokeTxnV1, chainId *felt.Felt) (*felt.Fe
 	), nil
 }
 
+// TransactionHashInvokeV3 calculates the transaction hash for a invoke V3 transaction.
+//
+// Parameters:
+//   - txn: The invoke V3 transaction to calculate the hash for
+//   - chainId: The chain ID as a *felt.Felt
+//
+// Returns:
+//   - *felt.Felt: the calculated transaction hash
+//   - error: an error if any
 func TransactionHashInvokeV3(txn *rpc.InvokeTxnV3, chainId *felt.Felt) (*felt.Felt, error) {
 	// https://github.com/starknet-io/SNIPs/blob/main/SNIPS/snip-8.md#protocol-changes
 	// https://docs.starknet.io/architecture-and-concepts/network-architecture/transactions/#v3_hash_calculation
@@ -664,16 +714,11 @@ func dataAvailabilityMode(feeDAMode, nonceDAMode rpc.DataAvailabilityMode) (uint
 // TransactionHashDeclare calculates the transaction hash for declaring a transaction type.
 //
 // Parameters:
-// - tx: The `tx` parameter of type `rpc.DeclareTxnType`
-// Can be one of the following types:
-//   - `rpc.DeclareTxnV1`
-//   - `rpc.DeclareTxnV2`
-//   - `rpc.DeclareTxnV3`
-//   - `rpc.BroadcastDeclareTxnV3`
+//   - tx: The `tx` parameter of type `rpc.DeclareTxnType`. Can be one of the types DeclareTxnV1/V2/V3, and BroadcastDeclareTxnV3
 //
 // Returns:
-// - *felt.Felt: the calculated transaction hash as `*felt.Felt` value
-// - error: an error, if any
+//   - *felt.Felt: the calculated transaction hash as `*felt.Felt` value
+//   - error: an error, if any
 //
 // If the `tx` parameter is not one of the supported types, the function returns an error `ErrTxnTypeUnSupported`.
 func (account *Account) TransactionHashDeclare(tx rpc.DeclareTxnType) (*felt.Felt, error) {
@@ -706,7 +751,15 @@ func (account *Account) TransactionHashDeclare(tx rpc.DeclareTxnType) (*felt.Fel
 	}
 }
 
-// TODO: descriptions for all these functions
+// TransactionHashDeclareV1 calculates the transaction hash for a declare V1 transaction.
+//
+// Parameters:
+//   - txn: The declare V1 transaction to calculate the hash for
+//   - chainId: The chain ID as a *felt.Felt
+//
+// Returns:
+//   - *felt.Felt: the calculated transaction hash
+//   - error: an error if any
 func TransactionHashDeclareV1(txn *rpc.DeclareTxnV1, chainId *felt.Felt) (*felt.Felt, error) {
 	// https://docs.starknet.io/architecture-and-concepts/network-architecture/transactions/#v1_deprecated_hash_calculation_2
 	if txn.SenderAddress == nil || txn.Version == "" || txn.ClassHash == nil || txn.MaxFee == nil || txn.Nonce == nil {
@@ -731,6 +784,15 @@ func TransactionHashDeclareV1(txn *rpc.DeclareTxnV1, chainId *felt.Felt) (*felt.
 	), nil
 }
 
+// TransactionHashDeclareV2 calculates the transaction hash for a declare V2 transaction.
+//
+// Parameters:
+//   - txn: The declare V2 transaction to calculate the hash for
+//   - chainId: The chain ID as a *felt.Felt
+//
+// Returns:
+//   - *felt.Felt: the calculated transaction hash
+//   - error: an error if any
 func TransactionHashDeclareV2(txn *rpc.DeclareTxnV2, chainId *felt.Felt) (*felt.Felt, error) {
 	// https://docs.starknet.io/architecture-and-concepts/network-architecture/transactions/#v2_deprecated_hash_calculation
 	if txn.CompiledClassHash == nil || txn.SenderAddress == nil || txn.Version == "" || txn.ClassHash == nil || txn.MaxFee == nil || txn.Nonce == nil {
@@ -756,6 +818,15 @@ func TransactionHashDeclareV2(txn *rpc.DeclareTxnV2, chainId *felt.Felt) (*felt.
 	), nil
 }
 
+// TransactionHashDeclareV3 calculates the transaction hash for a declare V3 transaction.
+//
+// Parameters:
+//   - txn: The declare V3 transaction to calculate the hash for
+//   - chainId: The chain ID as a *felt.Felt
+//
+// Returns:
+//   - *felt.Felt: the calculated transaction hash
+//   - error: an error if any
 func TransactionHashDeclareV3(txn *rpc.DeclareTxnV3, chainId *felt.Felt) (*felt.Felt, error) {
 	// https://docs.starknet.io/architecture-and-concepts/network-architecture/transactions/#v3_hash_calculation_2
 	// https://github.com/starknet-io/SNIPs/blob/main/SNIPS/snip-8.md#protocol-changes
@@ -796,6 +867,15 @@ func TransactionHashDeclareV3(txn *rpc.DeclareTxnV3, chainId *felt.Felt) (*felt.
 	), nil
 }
 
+// TransactionHashBroadcastDeclareV3 calculates the transaction hash for a broadcast declare V3 transaction.
+//
+// Parameters:
+//   - txn: The broadcast declare V3 transaction to calculate the hash for
+//   - chainId: The chain ID as a *felt.Felt
+//
+// Returns:
+//   - *felt.Felt: the calculated transaction hash
+//   - error: an error if any
 func TransactionHashBroadcastDeclareV3(txn *rpc.BroadcastDeclareTxnV3, chainId *felt.Felt) (*felt.Felt, error) {
 	// https://docs.starknet.io/architecture-and-concepts/network-architecture/transactions/#v3_hash_calculation_2
 	// https://github.com/starknet-io/SNIPs/blob/main/SNIPS/snip-8.md#protocol-changes
@@ -840,12 +920,13 @@ func TransactionHashBroadcastDeclareV3(txn *rpc.BroadcastDeclareTxnV3, chainId *
 // ref: https://docs.starknet.io/architecture-and-concepts/smart-contracts/contract-address/
 //
 // Parameters:
-// - salt: the salt for the address of the deployed contract
-// - classHash: the class hash of the contract to be deployed
-// - constructorCalldata: the parameters passed to the constructor
+//   - salt: the salt for the address of the deployed contract
+//   - classHash: the class hash of the contract to be deployed
+//   - constructorCalldata: the parameters passed to the constructor
+//
 // Returns:
-// - *felt.Felt: the precomputed address as a *felt.Felt
-// - error: an error if any
+//   - *felt.Felt: the precomputed address as a *felt.Felt
+//   - error: an error if any
 func PrecomputeAccountAddress(salt *felt.Felt, classHash *felt.Felt, constructorCalldata []*felt.Felt) *felt.Felt {
 	return contracts.PrecomputeAddress(&felt.Zero, salt, classHash, constructorCalldata)
 }
@@ -939,10 +1020,11 @@ func (account *Account) SendTransaction(ctx context.Context, txn rpc.BroadcastTx
 // FmtCalldata generates the formatted calldata for the given function calls and Cairo version.
 //
 // Parameters:
-// - fnCalls: a slice of rpc.FunctionCall representing the function calls.
+//   - fnCalls: a slice of rpc.FunctionCall representing the function calls.
+//
 // Returns:
-// - a slice of *felt.Felt representing the formatted calldata.
-// - an error if Cairo version is not supported.
+//   - a slice of *felt.Felt representing the formatted calldata.
+//   - an error if Cairo version is not supported.
 func (account *Account) FmtCalldata(fnCalls []rpc.FunctionCall) ([]*felt.Felt, error) {
 	switch account.CairoVersion {
 	case 0:
@@ -957,10 +1039,11 @@ func (account *Account) FmtCalldata(fnCalls []rpc.FunctionCall) ([]*felt.Felt, e
 // FmtCallDataCairo0 generates a slice of *felt.Felt that represents the calldata for the given function calls in Cairo 0 format.
 //
 // Parameters:
-// - fnCalls: a slice of rpc.FunctionCall containing the function calls.
+//   - fnCalls: a slice of rpc.FunctionCall containing the function calls.
 //
 // Returns:
-// - a slice of *felt.Felt representing the generated calldata.
+//   - a slice of *felt.Felt representing the generated calldata.
+//
 // https://github.com/project3fusion/StarkSharp/blob/main/StarkSharp/StarkSharp.Rpc/Modules/Transactions/Hash/TransactionHash.cs#L27
 func FmtCallDataCairo0(callArray []rpc.FunctionCall) []*felt.Felt {
 	var calldata []*felt.Felt
@@ -989,9 +1072,11 @@ func FmtCallDataCairo0(callArray []rpc.FunctionCall) []*felt.Felt {
 // FmtCallDataCairo2 generates the calldata for the given function calls for Cairo 2 contracs.
 //
 // Parameters:
-// - fnCalls: a slice of rpc.FunctionCall containing the function calls.
+//   - fnCalls: a slice of rpc.FunctionCall containing the function calls.
+//
 // Returns:
-// - a slice of *felt.Felt representing the generated calldata.
+//   - a slice of *felt.Felt representing the generated calldata.
+//
 // https://github.com/project3fusion/StarkSharp/blob/main/StarkSharp/StarkSharp.Rpc/Modules/Transactions/Hash/TransactionHash.cs#L22
 func FmtCallDataCairo2(callArray []rpc.FunctionCall) []*felt.Felt {
 	var result []*felt.Felt

--- a/account/account_test.go
+++ b/account/account_test.go
@@ -204,13 +204,13 @@ func TestTransactionHashInvoke(t *testing.T) {
 				SenderAddress: acc.AccountAddress,
 				Version:       test.TxDetails.Version,
 			}
-			hash, err := acc.TransactionHashInvoke(invokeTxn)
+			hashResp, err := acc.TransactionHashInvoke(invokeTxn)
 			require.NoError(t, err, "error returned from account.TransactionHash()")
-			require.Equal(t, test.ExpectedHash.String(), hash.String(), "transaction hash does not match expected")
+			require.Equal(t, test.ExpectedHash.String(), hashResp.String(), "transaction hash does not match expected")
 
-			hash2, err := account.TransactionHashInvokeV1(&invokeTxn, acc.ChainId)
+			hash2, err := hash.TransactionHashInvokeV1(&invokeTxn, acc.ChainId)
 			require.NoError(t, err)
-			assert.Equal(t, hash, hash2)
+			assert.Equal(t, hashResp, hash2)
 		})
 	}
 
@@ -833,19 +833,19 @@ func TestTransactionHashDeclare(t *testing.T) {
 		},
 	}[testEnv]
 	for _, test := range testSet {
-		hash, err := acnt.TransactionHashDeclare(test.Txn)
+		hashResp, err := acnt.TransactionHashDeclare(test.Txn)
 		require.Equal(t, test.ExpectedErr, err)
-		require.Equal(t, test.ExpectedHash.String(), hash.String(), "TransactionHashDeclare not what expected")
+		require.Equal(t, test.ExpectedHash.String(), hashResp.String(), "TransactionHashDeclare not what expected")
 
 		var hash2 *felt.Felt
 		switch txn := test.Txn.(type) {
 		case rpc.DeclareTxnV2:
-			hash2, err = account.TransactionHashDeclareV2(&txn, acnt.ChainId)
+			hash2, err = hash.TransactionHashDeclareV2(&txn, acnt.ChainId)
 		case rpc.DeclareTxnV3:
-			hash2, err = account.TransactionHashDeclareV3(&txn, acnt.ChainId)
+			hash2, err = hash.TransactionHashDeclareV3(&txn, acnt.ChainId)
 		}
 		require.NoError(t, err)
-		assert.Equal(t, hash, hash2)
+		assert.Equal(t, hashResp, hash2)
 	}
 }
 
@@ -949,13 +949,13 @@ func TestTransactionHashInvokeV3(t *testing.T) {
 		},
 	}[testEnv]
 	for _, test := range testSet {
-		hash, err := acnt.TransactionHashInvoke(&test.Txn)
+		hashResp, err := acnt.TransactionHashInvoke(&test.Txn)
 		require.Equal(t, test.ExpectedErr, err)
-		require.Equal(t, test.ExpectedHash.String(), hash.String(), "TransactionHashInvoke not what expected")
+		require.Equal(t, test.ExpectedHash.String(), hashResp.String(), "TransactionHashInvoke not what expected")
 
-		hash2, err := account.TransactionHashInvokeV3(&test.Txn, acnt.ChainId)
+		hash2, err := hash.TransactionHashInvokeV3(&test.Txn, acnt.ChainId)
 		require.NoError(t, err)
-		assert.Equal(t, hash, hash2)
+		assert.Equal(t, hashResp, hash2)
 	}
 }
 
@@ -1038,19 +1038,19 @@ func TestTransactionHashdeployAccount(t *testing.T) {
 		},
 	}[testEnv]
 	for _, test := range testSet {
-		hash, err := acnt.TransactionHashDeployAccount(test.Txn, test.SenderAddress)
+		hashResp, err := acnt.TransactionHashDeployAccount(test.Txn, test.SenderAddress)
 		require.Equal(t, test.ExpectedErr, err)
-		assert.Equal(t, test.ExpectedHash.String(), hash.String(), "TransactionHashDeployAccount not what expected")
+		assert.Equal(t, test.ExpectedHash.String(), hashResp.String(), "TransactionHashDeployAccount not what expected")
 
 		var hash2 *felt.Felt
 		switch txn := test.Txn.(type) {
 		case rpc.DeployAccountTxn:
-			hash2, err = account.TransactionHashDeployAccountV1(&txn, test.SenderAddress, acnt.ChainId)
+			hash2, err = hash.TransactionHashDeployAccountV1(&txn, test.SenderAddress, acnt.ChainId)
 		case rpc.DeployAccountTxnV3:
-			hash2, err = account.TransactionHashDeployAccountV3(&txn, test.SenderAddress, acnt.ChainId)
+			hash2, err = hash.TransactionHashDeployAccountV3(&txn, test.SenderAddress, acnt.ChainId)
 		}
 		require.NoError(t, err)
-		assert.Equal(t, hash, hash2)
+		assert.Equal(t, hashResp, hash2)
 	}
 }
 

--- a/account/account_test.go
+++ b/account/account_test.go
@@ -197,19 +197,18 @@ func TestTransactionHashInvoke(t *testing.T) {
 			mockRpcProvider.EXPECT().ChainID(context.Background()).Return(test.ChainID, nil)
 			acc, err := account.NewAccount(mockRpcProvider, test.AccountAddress, test.PubKey, ks, 0)
 			require.NoError(t, err, "error returned from account.NewAccount()")
-			invokeTxn := rpc.BroadcastInvokev1Txn{
-				InvokeTxnV1: rpc.InvokeTxnV1{
-					Calldata:      test.FnCall.Calldata,
-					Nonce:         test.TxDetails.Nonce,
-					MaxFee:        test.TxDetails.MaxFee,
-					SenderAddress: acc.AccountAddress,
-					Version:       test.TxDetails.Version,
-				}}
-			hash, err := acc.TransactionHashInvoke(invokeTxn.InvokeTxnV1)
+			invokeTxn := rpc.InvokeTxnV1{
+				Calldata:      test.FnCall.Calldata,
+				Nonce:         test.TxDetails.Nonce,
+				MaxFee:        test.TxDetails.MaxFee,
+				SenderAddress: acc.AccountAddress,
+				Version:       test.TxDetails.Version,
+			}
+			hash, err := acc.TransactionHashInvoke(invokeTxn)
 			require.NoError(t, err, "error returned from account.TransactionHash()")
 			require.Equal(t, test.ExpectedHash.String(), hash.String(), "transaction hash does not match expected")
 
-			hash2, err := account.TransactionHashInvokeV1(&invokeTxn.InvokeTxnV1, acc.ChainId)
+			hash2, err := account.TransactionHashInvokeV1(&invokeTxn, acc.ChainId)
 			require.NoError(t, err)
 			assert.Equal(t, hash, hash2)
 		})
@@ -467,7 +466,7 @@ func TestSendInvokeTxn(t *testing.T) {
 		AccountAddress       *felt.Felt
 		PubKey               *felt.Felt
 		PrivKey              *felt.Felt
-		InvokeTx             rpc.BroadcastInvokev3Txn
+		InvokeTx             rpc.BroadcastInvokeTxnV3
 	}
 	testSet := map[string][]testSetType{
 		"mock":   {},
@@ -481,7 +480,7 @@ func TestSendInvokeTxn(t *testing.T) {
 				SetKS:                true,
 				PubKey:               internalUtils.TestHexToFelt(t, "0x022288424ec8116c73d2e2ed3b0663c5030d328d9c0fb44c2b54055db467f31e"),
 				PrivKey:              internalUtils.TestHexToFelt(t, "0x04818374f8071c3b4c3070ff7ce766e7b9352628df7b815ea4de26e0fadb5cc9"), //
-				InvokeTx: rpc.BroadcastInvokev3Txn{
+				InvokeTx: rpc.BroadcastInvokeTxnV3{
 					InvokeTxnV3: rpc.InvokeTxnV3{
 						Nonce:   internalUtils.TestHexToFelt(t, "0xd"),
 						Type:    rpc.TransactionType_Invoke,

--- a/account/account_test.go
+++ b/account/account_test.go
@@ -1373,12 +1373,14 @@ func TestBuildAndEstimateDeployAccountTxn(t *testing.T) {
 func transferSTRKAndWaitConfirmation(t *testing.T, acc *account.Account, amount *felt.Felt, recipient *felt.Felt) {
 	t.Helper()
 	// Build and send invoke txn
+	u256Amount, err := internalUtils.HexToU256Felt(amount.String())
+	require.NoError(t, err, "Error converting amount to u256")
 	resp, err := acc.BuildAndSendInvokeTxn(context.Background(), []rpc.InvokeFunctionCall{
 		{
 			// STRK contract address in Sepolia
 			ContractAddress: internalUtils.TestHexToFelt(t, "0x04718f5a0Fc34cC1AF16A1cdee98fFB20C31f5cD61D6Ab07201858f4287c938D"),
 			FunctionName:    "transfer",
-			CallData:        []*felt.Felt{recipient, amount, &felt.Zero},
+			CallData:        append([]*felt.Felt{recipient}, u256Amount...),
 		},
 	}, 1.5)
 	require.NoError(t, err, "Error transferring STRK tokens")

--- a/examples/README.md
+++ b/examples/README.md
@@ -22,19 +22,19 @@ To run an example:
 1. How to interact with a deployed Cairo contract? How to send an `INVOKE_TXN`?  
   R: See [invoke](./invoke/main.go).
 1. How to make multiple function calls in the same transaction?  
-  R: See [invoke](./invoke/simpleInvoke.go), line 28.
+  R: See [invoke](./invoke/simpleInvoke.go), line 31.
 1. How to estimate fees?  
-  R: See [invoke](./invoke/verboseInvoke.go), line 65.
+  R: See [invoke](./invoke/verboseInvoke.go), line 67.
 1. How to generate random public and private keys?  
   R: See [deployAccount](./deployAccount/main.go), line 38.
 1. How to use my existing account importing my account address, and public and private keys?  
   R: See [deployContractUDC](./deployContractUDC/main.go), lines 54 and 64.
 1. How to get my nonce?  
-  R: See [invoke](./invoke/verboseInvoke.go), line 20.
+  R: See [invoke](./invoke/verboseInvoke.go), line 18.
 1. How to deploy a smart contract using UDC?  
   R: See [deployContractUDC](./deployContractUDC/main.go).
 1. How to get the transaction receipt?  
-  R: See [invoke](./invoke/verboseInvoke.go), line 87.
+  R: See [invoke](./invoke/verboseInvoke.go), line 89.
 1. How to deploy an ERC20 token?  
   R: See [deployContractUDC](./deployContractUDC/main.go).
 1. How to get the balance of a ERC20 token?  

--- a/examples/invoke/simpleInvoke.go
+++ b/examples/invoke/simpleInvoke.go
@@ -8,15 +8,20 @@ import (
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/starknet.go/account"
 	"github.com/NethermindEth/starknet.go/rpc"
+	"github.com/NethermindEth/starknet.go/utils"
 )
 
 // simpleInvoke is a function that shows how to easily send an invoke transaction.
 func simpleInvoke(accnt *account.Account, contractAddress *felt.Felt, contractMethod string, amount *felt.Felt) {
+	u256Amount, err := utils.HexToU256Felt(amount.String())
+	if err != nil {
+		panic(err)
+	}
 	// Building the functionCall struct, where :
 	FnCall := rpc.InvokeFunctionCall{
-		ContractAddress: contractAddress,                  //contractAddress is the contract that we want to call
-		FunctionName:    contractMethod,                   //this is the function that we want to call
-		CallData:        []*felt.Felt{amount, &felt.Zero}, //the calldata necessary to call the function. Here we are passing the "amount" value for the "mint" function
+		ContractAddress: contractAddress, //contractAddress is the contract that we want to call
+		FunctionName:    contractMethod,  //this is the function that we want to call
+		CallData:        u256Amount,      //the calldata necessary to call the function. Here we are passing the "amount" value (a u256 cairo variable) for the "mint" function
 	}
 
 	// Building and sending the Broadcast Invoke Txn.

--- a/examples/invoke/verboseInvoke.go
+++ b/examples/invoke/verboseInvoke.go
@@ -20,11 +20,15 @@ func verboseInvoke(accnt *account.Account, contractAddress *felt.Felt, contractM
 		panic(err)
 	}
 
+	u256Amount, err := utils.HexToU256Felt(amount.String())
+	if err != nil {
+		panic(err)
+	}
 	// Building the functionCall struct, where :
 	FnCall := rpc.FunctionCall{
 		ContractAddress:    contractAddress,                               //contractAddress is the contract that we want to call
 		EntryPointSelector: utils.GetSelectorFromNameFelt(contractMethod), //this is the function that we want to call
-		Calldata:           []*felt.Felt{amount, &felt.Zero},              //the calldata necessary to call the function. Here we are passing the "amount" value for the "mint" function
+		Calldata:           u256Amount,                                    //the calldata necessary to call the function. Here we are passing the "amount" value (a u256 cairo variable) for the "mint" function
 	}
 
 	// Building the Calldata with the help of FmtCalldata where we pass in the FnCall struct along with the Cairo version

--- a/examples/websocket/main.go
+++ b/examples/websocket/main.go
@@ -33,8 +33,8 @@ func main() {
 
 	// We then call the desired websocket method, passing in the channel and the parameters if needed.
 	// For example, to subscribe to new block headers, we call the SubscribeNewHeads method, passing in the channel and the blockID.
-	// As the description says it's optional, we pass nil for the blockID value. That way, the latest block will be used by default.
-	sub, err := wsClient.SubscribeNewHeads(context.Background(), newHeadsChan, nil)
+	// As the description says it's optional, we pass an empty BlockID as value. That way, the latest block will be used by default.
+	sub, err := wsClient.SubscribeNewHeads(context.Background(), newHeadsChan, rpc.BlockID{})
 	if err != nil {
 		panic(err)
 	}
@@ -66,7 +66,7 @@ loop1:
 
 	// We'll now subscribe to the node again, but this time we'll pass in an older block number as the blockID.
 	// This way, the node will send us block headers from that block number onwards.
-	sub, err = wsClient.SubscribeNewHeads(context.Background(), newHeadsChan, &rpc.SubscriptionBlockID{Number: latestBlockNumber - 10})
+	sub, err = wsClient.SubscribeNewHeads(context.Background(), newHeadsChan, rpc.WithBlockNumber(latestBlockNumber-10))
 	if err != nil {
 		panic(err)
 	}

--- a/hash/hash.go
+++ b/hash/hash.go
@@ -383,7 +383,7 @@ func TransactionHashInvokeV3(txn *rpc.InvokeTxnV3, chainId *felt.Felt) (*felt.Fe
 	if err != nil {
 		return nil, err
 	}
-	DAUint64, err := dataAvailabilityMode(txn.FeeMode, txn.NonceDataMode)
+	DAUint64, err := DataAvailabilityModeConc(txn.FeeMode, txn.NonceDataMode)
 	if err != nil {
 		return nil, err
 	}
@@ -391,7 +391,7 @@ func TransactionHashInvokeV3(txn *rpc.InvokeTxnV3, chainId *felt.Felt) (*felt.Fe
 	if err != nil {
 		return nil, err
 	}
-	tipAndResourceHash, err := tipAndResourcesHash(tipUint64, txn.ResourceBounds)
+	tipAndResourceHash, err := TipAndResourcesHash(tipUint64, txn.ResourceBounds)
 	if err != nil {
 		return nil, err
 	}
@@ -497,7 +497,7 @@ func TransactionHashDeclareV3(txn *rpc.DeclareTxnV3, chainId *felt.Felt) (*felt.
 	if err != nil {
 		return nil, err
 	}
-	DAUint64, err := dataAvailabilityMode(txn.FeeMode, txn.NonceDataMode)
+	DAUint64, err := DataAvailabilityModeConc(txn.FeeMode, txn.NonceDataMode)
 	if err != nil {
 		return nil, err
 	}
@@ -506,7 +506,7 @@ func TransactionHashDeclareV3(txn *rpc.DeclareTxnV3, chainId *felt.Felt) (*felt.
 		return nil, err
 	}
 
-	tipAndResourceHash, err := tipAndResourcesHash(tipUint64, txn.ResourceBounds)
+	tipAndResourceHash, err := TipAndResourcesHash(tipUint64, txn.ResourceBounds)
 	if err != nil {
 		return nil, err
 	}
@@ -546,7 +546,7 @@ func TransactionHashBroadcastDeclareV3(txn *rpc.BroadcastDeclareTxnV3, chainId *
 	if err != nil {
 		return nil, err
 	}
-	DAUint64, err := dataAvailabilityMode(txn.FeeMode, txn.NonceDataMode)
+	DAUint64, err := DataAvailabilityModeConc(txn.FeeMode, txn.NonceDataMode)
 	if err != nil {
 		return nil, err
 	}
@@ -555,7 +555,7 @@ func TransactionHashBroadcastDeclareV3(txn *rpc.BroadcastDeclareTxnV3, chainId *
 		return nil, err
 	}
 
-	tipAndResourceHash, err := tipAndResourcesHash(tipUint64, txn.ResourceBounds)
+	tipAndResourceHash, err := TipAndResourcesHash(tipUint64, txn.ResourceBounds)
 	if err != nil {
 		return nil, err
 	}
@@ -627,7 +627,7 @@ func TransactionHashDeployAccountV3(txn *rpc.DeployAccountTxnV3, contractAddress
 	if err != nil {
 		return nil, err
 	}
-	DAUint64, err := dataAvailabilityMode(txn.FeeMode, txn.NonceDataMode)
+	DAUint64, err := DataAvailabilityModeConc(txn.FeeMode, txn.NonceDataMode)
 	if err != nil {
 		return nil, err
 	}
@@ -635,7 +635,7 @@ func TransactionHashDeployAccountV3(txn *rpc.DeployAccountTxnV3, contractAddress
 	if err != nil {
 		return nil, err
 	}
-	tipAndResourceHash, err := tipAndResourcesHash(tipUint64, txn.ResourceBounds)
+	tipAndResourceHash, err := TipAndResourcesHash(tipUint64, txn.ResourceBounds)
 	if err != nil {
 		return nil, err
 	}
@@ -654,7 +654,7 @@ func TransactionHashDeployAccountV3(txn *rpc.DeployAccountTxnV3, contractAddress
 	), nil
 }
 
-func tipAndResourcesHash(tip uint64, resourceBounds rpc.ResourceBoundsMapping) (*felt.Felt, error) {
+func TipAndResourcesHash(tip uint64, resourceBounds rpc.ResourceBoundsMapping) (*felt.Felt, error) {
 	l1Bytes, err := resourceBounds.L1Gas.Bytes(rpc.ResourceL1Gas)
 	if err != nil {
 		return nil, err
@@ -673,7 +673,7 @@ func tipAndResourcesHash(tip uint64, resourceBounds rpc.ResourceBoundsMapping) (
 	return crypto.PoseidonArray(new(felt.Felt).SetUint64(tip), l1Bounds, l2Bounds, l1DataGasBounds), nil
 }
 
-func dataAvailabilityMode(feeDAMode, nonceDAMode rpc.DataAvailabilityMode) (uint64, error) {
+func DataAvailabilityModeConc(feeDAMode, nonceDAMode rpc.DataAvailabilityMode) (uint64, error) {
 	const dataAvailabilityModeBits = 32
 	fee64, err := feeDAMode.UInt64()
 	if err != nil {

--- a/hash/hash.go
+++ b/hash/hash.go
@@ -4,10 +4,23 @@ import (
 	"errors"
 	"slices"
 
+	"github.com/NethermindEth/juno/core/crypto"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/starknet.go/contracts"
 	"github.com/NethermindEth/starknet.go/curve"
 	internalUtils "github.com/NethermindEth/starknet.go/internal/utils"
+	"github.com/NethermindEth/starknet.go/rpc"
+)
+
+var (
+	PREFIX_TRANSACTION    = new(felt.Felt).SetBytes([]byte("invoke"))
+	PREFIX_DECLARE        = new(felt.Felt).SetBytes([]byte("declare"))
+	PREFIX_DEPLOY_ACCOUNT = new(felt.Felt).SetBytes([]byte("deploy_account"))
+)
+
+var (
+	ErrNotAllParametersSet = errors.New("not all neccessary parameters have been set")
+	ErrFeltToBigInt        = errors.New("felt to BigInt error")
 )
 
 // CalculateDeprecatedTransactionHashCommon calculates the transaction hash common to be used in the StarkNet network - a unique identifier of the transaction.
@@ -284,4 +297,391 @@ func hashCasmClassEntryPointByType(entryPoint []contracts.CasmEntryPoint) *felt.
 		flattened = append(flattened, elt.Selector, new(felt.Felt).SetUint64(uint64(elt.Offset)), builtInHash)
 	}
 	return curve.PoseidonArray(flattened...)
+}
+
+// TransactionHashInvokeV0 calculates the transaction hash for a invoke V0 transaction.
+//
+// Parameters:
+//   - txn: The invoke V0 transaction to calculate the hash for
+//   - chainId: The chain ID as a *felt.Felt
+//
+// Returns:
+//   - *felt.Felt: the calculated transaction hash
+//   - error: an error if any
+func TransactionHashInvokeV0(txn *rpc.InvokeTxnV0, chainId *felt.Felt) (*felt.Felt, error) {
+	// https://docs.starknet.io/architecture-and-concepts/network-architecture/transactions/#v0_deprecated_hash_calculation
+	if txn.Version == "" || len(txn.Calldata) == 0 || txn.MaxFee == nil || txn.EntryPointSelector == nil {
+		return nil, ErrNotAllParametersSet
+	}
+
+	calldataHash := curve.PedersenArray(txn.Calldata...)
+	txnVersionFelt, err := new(felt.Felt).SetString(string(txn.Version))
+	if err != nil {
+		return nil, err
+	}
+	return CalculateDeprecatedTransactionHashCommon(
+		PREFIX_TRANSACTION,
+		txnVersionFelt,
+		txn.ContractAddress,
+		txn.EntryPointSelector,
+		calldataHash,
+		txn.MaxFee,
+		chainId,
+		[]*felt.Felt{},
+	), nil
+}
+
+// TransactionHashInvokeV1 calculates the transaction hash for a invoke V1 transaction.
+//
+// Parameters:
+//   - txn: The invoke V1 transaction to calculate the hash for
+//   - chainId: The chain ID as a *felt.Felt
+//
+// Returns:
+//   - *felt.Felt: the calculated transaction hash
+//   - error: an error if any
+func TransactionHashInvokeV1(txn *rpc.InvokeTxnV1, chainId *felt.Felt) (*felt.Felt, error) {
+	// https://docs.starknet.io/architecture-and-concepts/network-architecture/transactions/#v1_deprecated_hash_calculation
+	if txn.Version == "" || len(txn.Calldata) == 0 || txn.Nonce == nil || txn.MaxFee == nil || txn.SenderAddress == nil {
+		return nil, ErrNotAllParametersSet
+	}
+
+	calldataHash := curve.PedersenArray(txn.Calldata...)
+	txnVersionFelt, err := new(felt.Felt).SetString(string(txn.Version))
+	if err != nil {
+		return nil, err
+	}
+	return CalculateDeprecatedTransactionHashCommon(
+		PREFIX_TRANSACTION,
+		txnVersionFelt,
+		txn.SenderAddress,
+		&felt.Zero,
+		calldataHash,
+		txn.MaxFee,
+		chainId,
+		[]*felt.Felt{txn.Nonce},
+	), nil
+}
+
+// TransactionHashInvokeV3 calculates the transaction hash for a invoke V3 transaction.
+//
+// Parameters:
+//   - txn: The invoke V3 transaction to calculate the hash for
+//   - chainId: The chain ID as a *felt.Felt
+//
+// Returns:
+//   - *felt.Felt: the calculated transaction hash
+//   - error: an error if any
+func TransactionHashInvokeV3(txn *rpc.InvokeTxnV3, chainId *felt.Felt) (*felt.Felt, error) {
+	// https://github.com/starknet-io/SNIPs/blob/main/SNIPS/snip-8.md#protocol-changes
+	// https://docs.starknet.io/architecture-and-concepts/network-architecture/transactions/#v3_hash_calculation
+	if txn.Version == "" || txn.ResourceBounds == (rpc.ResourceBoundsMapping{}) || len(txn.Calldata) == 0 || txn.Nonce == nil || txn.SenderAddress == nil || txn.PayMasterData == nil || txn.AccountDeploymentData == nil {
+		return nil, ErrNotAllParametersSet
+	}
+
+	txnVersionFelt, err := new(felt.Felt).SetString(string(txn.Version))
+	if err != nil {
+		return nil, err
+	}
+	DAUint64, err := dataAvailabilityMode(txn.FeeMode, txn.NonceDataMode)
+	if err != nil {
+		return nil, err
+	}
+	tipUint64, err := txn.Tip.ToUint64()
+	if err != nil {
+		return nil, err
+	}
+	tipAndResourceHash, err := tipAndResourcesHash(tipUint64, txn.ResourceBounds)
+	if err != nil {
+		return nil, err
+	}
+	return crypto.PoseidonArray(
+		PREFIX_TRANSACTION,
+		txnVersionFelt,
+		txn.SenderAddress,
+		tipAndResourceHash,
+		crypto.PoseidonArray(txn.PayMasterData...),
+		chainId,
+		txn.Nonce,
+		new(felt.Felt).SetUint64(DAUint64),
+		crypto.PoseidonArray(txn.AccountDeploymentData...),
+		crypto.PoseidonArray(txn.Calldata...),
+	), nil
+}
+
+// TransactionHashDeclareV1 calculates the transaction hash for a declare V1 transaction.
+//
+// Parameters:
+//   - txn: The declare V1 transaction to calculate the hash for
+//   - chainId: The chain ID as a *felt.Felt
+//
+// Returns:
+//   - *felt.Felt: the calculated transaction hash
+//   - error: an error if any
+func TransactionHashDeclareV1(txn *rpc.DeclareTxnV1, chainId *felt.Felt) (*felt.Felt, error) {
+	// https://docs.starknet.io/architecture-and-concepts/network-architecture/transactions/#v1_deprecated_hash_calculation_2
+	if txn.SenderAddress == nil || txn.Version == "" || txn.ClassHash == nil || txn.MaxFee == nil || txn.Nonce == nil {
+		return nil, ErrNotAllParametersSet
+	}
+
+	calldataHash := curve.PedersenArray(txn.ClassHash)
+
+	txnVersionFelt, err := new(felt.Felt).SetString(string(txn.Version))
+	if err != nil {
+		return nil, err
+	}
+	return CalculateDeprecatedTransactionHashCommon(
+		PREFIX_DECLARE,
+		txnVersionFelt,
+		txn.SenderAddress,
+		&felt.Zero,
+		calldataHash,
+		txn.MaxFee,
+		chainId,
+		[]*felt.Felt{txn.Nonce},
+	), nil
+}
+
+// TransactionHashDeclareV2 calculates the transaction hash for a declare V2 transaction.
+//
+// Parameters:
+//   - txn: The declare V2 transaction to calculate the hash for
+//   - chainId: The chain ID as a *felt.Felt
+//
+// Returns:
+//   - *felt.Felt: the calculated transaction hash
+//   - error: an error if any
+func TransactionHashDeclareV2(txn *rpc.DeclareTxnV2, chainId *felt.Felt) (*felt.Felt, error) {
+	// https://docs.starknet.io/architecture-and-concepts/network-architecture/transactions/#v2_deprecated_hash_calculation
+	if txn.CompiledClassHash == nil || txn.SenderAddress == nil || txn.Version == "" || txn.ClassHash == nil || txn.MaxFee == nil || txn.Nonce == nil {
+		return nil, ErrNotAllParametersSet
+	}
+
+	calldataHash := curve.PedersenArray(txn.ClassHash)
+
+	txnVersionFelt, err := new(felt.Felt).SetString(string(txn.Version))
+	if err != nil {
+		return nil, err
+	}
+
+	return CalculateDeprecatedTransactionHashCommon(
+		PREFIX_DECLARE,
+		txnVersionFelt,
+		txn.SenderAddress,
+		&felt.Zero,
+		calldataHash,
+		txn.MaxFee,
+		chainId,
+		[]*felt.Felt{txn.Nonce, txn.CompiledClassHash},
+	), nil
+}
+
+// TransactionHashDeclareV3 calculates the transaction hash for a declare V3 transaction.
+//
+// Parameters:
+//   - txn: The declare V3 transaction to calculate the hash for
+//   - chainId: The chain ID as a *felt.Felt
+//
+// Returns:
+//   - *felt.Felt: the calculated transaction hash
+//   - error: an error if any
+func TransactionHashDeclareV3(txn *rpc.DeclareTxnV3, chainId *felt.Felt) (*felt.Felt, error) {
+	// https://docs.starknet.io/architecture-and-concepts/network-architecture/transactions/#v3_hash_calculation_2
+	// https://github.com/starknet-io/SNIPs/blob/main/SNIPS/snip-8.md#protocol-changes
+	if txn.Version == "" || txn.ResourceBounds == (rpc.ResourceBoundsMapping{}) || txn.Nonce == nil || txn.SenderAddress == nil || txn.PayMasterData == nil || txn.AccountDeploymentData == nil ||
+		txn.ClassHash == nil || txn.CompiledClassHash == nil {
+		return nil, ErrNotAllParametersSet
+	}
+
+	txnVersionFelt, err := new(felt.Felt).SetString(string(txn.Version))
+	if err != nil {
+		return nil, err
+	}
+	DAUint64, err := dataAvailabilityMode(txn.FeeMode, txn.NonceDataMode)
+	if err != nil {
+		return nil, err
+	}
+	tipUint64, err := txn.Tip.ToUint64()
+	if err != nil {
+		return nil, err
+	}
+
+	tipAndResourceHash, err := tipAndResourcesHash(tipUint64, txn.ResourceBounds)
+	if err != nil {
+		return nil, err
+	}
+	return crypto.PoseidonArray(
+		PREFIX_DECLARE,
+		txnVersionFelt,
+		txn.SenderAddress,
+		tipAndResourceHash,
+		crypto.PoseidonArray(txn.PayMasterData...),
+		chainId,
+		txn.Nonce,
+		new(felt.Felt).SetUint64(DAUint64),
+		crypto.PoseidonArray(txn.AccountDeploymentData...),
+		txn.ClassHash,
+		txn.CompiledClassHash,
+	), nil
+}
+
+// TransactionHashBroadcastDeclareV3 calculates the transaction hash for a broadcast declare V3 transaction.
+//
+// Parameters:
+//   - txn: The broadcast declare V3 transaction to calculate the hash for
+//   - chainId: The chain ID as a *felt.Felt
+//
+// Returns:
+//   - *felt.Felt: the calculated transaction hash
+//   - error: an error if any
+func TransactionHashBroadcastDeclareV3(txn *rpc.BroadcastDeclareTxnV3, chainId *felt.Felt) (*felt.Felt, error) {
+	// https://docs.starknet.io/architecture-and-concepts/network-architecture/transactions/#v3_hash_calculation_2
+	// https://github.com/starknet-io/SNIPs/blob/main/SNIPS/snip-8.md#protocol-changes
+	if txn.Version == "" || txn.ResourceBounds == (rpc.ResourceBoundsMapping{}) || txn.Nonce == nil || txn.SenderAddress == nil || txn.PayMasterData == nil || txn.AccountDeploymentData == nil ||
+		txn.ContractClass == nil || txn.CompiledClassHash == nil {
+		return nil, ErrNotAllParametersSet
+	}
+
+	txnVersionFelt, err := new(felt.Felt).SetString(string(txn.Version))
+	if err != nil {
+		return nil, err
+	}
+	DAUint64, err := dataAvailabilityMode(txn.FeeMode, txn.NonceDataMode)
+	if err != nil {
+		return nil, err
+	}
+	tipUint64, err := txn.Tip.ToUint64()
+	if err != nil {
+		return nil, err
+	}
+
+	tipAndResourceHash, err := tipAndResourcesHash(tipUint64, txn.ResourceBounds)
+	if err != nil {
+		return nil, err
+	}
+	return crypto.PoseidonArray(
+		PREFIX_DECLARE,
+		txnVersionFelt,
+		txn.SenderAddress,
+		tipAndResourceHash,
+		crypto.PoseidonArray(txn.PayMasterData...),
+		chainId,
+		txn.Nonce,
+		new(felt.Felt).SetUint64(DAUint64),
+		crypto.PoseidonArray(txn.AccountDeploymentData...),
+		ClassHash(txn.ContractClass),
+		txn.CompiledClassHash,
+	), nil
+}
+
+// TransactionHashDeployAccountV1 calculates the transaction hash for a deploy account V1 transaction.
+//
+// Parameters:
+//   - txn: The deploy account V1 transaction to calculate the hash for
+//   - contractAddress: The contract address as parameters as a *felt.Felt
+//   - chainId: The chain ID as a *felt.Felt
+//
+// Returns:
+//   - *felt.Felt: the calculated transaction hash
+//   - error: an error if any
+func TransactionHashDeployAccountV1(txn *rpc.DeployAccountTxn, contractAddress, chainId *felt.Felt) (*felt.Felt, error) {
+	// https://docs.starknet.io/architecture-and-concepts/network-architecture/transactions/#v1_deprecated_hash_calculation_3
+	calldata := []*felt.Felt{txn.ClassHash, txn.ContractAddressSalt}
+	calldata = append(calldata, txn.ConstructorCalldata...)
+	calldataHash := curve.PedersenArray(calldata...)
+
+	versionFelt, err := new(felt.Felt).SetString(string(txn.Version))
+	if err != nil {
+		return nil, err
+	}
+
+	return CalculateDeprecatedTransactionHashCommon(
+		PREFIX_DEPLOY_ACCOUNT,
+		versionFelt,
+		contractAddress,
+		&felt.Zero,
+		calldataHash,
+		txn.MaxFee,
+		chainId,
+		[]*felt.Felt{txn.Nonce},
+	), nil
+}
+
+// TransactionHashDeployAccountV3 calculates the transaction hash for a deploy account V3 transaction.
+//
+// Parameters:
+//   - txn: The deploy account V3 transaction to calculate the hash for
+//   - contractAddress: The contract address as parameters as a *felt.Felt
+//   - chainId: The chain ID as a *felt.Felt
+//
+// Returns:
+//   - *felt.Felt: the calculated transaction hash
+//   - error: an error if any
+func TransactionHashDeployAccountV3(txn *rpc.DeployAccountTxnV3, contractAddress, chainId *felt.Felt) (*felt.Felt, error) {
+	// https://docs.starknet.io/architecture-and-concepts/network-architecture/transactions/#v3_hash_calculation_3
+	if txn.Version == "" || txn.ResourceBounds == (rpc.ResourceBoundsMapping{}) || txn.Nonce == nil || txn.PayMasterData == nil {
+		return nil, ErrNotAllParametersSet
+	}
+
+	txnVersionFelt, err := new(felt.Felt).SetString(string(txn.Version))
+	if err != nil {
+		return nil, err
+	}
+	DAUint64, err := dataAvailabilityMode(txn.FeeMode, txn.NonceDataMode)
+	if err != nil {
+		return nil, err
+	}
+	tipUint64, err := txn.Tip.ToUint64()
+	if err != nil {
+		return nil, err
+	}
+	tipAndResourceHash, err := tipAndResourcesHash(tipUint64, txn.ResourceBounds)
+	if err != nil {
+		return nil, err
+	}
+	return crypto.PoseidonArray(
+		PREFIX_DEPLOY_ACCOUNT,
+		txnVersionFelt,
+		contractAddress,
+		tipAndResourceHash,
+		crypto.PoseidonArray(txn.PayMasterData...),
+		chainId,
+		txn.Nonce,
+		new(felt.Felt).SetUint64(DAUint64),
+		crypto.PoseidonArray(txn.ConstructorCalldata...),
+		txn.ClassHash,
+		txn.ContractAddressSalt,
+	), nil
+}
+
+func tipAndResourcesHash(tip uint64, resourceBounds rpc.ResourceBoundsMapping) (*felt.Felt, error) {
+	l1Bytes, err := resourceBounds.L1Gas.Bytes(rpc.ResourceL1Gas)
+	if err != nil {
+		return nil, err
+	}
+	l2Bytes, err := resourceBounds.L2Gas.Bytes(rpc.ResourceL2Gas)
+	if err != nil {
+		return nil, err
+	}
+	l1DataGasBytes, err := resourceBounds.L1DataGas.Bytes(rpc.ResourceL1DataGas)
+	if err != nil {
+		return nil, err
+	}
+	l1Bounds := new(felt.Felt).SetBytes(l1Bytes)
+	l2Bounds := new(felt.Felt).SetBytes(l2Bytes)
+	l1DataGasBounds := new(felt.Felt).SetBytes(l1DataGasBytes)
+	return crypto.PoseidonArray(new(felt.Felt).SetUint64(tip), l1Bounds, l2Bounds, l1DataGasBounds), nil
+}
+
+func dataAvailabilityMode(feeDAMode, nonceDAMode rpc.DataAvailabilityMode) (uint64, error) {
+	const dataAvailabilityModeBits = 32
+	fee64, err := feeDAMode.UInt64()
+	if err != nil {
+		return 0, err
+	}
+	nonce64, err := nonceDAMode.UInt64()
+	if err != nil {
+		return 0, err
+	}
+	return fee64 + nonce64<<dataAvailabilityModeBits, nil
 }

--- a/hash/hash_test.go
+++ b/hash/hash_test.go
@@ -130,3 +130,5 @@ func TestClassHashes(t *testing.T) {
 		}
 	})
 }
+
+// Note: Tests for TransactionHash... methods are located in the account_test.go file from the account package

--- a/internal/utils/felt.go
+++ b/internal/utils/felt.go
@@ -273,3 +273,35 @@ func HexToU256Felt(hexStr string) ([]*felt.Felt, error) {
 	// Return as a slice [low, high]
 	return []*felt.Felt{lowFelt, highFelt}, nil
 }
+
+// U256FeltToHex converts a Cairo u256 representation (two felt.Felt values) back to a hexadecimal string.
+// The Cairo u256 is represented as two felt.Felt values:
+// - The first felt.Felt contains the 128 least significant bits (low part)
+// - The second felt.Felt contains the 128 most significant bits (high part)
+//
+// Parameters:
+// - u256: a slice containing two felt.Felt values [low, high]
+// Returns:
+// - string: the hexadecimal representation of the combined value
+// - error: if conversion fails
+func U256FeltToHex(u256 []*felt.Felt) (string, error) {
+	// Check if the input is valid
+	if len(u256) != 2 {
+		return "", fmt.Errorf("expected 2 felt values for u256, got %d", len(u256))
+	}
+
+	// Extract low and high parts
+	lowFelt, highFelt := u256[0], u256[1]
+
+	// Convert to big.Int
+	lowBits := FeltToBigInt(lowFelt)
+	highBits := FeltToBigInt(highFelt)
+
+	// Combine the parts: result = highBits << 128 + lowBits
+	result := new(big.Int).Lsh(highBits, 128)  // Shift high bits left by 128 bits
+	result = new(big.Int).Add(result, lowBits) // Add low bits
+
+	// Convert to hex string with "0x" prefix
+	hexStr := fmt.Sprintf("%#x", result)
+	return hexStr, nil
+}

--- a/internal/utils/felt_test.go
+++ b/internal/utils/felt_test.go
@@ -1,8 +1,11 @@
 package utils
 
 import (
+	"fmt"
+	"math/big"
 	"testing"
 
+	"github.com/NethermindEth/juno/core/felt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -166,6 +169,97 @@ func TestHexToU256Felt(t *testing.T) {
 
 			assert.Equal(t, tc.wantLow, lowHex, "low bits do not match expected value")
 			assert.Equal(t, tc.wantHigh, highHex, "high bits do not match expected value")
+		})
+	}
+}
+
+func TestU256FeltToHex(t *testing.T) {
+	var tests = []struct {
+		name       string
+		lowHex     string
+		highHex    string
+		wantHex    string
+		shouldFail bool
+	}{
+		{
+			name:    "simple decimal 2",
+			lowHex:  "0x2",
+			highHex: "0x0",
+			wantHex: "0x2",
+		},
+		{
+			name:    "2^128",
+			lowHex:  "0x0",
+			highHex: "0x1",
+			wantHex: "0x100000000000000000000000000000000",
+		},
+		{
+			name:    "2^129 + 2^128 + 20",
+			lowHex:  "0x14",
+			highHex: "0x3",
+			wantHex: "0x300000000000000000000000000000014",
+		},
+		{
+			name:    "max uint128 in low part",
+			lowHex:  "0xffffffffffffffffffffffffffffffff",
+			highHex: "0x0",
+			wantHex: "0xffffffffffffffffffffffffffffffff",
+		},
+		{
+			name:    "max uint128 in high part",
+			lowHex:  "0x0",
+			highHex: "0xffffffffffffffffffffffffffffffff",
+			wantHex: "0xffffffffffffffffffffffffffffffff00000000000000000000000000000000",
+		},
+		{
+			name:    "zero value",
+			lowHex:  "0x0",
+			highHex: "0x0",
+			wantHex: "0x0",
+		},
+		{
+			name:       "invalid input length",
+			shouldFail: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var input []*felt.Felt
+
+			if tc.shouldFail {
+				// Test with empty slice for error case
+				result, err := U256FeltToHex(input)
+				assert.Error(t, err, "expected error but got none")
+				assert.Empty(t, result, "expected empty result on error")
+				return
+			}
+
+			// Parse the low and high hex values into felt.Felt objects
+			lowFelt, err := HexToFelt(tc.lowHex)
+			require.NoError(t, err, "failed to parse low hex")
+
+			highFelt, err := HexToFelt(tc.highHex)
+			require.NoError(t, err, "failed to parse high hex")
+
+			input = []*felt.Felt{lowFelt, highFelt}
+
+			// Call the function under test
+			result, err := U256FeltToHex(input)
+			require.NoError(t, err, "unexpected error")
+
+			// Normalize expected value for comparison
+			// Convert hex to big.Int and back to normalized hex for consistent comparison
+			expectedBigInt, _ := new(big.Int).SetString(tc.wantHex[2:], 16)
+			expectedHex := fmt.Sprintf("%#x", expectedBigInt)
+
+			assert.Equal(t, expectedHex, result, "hex representation does not match expected value")
+
+			// Round-trip test: Convert back to u256 felt representation
+			roundTrip, err := HexToU256Felt(result)
+			require.NoError(t, err, "failed in round-trip conversion")
+			assert.Equal(t, lowFelt.String(), roundTrip[0].String(), "round-trip low bits do not match")
+			assert.Equal(t, highFelt.String(), roundTrip[1].String(), "round-trip high bits do not match")
 		})
 	}
 }

--- a/mocks/mock_account.go
+++ b/mocks/mock_account.go
@@ -15,6 +15,7 @@ import (
 	time "time"
 
 	felt "github.com/NethermindEth/juno/core/felt"
+	contracts "github.com/NethermindEth/starknet.go/contracts"
 	rpc "github.com/NethermindEth/starknet.go/rpc"
 	gomock "go.uber.org/mock/gomock"
 )
@@ -23,6 +24,7 @@ import (
 type MockAccountInterface struct {
 	ctrl     *gomock.Controller
 	recorder *MockAccountInterfaceMockRecorder
+	isgomock struct{}
 }
 
 // MockAccountInterfaceMockRecorder is the mock recorder for MockAccountInterface.
@@ -42,19 +44,80 @@ func (m *MockAccountInterface) EXPECT() *MockAccountInterfaceMockRecorder {
 	return m.recorder
 }
 
-// PrecomputeAccountAddress mocks base method.
-func (m *MockAccountInterface) PrecomputeAccountAddress(salt, classHash *felt.Felt, constructorCalldata []*felt.Felt) (*felt.Felt, error) {
+// BuildAndEstimateDeployAccountTxn mocks base method.
+func (m *MockAccountInterface) BuildAndEstimateDeployAccountTxn(ctx context.Context, salt, classHash *felt.Felt, constructorCalldata []*felt.Felt, multiplier float64) (*rpc.BroadcastDeployAccountTxnV3, *felt.Felt, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PrecomputeAccountAddress", salt, classHash, constructorCalldata)
+	ret := m.ctrl.Call(m, "BuildAndEstimateDeployAccountTxn", ctx, salt, classHash, constructorCalldata, multiplier)
+	ret0, _ := ret[0].(*rpc.BroadcastDeployAccountTxnV3)
+	ret1, _ := ret[1].(*felt.Felt)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// BuildAndEstimateDeployAccountTxn indicates an expected call of BuildAndEstimateDeployAccountTxn.
+func (mr *MockAccountInterfaceMockRecorder) BuildAndEstimateDeployAccountTxn(ctx, salt, classHash, constructorCalldata, multiplier any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildAndEstimateDeployAccountTxn", reflect.TypeOf((*MockAccountInterface)(nil).BuildAndEstimateDeployAccountTxn), ctx, salt, classHash, constructorCalldata, multiplier)
+}
+
+// BuildAndSendDeclareTxn mocks base method.
+func (m *MockAccountInterface) BuildAndSendDeclareTxn(ctx context.Context, casmClass *contracts.CasmClass, contractClass *contracts.ContractClass, multiplier float64) (*rpc.AddDeclareTransactionResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BuildAndSendDeclareTxn", ctx, casmClass, contractClass, multiplier)
+	ret0, _ := ret[0].(*rpc.AddDeclareTransactionResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// BuildAndSendDeclareTxn indicates an expected call of BuildAndSendDeclareTxn.
+func (mr *MockAccountInterfaceMockRecorder) BuildAndSendDeclareTxn(ctx, casmClass, contractClass, multiplier any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildAndSendDeclareTxn", reflect.TypeOf((*MockAccountInterface)(nil).BuildAndSendDeclareTxn), ctx, casmClass, contractClass, multiplier)
+}
+
+// BuildAndSendInvokeTxn mocks base method.
+func (m *MockAccountInterface) BuildAndSendInvokeTxn(ctx context.Context, functionCalls []rpc.InvokeFunctionCall, multiplier float64) (*rpc.AddInvokeTransactionResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BuildAndSendInvokeTxn", ctx, functionCalls, multiplier)
+	ret0, _ := ret[0].(*rpc.AddInvokeTransactionResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// BuildAndSendInvokeTxn indicates an expected call of BuildAndSendInvokeTxn.
+func (mr *MockAccountInterfaceMockRecorder) BuildAndSendInvokeTxn(ctx, functionCalls, multiplier any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildAndSendInvokeTxn", reflect.TypeOf((*MockAccountInterface)(nil).BuildAndSendInvokeTxn), ctx, functionCalls, multiplier)
+}
+
+// Nonce mocks base method.
+func (m *MockAccountInterface) Nonce(ctx context.Context) (*felt.Felt, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Nonce", ctx)
 	ret0, _ := ret[0].(*felt.Felt)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// PrecomputeAccountAddress indicates an expected call of PrecomputeAccountAddress.
-func (mr *MockAccountInterfaceMockRecorder) PrecomputeAccountAddress(salt, classHash, constructorCalldata any) *gomock.Call {
+// Nonce indicates an expected call of Nonce.
+func (mr *MockAccountInterfaceMockRecorder) Nonce(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrecomputeAccountAddress", reflect.TypeOf((*MockAccountInterface)(nil).PrecomputeAccountAddress), salt, classHash, constructorCalldata)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Nonce", reflect.TypeOf((*MockAccountInterface)(nil).Nonce), ctx)
+}
+
+// SendTransaction mocks base method.
+func (m *MockAccountInterface) SendTransaction(ctx context.Context, txn rpc.BroadcastTxn) (*rpc.TransactionResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SendTransaction", ctx, txn)
+	ret0, _ := ret[0].(*rpc.TransactionResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SendTransaction indicates an expected call of SendTransaction.
+func (mr *MockAccountInterfaceMockRecorder) SendTransaction(ctx, txn any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendTransaction", reflect.TypeOf((*MockAccountInterface)(nil).SendTransaction), ctx, txn)
 }
 
 // Sign mocks base method.
@@ -73,7 +136,7 @@ func (mr *MockAccountInterfaceMockRecorder) Sign(ctx, msg any) *gomock.Call {
 }
 
 // SignDeclareTransaction mocks base method.
-func (m *MockAccountInterface) SignDeclareTransaction(ctx context.Context, tx *rpc.DeclareTxnV2) error {
+func (m *MockAccountInterface) SignDeclareTransaction(ctx context.Context, tx rpc.DeclareTxnType) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SignDeclareTransaction", ctx, tx)
 	ret0, _ := ret[0].(error)
@@ -87,7 +150,7 @@ func (mr *MockAccountInterfaceMockRecorder) SignDeclareTransaction(ctx, tx any) 
 }
 
 // SignDeployAccountTransaction mocks base method.
-func (m *MockAccountInterface) SignDeployAccountTransaction(ctx context.Context, tx *rpc.DeployAccountTxn, precomputeAddress *felt.Felt) error {
+func (m *MockAccountInterface) SignDeployAccountTransaction(ctx context.Context, tx rpc.DeployAccountType, precomputeAddress *felt.Felt) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SignDeployAccountTransaction", ctx, tx, precomputeAddress)
 	ret0, _ := ret[0].(error)
@@ -101,7 +164,7 @@ func (mr *MockAccountInterfaceMockRecorder) SignDeployAccountTransaction(ctx, tx
 }
 
 // SignInvokeTransaction mocks base method.
-func (m *MockAccountInterface) SignInvokeTransaction(ctx context.Context, tx *rpc.InvokeTxnV1) error {
+func (m *MockAccountInterface) SignInvokeTransaction(ctx context.Context, tx rpc.InvokeTxnType) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SignInvokeTransaction", ctx, tx)
 	ret0, _ := ret[0].(error)

--- a/mocks/mock_rpc_provider.go
+++ b/mocks/mock_rpc_provider.go
@@ -45,7 +45,7 @@ func (m *MockRpcProvider) EXPECT() *MockRpcProviderMockRecorder {
 }
 
 // AddDeclareTransaction mocks base method.
-func (m *MockRpcProvider) AddDeclareTransaction(ctx context.Context, declareTransaction rpc.BroadcastDeclareTxnType) (*rpc.AddDeclareTransactionResponse, error) {
+func (m *MockRpcProvider) AddDeclareTransaction(ctx context.Context, declareTransaction *rpc.BroadcastDeclareTxnV3) (*rpc.AddDeclareTransactionResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddDeclareTransaction", ctx, declareTransaction)
 	ret0, _ := ret[0].(*rpc.AddDeclareTransactionResponse)
@@ -60,7 +60,7 @@ func (mr *MockRpcProviderMockRecorder) AddDeclareTransaction(ctx, declareTransac
 }
 
 // AddDeployAccountTransaction mocks base method.
-func (m *MockRpcProvider) AddDeployAccountTransaction(ctx context.Context, deployAccountTransaction rpc.BroadcastAddDeployTxnType) (*rpc.AddDeployAccountTransactionResponse, error) {
+func (m *MockRpcProvider) AddDeployAccountTransaction(ctx context.Context, deployAccountTransaction *rpc.BroadcastDeployAccountTxnV3) (*rpc.AddDeployAccountTransactionResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddDeployAccountTransaction", ctx, deployAccountTransaction)
 	ret0, _ := ret[0].(*rpc.AddDeployAccountTransactionResponse)
@@ -75,7 +75,7 @@ func (mr *MockRpcProviderMockRecorder) AddDeployAccountTransaction(ctx, deployAc
 }
 
 // AddInvokeTransaction mocks base method.
-func (m *MockRpcProvider) AddInvokeTransaction(ctx context.Context, invokeTxn rpc.BroadcastInvokeTxnType) (*rpc.AddInvokeTransactionResponse, error) {
+func (m *MockRpcProvider) AddInvokeTransaction(ctx context.Context, invokeTxn *rpc.BroadcastInvokeTxnV3) (*rpc.AddInvokeTransactionResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddInvokeTransaction", ctx, invokeTxn)
 	ret0, _ := ret[0].(*rpc.AddInvokeTransactionResponse)

--- a/mocks/mock_rpc_provider.go
+++ b/mocks/mock_rpc_provider.go
@@ -564,18 +564,18 @@ func (mr *MockWebsocketProviderMockRecorder) SubscribeEvents(ctx, events, option
 }
 
 // SubscribeNewHeads mocks base method.
-func (m *MockWebsocketProvider) SubscribeNewHeads(ctx context.Context, headers chan<- *rpc.BlockHeader, subBlockID *rpc.SubscriptionBlockID) (*client.ClientSubscription, error) {
+func (m *MockWebsocketProvider) SubscribeNewHeads(ctx context.Context, headers chan<- *rpc.BlockHeader, blockID rpc.BlockID) (*client.ClientSubscription, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SubscribeNewHeads", ctx, headers, subBlockID)
+	ret := m.ctrl.Call(m, "SubscribeNewHeads", ctx, headers, blockID)
 	ret0, _ := ret[0].(*client.ClientSubscription)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // SubscribeNewHeads indicates an expected call of SubscribeNewHeads.
-func (mr *MockWebsocketProviderMockRecorder) SubscribeNewHeads(ctx, headers, subBlockID any) *gomock.Call {
+func (mr *MockWebsocketProviderMockRecorder) SubscribeNewHeads(ctx, headers, blockID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubscribeNewHeads", reflect.TypeOf((*MockWebsocketProvider)(nil).SubscribeNewHeads), ctx, headers, subBlockID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubscribeNewHeads", reflect.TypeOf((*MockWebsocketProvider)(nil).SubscribeNewHeads), ctx, headers, blockID)
 }
 
 // SubscribePendingTransactions mocks base method.

--- a/rpc/contract.go
+++ b/rpc/contract.go
@@ -135,7 +135,7 @@ func (provider *Provider) Nonce(ctx context.Context, blockID BlockID, contractAd
 
 // Estimates the resources required by a given sequence of transactions when applied on a given state.
 // If one of the transactions reverts or fails due to any reason (e.g. validation failure or an internal error),
-// a TRANSACTION_EXECUTION_ERROR is returned. For v0-2 transactions the estimate is given in wei, and for v3 transactions it is given in fri.
+// a TRANSACTION_EXECUTION_ERROR is returned.  The estimate is given in fri.
 //
 // Parameters:
 // - ctx: The context of the function call

--- a/rpc/contract.go
+++ b/rpc/contract.go
@@ -182,6 +182,11 @@ func (provider *Provider) EstimateMessageFee(ctx context.Context, msg MsgFromL1,
 // the path to it may end in an edge node whose path is not a prefix of the requested leaf, thus effectively proving non-membership
 // - error: an error if any occurred during the execution
 func (provider *Provider) GetStorageProof(ctx context.Context, storageProofInput StorageProofInput) (*StorageProofResult, error) {
+	err := checkForPending(storageProofInput.BlockID)
+	if err != nil {
+		return nil, err
+	}
+
 	var raw StorageProofResult
 	if err := doAsObject(ctx, provider.c, "starknet_getStorageProof", &raw, storageProofInput); err != nil {
 		return nil, tryUnwrapToRPCErr(err, ErrBlockNotFound, ErrStorageProofNotSupported)

--- a/rpc/contract_test.go
+++ b/rpc/contract_test.go
@@ -494,7 +494,7 @@ func TestEstimateFee(t *testing.T) {
 		expectedError *RPCError
 	}
 
-	bradcastInvokeV3 := *internalUtils.TestUnmarshalJSONFileToType[BroadcastInvokev3Txn](t, "./tests/transactions/sepoliaInvokeV3_0x6035477af07a1b0a0186bec85287a6f629791b2f34b6e90eec9815c7a964f64.json", "")
+	bradcastInvokeV3 := *internalUtils.TestUnmarshalJSONFileToType[BroadcastInvokeTxnV3](t, "./tests/transactions/sepoliaInvokeV3_0x6035477af07a1b0a0186bec85287a6f629791b2f34b6e90eec9815c7a964f64.json", "")
 
 	testSet, ok := map[string][]testSetType{
 		"mock": {

--- a/rpc/contract_test.go
+++ b/rpc/contract_test.go
@@ -833,15 +833,20 @@ func assertStorageProofJSONEquality(t *testing.T, expectedResult, result []byte)
 	// compare 'contracts_storage_proofs'
 	expectedContractsStorageProofs, ok := expectedResultMap["contracts_storage_proofs"].([]any)
 	require.True(t, ok)
+	expectedGeneralSlice := make([]any, 0)
 	resultContractsStorageProofs, ok := resultMap["contracts_storage_proofs"].([]any)
 	require.True(t, ok)
+	resultGeneralSlice := make([]any, 0)
 	for i, expectedContractStorageProof := range expectedContractsStorageProofs {
 		expectedContractStorageProofArray, ok := expectedContractStorageProof.([]any)
 		require.True(t, ok)
+		expectedGeneralSlice = append(expectedGeneralSlice, expectedContractStorageProofArray...)
+
 		resultContractStorageProofArray, ok := resultContractsStorageProofs[i].([]any)
 		require.True(t, ok)
-		assert.ElementsMatch(t, expectedContractStorageProofArray, resultContractStorageProofArray)
+		resultGeneralSlice = append(resultGeneralSlice, resultContractStorageProofArray...)
 	}
+	assert.ElementsMatch(t, expectedGeneralSlice, resultGeneralSlice)
 
 	// compare 'global_roots'
 	assert.Equal(t, expectedResultMap["global_roots"], resultMap["global_roots"])

--- a/rpc/contract_test.go
+++ b/rpc/contract_test.go
@@ -670,14 +670,14 @@ func TestGetStorageProof(t *testing.T) {
 			{
 				Description: "normal call, only required field block_id with 'latest' tag",
 				StorageProofInput: StorageProofInput{
-					BlockID: BlockIDWithoutPending{Tag: "latest"},
+					BlockID: BlockID{Tag: "latest"},
 				},
 				ExpectedError: nil,
 			},
 			{
 				Description: "block_id + class_hashes parameter",
 				StorageProofInput: StorageProofInput{
-					BlockID: BlockIDWithoutPending{Tag: "latest"},
+					BlockID: BlockID{Tag: "latest"},
 					ClassHashes: []*felt.Felt{
 						internalUtils.TestHexToFelt(t, "0x076791ef97c042f81fbf352ad95f39a22554ee8d7927b2ce3c681f3418b5206a"),
 					},
@@ -687,7 +687,7 @@ func TestGetStorageProof(t *testing.T) {
 			{
 				Description: "block_id + contract_addresses parameter",
 				StorageProofInput: StorageProofInput{
-					BlockID: BlockIDWithoutPending{Tag: "latest"},
+					BlockID: BlockID{Tag: "latest"},
 					ContractAddresses: []*felt.Felt{
 						internalUtils.TestHexToFelt(t, "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7"),
 					},
@@ -697,7 +697,7 @@ func TestGetStorageProof(t *testing.T) {
 			{
 				Description: "block_id + contracts_storage_keys parameter",
 				StorageProofInput: StorageProofInput{
-					BlockID: BlockIDWithoutPending{Tag: "latest"},
+					BlockID: BlockID{Tag: "latest"},
 					ContractsStorageKeys: []ContractStorageKeys{
 						{
 							ContractAddress: internalUtils.TestHexToFelt(t, "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7"),
@@ -712,7 +712,7 @@ func TestGetStorageProof(t *testing.T) {
 			{
 				Description: "block_id + class_hashes + contract_addresses + contracts_storage_keys parameter",
 				StorageProofInput: StorageProofInput{
-					BlockID: BlockIDWithoutPending{Tag: "latest"},
+					BlockID: BlockID{Tag: "latest"},
 					ClassHashes: []*felt.Felt{
 						internalUtils.TestHexToFelt(t, "0x076791ef97c042f81fbf352ad95f39a22554ee8d7927b2ce3c681f3418b5206a"),
 						internalUtils.TestHexToFelt(t, "0x009524a94b41c4440a16fd96d7c1ef6ad6f44c1c013e96662734502cd4ee9b1f"),
@@ -743,16 +743,16 @@ func TestGetStorageProof(t *testing.T) {
 			{
 				Description: "error: using pending tag in block_id",
 				StorageProofInput: StorageProofInput{
-					BlockID: BlockIDWithoutPending{Tag: "pending"},
+					BlockID: BlockID{Tag: "pending"},
 				},
 				ExpectedError: ErrInvalidBlockID,
 			},
 			{
 				Description: "error: invalid block number",
 				StorageProofInput: StorageProofInput{
-					BlockID: func() BlockIDWithoutPending {
+					BlockID: func() BlockID {
 						num := uint64(999999999)
-						return BlockIDWithoutPending{Number: &num}
+						return BlockID{Number: &num}
 					}(),
 				},
 				ExpectedError: ErrBlockNotFound,
@@ -760,9 +760,9 @@ func TestGetStorageProof(t *testing.T) {
 			{
 				Description: "error: storage proof not supported",
 				StorageProofInput: StorageProofInput{
-					BlockID: func() BlockIDWithoutPending {
+					BlockID: func() BlockID {
 						num := uint64(123456)
-						return BlockIDWithoutPending{Number: &num}
+						return BlockID{Number: &num}
 					}(),
 				},
 				ExpectedError: ErrStorageProofNotSupported,

--- a/rpc/mock_test.go
+++ b/rpc/mock_test.go
@@ -836,7 +836,7 @@ func mock_starknet_addInvokeTransaction(result interface{}, args ...interface{})
 		return errors.Wrap(errWrongArgs, fmt.Sprint("wrong number of args ", len(args)))
 	}
 	switch args[0].(type) {
-	case BroadcastInvokeTxnV3:
+	case *BroadcastInvokeTxnV3, BroadcastInvokeTxnV3:
 		deadbeefFelt, err := internalUtils.HexToFelt("0x49728601e0bb2f48ce506b0cbd9c0e2a9e50d95858aa41463f46386dca489fd")
 		if err != nil {
 			return err
@@ -866,7 +866,7 @@ func mock_starknet_addDeployAccountTransaction(result interface{}, args ...inter
 		return errors.Wrap(errWrongArgs, fmt.Sprint("wrong number of args ", len(args)))
 	}
 	switch args[0].(type) {
-	case BroadcastDeployAccountTxnV3:
+	case *BroadcastDeployAccountTxnV3, BroadcastDeployAccountTxnV3:
 
 		deadbeefFelt, err := internalUtils.HexToFelt("0x32b272b6d0d584305a460197aa849b5c7a9a85903b66e9d3e1afa2427ef093e")
 		if err != nil {

--- a/rpc/mock_test.go
+++ b/rpc/mock_test.go
@@ -641,7 +641,7 @@ func mock_starknet_addDeclareTransaction(result interface{}, args ...interface{}
 	}
 
 	switch args[0].(type) {
-	case BroadcastDeclareTxnV3:
+	case *BroadcastDeclareTxnV3, BroadcastDeclareTxnV3:
 		deadbeefFelt, err := internalUtils.HexToFelt("0x41d1f5206ef58a443e7d3d1ca073171ec25fa75313394318fc83a074a6631c3")
 		if err != nil {
 			return err
@@ -659,7 +659,7 @@ func mock_starknet_addDeclareTransaction(result interface{}, args ...interface{}
 		}
 		return nil
 	}
-	return errors.Wrap(errWrongArgs, fmt.Sprintf("args[0] should be DeclareTxnV3, got %T\n", args[0]))
+	return errors.Wrap(errWrongArgs, fmt.Sprintf("args[0] should be BroadcastDeclareTxnV3, got %T\n", args[0]))
 }
 
 // mock_starknet_estimateFee simulates the estimation of a fee in the StarkNet network.

--- a/rpc/mock_test.go
+++ b/rpc/mock_test.go
@@ -641,7 +641,7 @@ func mock_starknet_addDeclareTransaction(result interface{}, args ...interface{}
 	}
 
 	switch args[0].(type) {
-	case BroadcastDeclareTxnV2, BroadcastDeclareTxnV3:
+	case BroadcastDeclareTxnV3:
 		deadbeefFelt, err := internalUtils.HexToFelt("0x41d1f5206ef58a443e7d3d1ca073171ec25fa75313394318fc83a074a6631c3")
 		if err != nil {
 			return err
@@ -659,7 +659,7 @@ func mock_starknet_addDeclareTransaction(result interface{}, args ...interface{}
 		}
 		return nil
 	}
-	return errors.Wrap(errWrongArgs, fmt.Sprintf("args[0] should be DeclareTxnV2 or DeclareTxnV3, got %T\n", args[0]))
+	return errors.Wrap(errWrongArgs, fmt.Sprintf("args[0] should be DeclareTxnV3, got %T\n", args[0]))
 }
 
 // mock_starknet_estimateFee simulates the estimation of a fee in the StarkNet network.
@@ -835,31 +835,8 @@ func mock_starknet_addInvokeTransaction(result interface{}, args ...interface{})
 	if len(args) != 1 {
 		return errors.Wrap(errWrongArgs, fmt.Sprint("wrong number of args ", len(args)))
 	}
-	switch invokeTx := args[0].(type) {
-	case BroadcastInvokev1Txn:
-		if invokeTx.SenderAddress != nil {
-			if invokeTx.SenderAddress.Equal(new(felt.Felt).SetUint64(123)) {
-				unexpErr := *ErrUnexpectedError
-				unexpErr.Data = StringErrData("Something crazy happened")
-				return &unexpErr
-			}
-		}
-		deadbeefFelt, err := internalUtils.HexToFelt("0xdeadbeef")
-		if err != nil {
-			return err
-		}
-		output := AddInvokeTransactionResponse{
-			TransactionHash: deadbeefFelt,
-		}
-		outputContent, err := json.Marshal(output)
-		if err != nil {
-			return err
-		}
-		if err := json.Unmarshal(outputContent, r); err != nil {
-			return err
-		}
-		return nil
-	case BroadcastInvokev3Txn:
+	switch args[0].(type) {
+	case BroadcastInvokeTxnV3:
 		deadbeefFelt, err := internalUtils.HexToFelt("0x49728601e0bb2f48ce506b0cbd9c0e2a9e50d95858aa41463f46386dca489fd")
 		if err != nil {
 			return err
@@ -876,9 +853,10 @@ func mock_starknet_addInvokeTransaction(result interface{}, args ...interface{})
 		}
 		return nil
 	default:
-		return errors.Wrap(errWrongArgs, fmt.Sprintf("args[0] should be InvokeTxnV1 or InvokeTxnV3, got %T\n", args[0]))
+		return errors.Wrap(errWrongArgs, fmt.Sprintf("args[0] should be InvokeTxnV3, got %T\n", args[0]))
 	}
 }
+
 func mock_starknet_addDeployAccountTransaction(result interface{}, args ...interface{}) error {
 	r, ok := result.(*json.RawMessage)
 	if !ok {
@@ -888,7 +866,7 @@ func mock_starknet_addDeployAccountTransaction(result interface{}, args ...inter
 		return errors.Wrap(errWrongArgs, fmt.Sprint("wrong number of args ", len(args)))
 	}
 	switch args[0].(type) {
-	case BroadcastDeployAccountTxn, BroadcastDeployAccountTxnV3:
+	case BroadcastDeployAccountTxnV3:
 
 		deadbeefFelt, err := internalUtils.HexToFelt("0x32b272b6d0d584305a460197aa849b5c7a9a85903b66e9d3e1afa2427ef093e")
 		if err != nil {
@@ -907,7 +885,7 @@ func mock_starknet_addDeployAccountTransaction(result interface{}, args ...inter
 		}
 		return nil
 	default:
-		return errors.Wrap(errWrongArgs, fmt.Sprintf("args[0] should be DeployAccountTxn or DeployAccountTxnV3, got %T\n", args[0]))
+		return errors.Wrap(errWrongArgs, fmt.Sprintf("args[0] should be DeployAccountTxnV3, got %T\n", args[0]))
 	}
 
 }

--- a/rpc/provider.go
+++ b/rpc/provider.go
@@ -73,9 +73,9 @@ func NewWebsocketProvider(url string, options ...client.ClientOption) (*WsProvid
 
 //go:generate mockgen -destination=../mocks/mock_rpc_provider.go -package=mocks -source=provider.go api
 type RpcProvider interface {
-	AddInvokeTransaction(ctx context.Context, invokeTxn BroadcastInvokeTxnType) (*AddInvokeTransactionResponse, error)
-	AddDeclareTransaction(ctx context.Context, declareTransaction BroadcastDeclareTxnType) (*AddDeclareTransactionResponse, error)
-	AddDeployAccountTransaction(ctx context.Context, deployAccountTransaction BroadcastAddDeployTxnType) (*AddDeployAccountTransactionResponse, error)
+	AddInvokeTransaction(ctx context.Context, invokeTxn *BroadcastInvokeTxnV3) (*AddInvokeTransactionResponse, error)
+	AddDeclareTransaction(ctx context.Context, declareTransaction *BroadcastDeclareTxnV3) (*AddDeclareTransactionResponse, error)
+	AddDeployAccountTransaction(ctx context.Context, deployAccountTransaction *BroadcastDeployAccountTxnV3) (*AddDeployAccountTransactionResponse, error)
 	BlockHashAndNumber(ctx context.Context) (*BlockHashAndNumberOutput, error)
 	BlockNumber(ctx context.Context) (uint64, error)
 	BlockTransactionCount(ctx context.Context, blockID BlockID) (uint64, error)

--- a/rpc/provider.go
+++ b/rpc/provider.go
@@ -109,7 +109,7 @@ type RpcProvider interface {
 
 type WebsocketProvider interface {
 	SubscribeEvents(ctx context.Context, events chan<- *EmittedEvent, options *EventSubscriptionInput) (*client.ClientSubscription, error)
-	SubscribeNewHeads(ctx context.Context, headers chan<- *BlockHeader, subBlockID *SubscriptionBlockID) (*client.ClientSubscription, error)
+	SubscribeNewHeads(ctx context.Context, headers chan<- *BlockHeader, blockID BlockID) (*client.ClientSubscription, error)
 	SubscribePendingTransactions(ctx context.Context, pendingTxns chan<- *SubPendingTxns, options *SubPendingTxnsInput) (*client.ClientSubscription, error)
 	SubscribeTransactionStatus(ctx context.Context, newStatus chan<- *NewTxnStatusResp, transactionHash *felt.Felt) (*client.ClientSubscription, error)
 }

--- a/rpc/types.go
+++ b/rpc/types.go
@@ -198,6 +198,7 @@ type TxDetails struct {
 	Version TransactionVersion
 }
 
+// a sequence of fee estimation where the i'th estimate corresponds to the i'th transaction
 type FeeEstimation struct {
 	// The Ethereum gas consumption of the transaction, charged for L1->L2 messages and, depending on the block's DA_MODE, state diffs
 	L1GasConsumed *felt.Felt `json:"l1_gas_consumed"`

--- a/rpc/types_broadcast_transaction.go
+++ b/rpc/types_broadcast_transaction.go
@@ -7,101 +7,17 @@ import (
 
 type BroadcastTxn interface{}
 
-// TODO: Remove the deprecated broadcast types, only keep the v3 types
+// Note: this allow all types to pass, but are to help users of starknet.go
+// understand which types are allowed where.
 var (
-	_ BroadcastTxn = BroadcastInvokev0Txn{}
-	_ BroadcastTxn = BroadcastInvokev1Txn{}
-	_ BroadcastTxn = BroadcastInvokev3Txn{}
-	_ BroadcastTxn = BroadcastDeclareTxnV1{}
-	_ BroadcastTxn = BroadcastDeclareTxnV2{}
+	_ BroadcastTxn = BroadcastInvokeTxnV3{}
 	_ BroadcastTxn = BroadcastDeclareTxnV3{}
-	_ BroadcastTxn = BroadcastDeployAccountTxn{}
+	_ BroadcastTxn = BroadcastDeployAccountTxnV3{}
 )
 
-type BroadcastInvokeTxnType interface {
-	GetCalldata() []*felt.Felt
-}
-
-var (
-	_ BroadcastInvokeTxnType = BroadcastInvokev0Txn{}
-	_ BroadcastInvokeTxnType = BroadcastInvokev1Txn{}
-	_ BroadcastInvokeTxnType = BroadcastInvokev3Txn{}
-)
-
-type BroadcastDeclareTxnType interface {
-	GetContractClass() interface{}
-}
-
-var (
-	_ BroadcastDeclareTxnType = BroadcastDeclareTxnV1{}
-	_ BroadcastDeclareTxnType = BroadcastDeclareTxnV2{}
-	_ BroadcastDeclareTxnType = BroadcastDeclareTxnV3{}
-)
-
-type BroadcastAddDeployTxnType interface {
-	GetConstructorCalldata() []*felt.Felt
-}
-
-var (
-	_ BroadcastAddDeployTxnType = BroadcastDeployAccountTxn{}
-	_ BroadcastAddDeployTxnType = BroadcastDeployAccountTxnV3{}
-)
-
-type BroadcastInvokev0Txn struct {
-	InvokeTxnV0
-}
-
-func (tx BroadcastInvokev0Txn) GetCalldata() []*felt.Felt {
-	return tx.Calldata
-}
-
-type BroadcastInvokev1Txn struct {
-	InvokeTxnV1
-}
-
-func (tx BroadcastInvokev1Txn) GetCalldata() []*felt.Felt {
-	return tx.Calldata
-}
-
-type BroadcastInvokev3Txn struct {
+type BroadcastInvokeTxnV3 struct {
 	InvokeTxnV3
 }
-
-func (tx BroadcastInvokev3Txn) GetCalldata() []*felt.Felt {
-	return tx.Calldata
-}
-
-type BroadcastDeclareTxnV1 struct {
-	Type TransactionType `json:"type"`
-	// SenderAddress the address of the account contract sending the declaration transaction
-	SenderAddress *felt.Felt                        `json:"sender_address"`
-	MaxFee        *felt.Felt                        `json:"max_fee"`
-	Version       TransactionVersion                `json:"version"`
-	Signature     []*felt.Felt                      `json:"signature"`
-	Nonce         *felt.Felt                        `json:"nonce"`
-	ContractClass contracts.DeprecatedContractClass `json:"contract_class"`
-}
-
-func (tx BroadcastDeclareTxnV1) GetContractClass() interface{} {
-	return tx.ContractClass
-}
-
-type BroadcastDeclareTxnV2 struct {
-	Type TransactionType `json:"type"`
-	// SenderAddress the address of the account contract sending the declaration transaction
-	SenderAddress     *felt.Felt              `json:"sender_address"`
-	CompiledClassHash *felt.Felt              `json:"compiled_class_hash"`
-	MaxFee            *felt.Felt              `json:"max_fee"`
-	Version           TransactionVersion      `json:"version"`
-	Signature         []*felt.Felt            `json:"signature"`
-	Nonce             *felt.Felt              `json:"nonce"`
-	ContractClass     contracts.ContractClass `json:"contract_class"`
-}
-
-func (tx BroadcastDeclareTxnV2) GetContractClass() interface{} {
-	return tx.ContractClass
-}
-
 type BroadcastDeclareTxnV3 struct {
 	Type              TransactionType          `json:"type"`
 	SenderAddress     *felt.Felt               `json:"sender_address"`
@@ -122,22 +38,6 @@ type BroadcastDeclareTxnV3 struct {
 	FeeMode DataAvailabilityMode `json:"fee_data_availability_mode"`
 }
 
-func (tx BroadcastDeclareTxnV3) GetContractClass() interface{} {
-	return *tx.ContractClass
-}
-
-type BroadcastDeployAccountTxn struct {
-	DeployAccountTxn
-}
-
-func (tx BroadcastDeployAccountTxn) GetConstructorCalldata() []*felt.Felt {
-	return tx.ConstructorCalldata
-}
-
 type BroadcastDeployAccountTxnV3 struct {
 	DeployAccountTxnV3
-}
-
-func (tx BroadcastDeployAccountTxnV3) GetConstructorCalldata() []*felt.Felt {
-	return tx.ConstructorCalldata
 }

--- a/rpc/types_contract.go
+++ b/rpc/types_contract.go
@@ -39,7 +39,7 @@ var _ ClassOutput = &contracts.ContractClass{}
 
 type StorageProofInput struct {
 	// Required. The hash of the requested block, or number (height) of the requested block, or a block tag
-	BlockID BlockIDWithoutPending `json:"block_id"`
+	BlockID BlockID `json:"block_id"`
 	// Optional. A list of the class hashes for which we want to prove membership in the classes trie
 	ClassHashes []*felt.Felt `json:"class_hashes,omitempty"`
 	// Optional. A list of contracts for which we want to prove membership in the global state trie

--- a/rpc/types_event.go
+++ b/rpc/types_event.go
@@ -51,7 +51,7 @@ type EventsInput struct {
 }
 
 type EventSubscriptionInput struct {
-	FromAddress *felt.Felt          `json:"from_address,omitempty"` // Optional. Filter events by from_address which emitted the event
-	Keys        [][]*felt.Felt      `json:"keys,omitempty"`         // Optional. Per key (by position), designate the possible values to be matched for events to be returned. Empty array designates 'any' value
-	BlockID     SubscriptionBlockID `json:"block_id,omitempty"`     // Optional. The block to get notifications from, default is latest, limited to 1024 blocks back
+	FromAddress *felt.Felt     `json:"from_address,omitempty"` // Optional. Filter events by from_address which emitted the event
+	Keys        [][]*felt.Felt `json:"keys,omitempty"`         // Optional. Per key (by position), designate the possible values to be matched for events to be returned. Empty array designates 'any' value
+	BlockID     BlockID        `json:"block_id,omitempty"`     // Optional. The block to get notifications from, default is latest, limited to 1024 blocks back
 }

--- a/rpc/write.go
+++ b/rpc/write.go
@@ -12,7 +12,7 @@ import (
 // Returns:
 // - *AddInvokeTransactionResponse: the response of adding the invoke transaction
 // - error: an error if any
-func (provider *Provider) AddInvokeTransaction(ctx context.Context, invokeTxn BroadcastInvokeTxnType) (*AddInvokeTransactionResponse, error) {
+func (provider *Provider) AddInvokeTransaction(ctx context.Context, invokeTxn *BroadcastInvokeTxnV3) (*AddInvokeTransactionResponse, error) {
 	var output AddInvokeTransactionResponse
 	if err := do(ctx, provider.c, "starknet_addInvokeTransaction", &output, invokeTxn); err != nil {
 		return nil, tryUnwrapToRPCErr(
@@ -38,7 +38,7 @@ func (provider *Provider) AddInvokeTransaction(ctx context.Context, invokeTxn Br
 // Returns:
 // - *AddDeclareTransactionResponse: The response of submitting the declare transaction
 // - error: an error if any
-func (provider *Provider) AddDeclareTransaction(ctx context.Context, declareTransaction BroadcastDeclareTxnType) (*AddDeclareTransactionResponse, error) {
+func (provider *Provider) AddDeclareTransaction(ctx context.Context, declareTransaction *BroadcastDeclareTxnV3) (*AddDeclareTransactionResponse, error) {
 	var result AddDeclareTransactionResponse
 	if err := do(ctx, provider.c, "starknet_addDeclareTransaction", &result, declareTransaction); err != nil {
 		return nil, tryUnwrapToRPCErr(
@@ -67,7 +67,7 @@ func (provider *Provider) AddDeclareTransaction(ctx context.Context, declareTran
 // - deployAccountTransaction: The deploy account transaction to be added
 // Returns:
 // - *AddDeployAccountTransactionResponse: the response of adding the deploy account transaction or an error
-func (provider *Provider) AddDeployAccountTransaction(ctx context.Context, deployAccountTransaction BroadcastAddDeployTxnType) (*AddDeployAccountTransactionResponse, error) {
+func (provider *Provider) AddDeployAccountTransaction(ctx context.Context, deployAccountTransaction *BroadcastDeployAccountTxnV3) (*AddDeployAccountTransactionResponse, error) {
 	var result AddDeployAccountTransactionResponse
 	if err := do(ctx, provider.c, "starknet_addDeployAccountTransaction", &result, deployAccountTransaction); err != nil {
 		return nil, tryUnwrapToRPCErr(

--- a/rpc/write_test.go
+++ b/rpc/write_test.go
@@ -14,7 +14,7 @@ func TestDeclareTransaction(t *testing.T) {
 	testConfig := beforeEach(t, false)
 
 	type testSetType struct {
-		DeclareTx     BroadcastDeclareTxnType
+		DeclareTx     BroadcastDeclareTxnV3
 		ExpectedResp  AddDeclareTransactionResponse
 		ExpectedError *RPCError
 	}
@@ -23,29 +23,17 @@ func TestDeclareTransaction(t *testing.T) {
 		"mainnet": {},
 		"mock": {
 			{
-				DeclareTx: BroadcastDeclareTxnV2{},
-				ExpectedResp: AddDeclareTransactionResponse{
-					TransactionHash: internalUtils.TestHexToFelt(t, "0x41d1f5206ef58a443e7d3d1ca073171ec25fa75313394318fc83a074a6631c3")},
-				ExpectedError: nil,
-			},
-			{
 				DeclareTx: BroadcastDeclareTxnV3{},
 				ExpectedResp: AddDeclareTransactionResponse{
 					TransactionHash: internalUtils.TestHexToFelt(t, "0x41d1f5206ef58a443e7d3d1ca073171ec25fa75313394318fc83a074a6631c3")},
 				ExpectedError: nil,
 			},
 		},
-		"testnet": {{
-			DeclareTx: BroadcastDeclareTxnV1{},
-			ExpectedResp: AddDeclareTransactionResponse{
-				TransactionHash: internalUtils.TestHexToFelt(t, "0x55b094dc5c84c2042e067824f82da90988674314d37e45cb0032aca33d6e0b9")},
-			ExpectedError: &RPCError{Code: InvalidParams, Message: "Invalid Params"},
-		},
-		},
+		"testnet": {},
 	}[testEnv]
 
 	for _, test := range testSet {
-		resp, err := testConfig.provider.AddDeclareTransaction(context.Background(), test.DeclareTx)
+		resp, err := testConfig.provider.AddDeclareTransaction(context.Background(), &test.DeclareTx)
 		if err != nil {
 			rpcErr, ok := err.(*RPCError)
 			require.True(t, ok)
@@ -63,7 +51,7 @@ func TestAddInvokeTransaction(t *testing.T) {
 	testConfig := beforeEach(t, false)
 
 	type testSetType struct {
-		InvokeTx      BroadcastInvokeTxnType
+		InvokeTx      BroadcastInvokeTxnV3
 		ExpectedResp  AddInvokeTransactionResponse
 		ExpectedError *RPCError
 	}
@@ -72,21 +60,7 @@ func TestAddInvokeTransaction(t *testing.T) {
 		"mainnet": {},
 		"mock": {
 			{
-				InvokeTx:     BroadcastInvokev1Txn{InvokeTxnV1{SenderAddress: new(felt.Felt).SetUint64(123)}},
-				ExpectedResp: AddInvokeTransactionResponse{&felt.Zero},
-				ExpectedError: &RPCError{
-					Code:    ErrUnexpectedError.Code,
-					Message: ErrUnexpectedError.Message,
-					Data:    StringErrData("Something crazy happened"),
-				},
-			},
-			{
-				InvokeTx:      BroadcastInvokev1Txn{InvokeTxnV1{}},
-				ExpectedResp:  AddInvokeTransactionResponse{internalUtils.TestHexToFelt(t, "0xdeadbeef")},
-				ExpectedError: nil,
-			},
-			{
-				InvokeTx: BroadcastInvokev3Txn{
+				InvokeTx: BroadcastInvokeTxnV3{
 					InvokeTxnV3{
 						Type:    TransactionType_Invoke,
 						Version: TransactionV3,
@@ -137,7 +111,7 @@ func TestAddInvokeTransaction(t *testing.T) {
 	}[testEnv]
 
 	for _, test := range testSet {
-		resp, err := testConfig.provider.AddInvokeTransaction(context.Background(), test.InvokeTx)
+		resp, err := testConfig.provider.AddInvokeTransaction(context.Background(), &test.InvokeTx)
 		if test.ExpectedError != nil {
 			require.Equal(t, test.ExpectedError, err)
 		} else {
@@ -152,7 +126,7 @@ func TestAddDeployAccountTansaction(t *testing.T) {
 	testConfig := beforeEach(t, false)
 
 	type testSetType struct {
-		DeployTx      BroadcastAddDeployTxnType
+		DeployTx      BroadcastDeployAccountTxnV3
 		ExpectedResp  AddDeployAccountTransactionResponse
 		ExpectedError error
 	}
@@ -160,14 +134,6 @@ func TestAddDeployAccountTansaction(t *testing.T) {
 		"devnet":  {},
 		"mainnet": {},
 		"mock": {
-			{
-				DeployTx: BroadcastDeployAccountTxn{DeployAccountTxn{}},
-				ExpectedResp: AddDeployAccountTransactionResponse{
-					TransactionHash: internalUtils.TestHexToFelt(t, "0x32b272b6d0d584305a460197aa849b5c7a9a85903b66e9d3e1afa2427ef093e"),
-					ContractAddress: internalUtils.TestHexToFelt(t, "0x0"),
-				},
-				ExpectedError: nil,
-			},
 			{
 				DeployTx: BroadcastDeployAccountTxnV3{
 					DeployAccountTxnV3{
@@ -208,7 +174,7 @@ func TestAddDeployAccountTansaction(t *testing.T) {
 
 	for _, test := range testSet {
 
-		resp, err := testConfig.provider.AddDeployAccountTransaction(context.Background(), test.DeployTx)
+		resp, err := testConfig.provider.AddDeployAccountTransaction(context.Background(), &test.DeployTx)
 		if err != nil {
 			require.Equal(t, err.Error(), test.ExpectedError)
 		} else {

--- a/rpc/write_test.go
+++ b/rpc/write_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/NethermindEth/juno/core/felt"
 	internalUtils "github.com/NethermindEth/starknet.go/internal/utils"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -34,14 +35,16 @@ func TestDeclareTransaction(t *testing.T) {
 
 	for _, test := range testSet {
 		resp, err := testConfig.provider.AddDeclareTransaction(context.Background(), &test.DeclareTx)
-		if err != nil {
+		if test.ExpectedError != nil {
+			require.Error(t, err)
 			rpcErr, ok := err.(*RPCError)
 			require.True(t, ok)
-			require.Equal(t, test.ExpectedError.Code, rpcErr.Code)
-			require.Equal(t, test.ExpectedError.Message, rpcErr.Message)
-		} else {
-			require.Equal(t, (*resp.TransactionHash).String(), (*test.ExpectedResp.TransactionHash).String())
+			assert.Equal(t, test.ExpectedError.Code, rpcErr.Code)
+			assert.Equal(t, test.ExpectedError.Message, rpcErr.Message)
+			continue
 		}
+		require.NoError(t, err)
+		assert.Equal(t, (*resp.TransactionHash).String(), (*test.ExpectedResp.TransactionHash).String())
 
 	}
 }

--- a/utils/felt.go
+++ b/utils/felt.go
@@ -151,3 +151,17 @@ func BigIntArrToFeltArr(bigArr []*big.Int) []*felt.Felt {
 func HexToU256Felt(hexStr string) ([]*felt.Felt, error) {
 	return internalUtils.HexToU256Felt(hexStr)
 }
+
+// U256FeltToHex converts a Cairo u256 representation (two felt.Felt values) back to a hexadecimal string.
+// The Cairo u256 is represented as two felt.Felt values:
+// - The first felt.Felt contains the 128 least significant bits (low part)
+// - The second felt.Felt contains the 128 most significant bits (high part)
+//
+// Parameters:
+// - u256: a slice containing two felt.Felt values [low, high]
+// Returns:
+// - string: the hexadecimal representation of the combined value
+// - error: if conversion fails
+func U256FeltToHex(u256 []*felt.Felt) (string, error) {
+	return internalUtils.U256FeltToHex(u256)
+}

--- a/utils/felt.go
+++ b/utils/felt.go
@@ -137,3 +137,17 @@ func ByteArrFeltToString(arr []*felt.Felt) (string, error) {
 func BigIntArrToFeltArr(bigArr []*big.Int) []*felt.Felt {
 	return internalUtils.BigIntArrToFeltArr(bigArr)
 }
+
+// HexToU256Felt converts a hexadecimal string to a Cairo u256 representation.
+// The Cairo u256 is represented as two felt.Felt values:
+// - The first felt.Felt contains the 128 least significant bits (low part)
+// - The second felt.Felt contains the 128 most significant bits (high part)
+//
+// Parameters:
+// - hexStr: the hexadecimal string to convert to a Cairo u256
+// Returns:
+// - []*felt.Felt: a slice containing two felt.Felt values [low, high]
+// - error: if conversion fails
+func HexToU256Felt(hexStr string) ([]*felt.Felt, error) {
+	return internalUtils.HexToU256Felt(hexStr)
+}

--- a/utils/transactions.go
+++ b/utils/transactions.go
@@ -37,8 +37,8 @@ func BuildInvokeTxn(
 	nonce *felt.Felt,
 	calldata []*felt.Felt,
 	resourceBounds rpc.ResourceBoundsMapping,
-) rpc.BroadcastInvokev3Txn {
-	invokeTxn := rpc.BroadcastInvokev3Txn{
+) *rpc.BroadcastInvokeTxnV3 {
+	invokeTxn := rpc.BroadcastInvokeTxnV3{
 		InvokeTxnV3: rpc.InvokeTxnV3{
 			Type:                  rpc.TransactionType_Invoke,
 			SenderAddress:         senderAddress,
@@ -55,7 +55,7 @@ func BuildInvokeTxn(
 		},
 	}
 
-	return invokeTxn
+	return &invokeTxn
 }
 
 // BuildDeclareTxn creates a new declare transaction (v3) for the StarkNet network.
@@ -77,10 +77,10 @@ func BuildDeclareTxn(
 	contractClass *contracts.ContractClass,
 	nonce *felt.Felt,
 	resourceBounds rpc.ResourceBoundsMapping,
-) (rpc.BroadcastDeclareTxnV3, error) {
+) (*rpc.BroadcastDeclareTxnV3, error) {
 	compiledClassHash, err := hash.CompiledClassHash(casmClass)
 	if err != nil {
-		return rpc.BroadcastDeclareTxnV3{}, err
+		return nil, err
 	}
 
 	declareTxn := rpc.BroadcastDeclareTxnV3{
@@ -99,7 +99,7 @@ func BuildDeclareTxn(
 		FeeMode:               rpc.DAModeL1,
 	}
 
-	return declareTxn, nil
+	return &declareTxn, nil
 }
 
 // BuildDeployAccountTxn creates a new deploy account transaction (v3) for the StarkNet network.
@@ -121,7 +121,7 @@ func BuildDeployAccountTxn(
 	constructorCalldata []*felt.Felt,
 	classHash *felt.Felt,
 	resourceBounds rpc.ResourceBoundsMapping,
-) rpc.BroadcastDeployAccountTxnV3 {
+) *rpc.BroadcastDeployAccountTxnV3 {
 	deployAccountTxn := rpc.BroadcastDeployAccountTxnV3{
 		DeployAccountTxnV3: rpc.DeployAccountTxnV3{
 			Type:                rpc.TransactionType_DeployAccount,
@@ -139,7 +139,7 @@ func BuildDeployAccountTxn(
 		},
 	}
 
-	return deployAccountTxn
+	return &deployAccountTxn
 }
 
 // InvokeFuncCallsToFunctionCalls converts a slice of InvokeFunctionCall to a slice of FunctionCall.


### PR DESCRIPTION
https://github.com/NethermindEth/starknet.go/issues/623

This PR aims to:
- Remove deprecated Broadcast Txn versions, keeping only V3 txns.
- Move all `TransactionHash...` functions from the `account` pkg to the `hash` pkg
- Make `AddTransactions...`  and `acc.SendTransaction()` methods only accept V3 txns.
- Remove BlockIDWithoutPending and SubscriptionBlockID types, use `BlockID` instead with a helper func.
- New `fillEmptyFeeEstimation` internal util to bypass an estimateFee bug.
- New `HexToU256Felt` and `U256FeltToHex` utils to deal with U256 cairo var type.
- Update examples to use the `HexToU256Felt` utils
- Make `BuildTxns...` utils return a pointer instead of a struct
- Fix and improve some tests and descriptions.
