### PR TITLE
Update CallContext to CallContextWithSliceArgs in `requestUnsubscribe()`

### DIFF
--- a/client/subscription.go
+++ b/client/subscription.go
@@ -429,6 +429,6 @@ func (sub *ClientSubscription) requestUnsubscribe() error {
 	ctx, cancel := context.WithTimeout(context.Background(), unsubscribeTimeout)
 	defer cancel()
 
-	err := sub.client.CallContext(ctx, &result, sub.namespace+unsubscribeMethodSuffix, sub.subid)
+	err := sub.client.CallContextWithSliceArgs(ctx, &result, sub.namespace+unsubscribeMethodSuffix, sub.subid)
 	return err
 }


### PR DESCRIPTION
With our previous changes to the CallContext method, it now sends the type as is instead of wrapping it in a slice. Therefore, the `requestUnsubscribe()` that previously passed the `subscription_id` inside an array in the JSON-RPC request now is passing it as a string, since the param is in fact a string (e.g.: `{"jsonrpc":"2.0","method":"starknet_unsubscribe","params":"360015397650685332","id":2}}`

This causes the Juno node to log this:
`Request sanity check failed     {"err": "params should be an array or an object"}`

This PR replaces `CallContext` with `CallContextWithSliceArgs`, which passes parameters inside a slice, solving our issue.