### PR TITLE
Hotfix/not estimating querybitversion txns

### DIFF
--- a/account/account.go
+++ b/account/account.go
@@ -124,7 +124,12 @@ func (account *Account) Nonce(ctx context.Context) (*felt.Felt, error) {
 // Returns:
 //   - *rpc.AddInvokeTransactionResponse: the response of the submitted transaction.
 //   - error: An error if the transaction building fails.
-func (account *Account) BuildAndSendInvokeTxn(ctx context.Context, functionCalls []rpc.InvokeFunctionCall, multiplier float64, withQueryBitVersion bool) (*rpc.AddInvokeTransactionResponse, error) {
+func (account *Account) BuildAndSendInvokeTxn(
+	ctx context.Context,
+	functionCalls []rpc.InvokeFunctionCall,
+	multiplier float64,
+	withQueryBitVersion bool,
+) (*rpc.AddInvokeTransactionResponse, error) {
 	nonce, err := account.Nonce(ctx)
 	if err != nil {
 		return nil, err

--- a/account/account.go
+++ b/account/account.go
@@ -137,13 +137,14 @@ func (account *Account) BuildAndSendInvokeTxn(ctx context.Context, functionCalls
 
 	// building and signing the txn, as it needs a signature to estimate the fee
 	broadcastInvokeTxnV3 := utils.BuildInvokeTxn(account.Address, nonce, callData, makeResourceBoundsMapWithZeroValues())
-	err = account.SignInvokeTransaction(ctx, &broadcastInvokeTxnV3.InvokeTxnV3)
-	if err != nil {
-		return nil, err
-	}
 
 	if len(hasQueryBitVersion) > 0 && hasQueryBitVersion[0] {
 		broadcastInvokeTxnV3.InvokeTxnV3.Version = rpc.TransactionV3WithQueryBit
+	}
+
+	err = account.SignInvokeTransaction(ctx, &broadcastInvokeTxnV3.InvokeTxnV3)
+	if err != nil {
+		return nil, err
 	}
 
 	// estimate txn fee
@@ -271,16 +272,16 @@ func (account *Account) BuildAndEstimateDeployAccountTxn(
 	// building and signing the txn, as it needs a signature to estimate the fee
 	broadcastDepAccTxnV3 := utils.BuildDeployAccountTxn(&felt.Zero, salt, constructorCalldata, classHash, makeResourceBoundsMapWithZeroValues())
 
+	if len(hasQueryBitVersion) > 0 && hasQueryBitVersion[0] {
+		broadcastDepAccTxnV3.DeployAccountTxnV3.Version = rpc.TransactionV3WithQueryBit
+	}
+
 	precomputedAddress := PrecomputeAccountAddress(salt, classHash, constructorCalldata)
 
 	// signing the txn, as it needs a signature to estimate the fee
 	err := account.SignDeployAccountTransaction(ctx, &broadcastDepAccTxnV3.DeployAccountTxnV3, precomputedAddress)
 	if err != nil {
 		return nil, nil, err
-	}
-
-	if len(hasQueryBitVersion) > 0 && hasQueryBitVersion[0] {
-		broadcastDepAccTxnV3.DeployAccountTxnV3.Version = rpc.TransactionV3WithQueryBit
 	}
 
 	// estimate txn fee

--- a/account/account_test.go
+++ b/account/account_test.go
@@ -1314,7 +1314,7 @@ func TestBuildAndSendInvokeTxn(t *testing.T) {
 			FunctionName:    "mint",
 			CallData:        []*felt.Felt{new(felt.Felt).SetUint64(10000), &felt.Zero},
 		},
-	}, 1.5)
+	}, 1.5, false)
 	require.NoError(t, err, "Error building and sending invoke txn")
 
 	// check the transaction hash
@@ -1355,7 +1355,7 @@ func TestBuildAndSendDeclareTxn(t *testing.T) {
 	casmClass := *internalUtils.TestUnmarshalJSONFileToType[contracts.CasmClass](t, "./tests/contracts_v2_HelloStarknet.casm.json", "")
 
 	// Build and send declare txn
-	resp, err := acc.BuildAndSendDeclareTxn(context.Background(), &casmClass, &class, 1.5)
+	resp, err := acc.BuildAndSendDeclareTxn(context.Background(), &casmClass, &class, 1.5, false)
 	if err != nil {
 		require.EqualError(t, err, "41 Transaction execution error: Class with hash 0x0224518978adb773cfd4862a894e9d333192fbd24bc83841dc7d4167c09b89c5 is already declared.")
 		t.Log("declare txn not sent: class already declared")
@@ -1415,7 +1415,9 @@ func TestBuildAndEstimateDeployAccountTxn(t *testing.T) {
 		new(felt.Felt).SetUint64(uint64(time.Now().UnixNano())), // random salt
 		classHash,
 		[]*felt.Felt{pub},
-		1.5)
+		1.5,
+		false,
+	)
 	require.NoError(t, err, "Error building and estimating deploy account txn")
 	require.NotNil(t, deployAccTxn)
 	require.NotNil(t, precomputedAddress)
@@ -1456,7 +1458,7 @@ func transferSTRKAndWaitConfirmation(t *testing.T, acc *account.Account, amount 
 			FunctionName:    "transfer",
 			CallData:        append([]*felt.Felt{recipient}, u256Amount...),
 		},
-	}, 1.5)
+	}, 1.5, false)
 	require.NoError(t, err, "Error transferring STRK tokens")
 
 	// check the transaction hash

--- a/account/account_test.go
+++ b/account/account_test.go
@@ -1543,7 +1543,11 @@ func TestBraavosAccountWarning(t *testing.T) {
 	}
 }
 
-// TODO: add description
+// TestBuildAndSendMethodsWithQueryBit is a test function that tests the BuildAndSendDeclareTxn, BuildAndSendInvokeTxn
+// and BuildAndEstimateDeployAccountTxn methods with a query bit version.
+//
+// This function tests these methods when called with the 'hasQueryBitVersion' parameter set to true, assuming that
+// the transaction indeed has the version with the query bit.
 func TestBuildAndSendMethodsWithQueryBit(t *testing.T) {
 	if testEnv != "devnet" {
 		t.Skip("Skipping test as it requires a devnet environment")
@@ -1570,7 +1574,8 @@ func TestBuildAndSendMethodsWithQueryBit(t *testing.T) {
 		// Build and send declare txn
 		_, err := acnt.BuildAndSendDeclareTxn(context.Background(), &casmClass, &class, 1.5, true)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), devnetQueryErrorMsg)
+		// assert that the transaction contains the query bit version
+		assert.Contains(t, err.Error(), devnetQueryErrorMsg)
 	})
 
 	t.Run("TestBuildAndSendInvokeTxn", func(t *testing.T) {
@@ -1588,7 +1593,8 @@ func TestBuildAndSendMethodsWithQueryBit(t *testing.T) {
 			},
 		}, 1.5, true)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), devnetQueryErrorMsg)
+		// assert that the transaction contains the query bit version
+		assert.Contains(t, err.Error(), devnetQueryErrorMsg)
 	})
 
 	t.Run("TestBuildAndEstimateDeployAccountTxn", func(t *testing.T) {

--- a/account/account_test.go
+++ b/account/account_test.go
@@ -1542,3 +1542,44 @@ func TestBraavosAccountWarning(t *testing.T) {
 		})
 	}
 }
+
+// TODO: add description
+func TestBuildAndSendMethodsWithQueryBit(t *testing.T) {
+	if testEnv != "devnet" {
+		t.Skip("Skipping test as it requires a devnet environment")
+	}
+	client, err := rpc.NewProvider(base)
+	require.NoError(t, err, "Error in rpc.NewClient")
+
+	_, acnts, err := newDevnet(t, base)
+	require.NoError(t, err, "Error setting up Devnet")
+
+	fakeUser := acnts[0]
+	acnt, err := newDevnetAccount(t, client, fakeUser)
+	require.NoError(t, err)
+
+	// Devnet returns an error when sending a txn with a query bit version
+	devnetQueryErrorMsg := "only-query transactions are not supported"
+
+	t.Run("TestBuildAndSendDeclareTxn", func(t *testing.T) {
+		// Class
+		class := *internalUtils.TestUnmarshalJSONFileToType[contracts.ContractClass](t, "./tests/contracts_v2_HelloStarknet.sierra.json", "")
+
+		// Casm Class
+		casmClass := *internalUtils.TestUnmarshalJSONFileToType[contracts.CasmClass](t, "./tests/contracts_v2_HelloStarknet.casm.json", "")
+
+		// Build and send declare txn
+		_, err := acnt.BuildAndSendDeclareTxn(context.Background(), &casmClass, &class, 1.5, true)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), devnetQueryErrorMsg)
+	})
+	// t.Run("TestBuildAndSendInvokeTxn", func(t *testing.T) {
+	// 	acnt.BuildAndSendInvokeTxn(context.Background(), []rpc.InvokeFunctionCall{
+	// 		{
+	// 			ContractAddress: internalUtils.TestHexToFelt(t, "0x0669e24364ce0ae7ec2864fb03eedbe60cfbc9d1c74438d10fa4b86552907d54"),
+	// 			FunctionName:    "mint",
+	// 			CallData:        []*felt.Felt{new(felt.Felt).SetUint64(10000), &felt.Zero},
+	// 		},
+	// 	}, 1.5)
+	// })
+}

--- a/examples/deployAccount/main.go
+++ b/examples/deployAccount/main.go
@@ -54,7 +54,7 @@ func main() {
 	// Build and estimate fees for the deploy account transaction, and precompute the address of the new account.
 	// In our case, the OZ account constructor requires the public key of the account as calldata, so we pass it as calldata.
 	// The multiplier for the fee estimation is 1.5, as we want to be sure that the transaction will be accepted.
-	deployAccountTxn, precomputedAddress, err := accnt.BuildAndEstimateDeployAccountTxn(context.Background(), pub, classHash, []*felt.Felt{pub}, 1.5)
+	deployAccountTxn, precomputedAddress, err := accnt.BuildAndEstimateDeployAccountTxn(context.Background(), pub, classHash, []*felt.Felt{pub}, 1.5, false)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/deployContractUDC/main.go
+++ b/examples/deployContractUDC/main.go
@@ -80,7 +80,7 @@ func main() {
 	}
 
 	// After the signing we finally call the AddInvokeTransaction in order to invoke the contract function
-	resp, err := accnt.BuildAndSendInvokeTxn(context.Background(), []rpc.InvokeFunctionCall{FnCall}, 1.5)
+	resp, err := accnt.BuildAndSendInvokeTxn(context.Background(), []rpc.InvokeFunctionCall{FnCall}, 1.5, false)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/invoke/simpleInvoke.go
+++ b/examples/invoke/simpleInvoke.go
@@ -28,7 +28,7 @@ func simpleInvoke(accnt *account.Account, contractAddress *felt.Felt, contractMe
 	//
 	// note: in Starknet, you can execute multiple function calls in the same transaction, even if they are from different contracts.
 	// To do this in Starknet.go, just group all the 'InvokeFunctionCall' in the same slice and pass it to BuildInvokeTxn.
-	resp, err := accnt.BuildAndSendInvokeTxn(context.Background(), []rpc.InvokeFunctionCall{FnCall}, 1.5)
+	resp, err := accnt.BuildAndSendInvokeTxn(context.Background(), []rpc.InvokeFunctionCall{FnCall}, 1.5, false)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/simpleDeclare/main.go
+++ b/examples/simpleDeclare/main.go
@@ -73,7 +73,7 @@ func main() {
 	//
 	// note: in Starknet, you can execute multiple function calls in the same transaction, even if they are from different contracts.
 	// To do this in Starknet.go, just group all the 'InvokeFunctionCall' in the same slice and pass it to BuildInvokeTxn.
-	resp, err := accnt.BuildAndSendDeclareTxn(context.Background(), casmClass, contractClass, 1.5)
+	resp, err := accnt.BuildAndSendDeclareTxn(context.Background(), casmClass, contractClass, 1.5, false)
 	if err != nil {
 		if strings.Contains(err.Error(), "is already declared") {
 			fmt.Println("")

--- a/rpc/errors.go
+++ b/rpc/errors.go
@@ -64,7 +64,7 @@ func tryUnwrapToRPCErr(baseError error, rpcErrors ...*RPCError) *RPCError {
 		}
 	}
 
-	if nodeErr.Code == 0 {
+	if nodeErr.Code <= 0 {
 		return &RPCError{Code: InternalError, Message: "The error is not a valid RPC error", Data: StringErrData(baseError.Error())}
 	}
 

--- a/utils/transactions.go
+++ b/utils/transactions.go
@@ -22,6 +22,10 @@ var (
 
 // BuildInvokeTxn creates a new invoke transaction (v3) for the StarkNet network.
 //
+// The default version of the returned transaction is rpc.TransactionV3 (0x3). If a version with
+// rpc.TransactionV3WithQueryBit ('0x100000000000000000000000000000003') is required, it should be set manually
+// in the returned transaction.
+//
 // Parameters:
 //   - senderAddress: The address of the account sending the transaction
 //   - nonce: The account's nonce
@@ -60,6 +64,10 @@ func BuildInvokeTxn(
 
 // BuildDeclareTxn creates a new declare transaction (v3) for the StarkNet network.
 // A declare transaction is used to declare a new contract class on the network.
+//
+// The default version of the returned transaction is rpc.TransactionV3 (0x3). If a version with
+// rpc.TransactionV3WithQueryBit ('0x100000000000000000000000000000003') is required, it should be set manually
+// in the returned transaction.
 //
 // Parameters:
 //   - senderAddress: The address of the account sending the transaction
@@ -104,6 +112,10 @@ func BuildDeclareTxn(
 
 // BuildDeployAccountTxn creates a new deploy account transaction (v3) for the StarkNet network.
 // A deploy account transaction is used to deploy a new account contract on the network.
+//
+// The default version of the returned transaction is rpc.TransactionV3 (0x3). If a version with
+// rpc.TransactionV3WithQueryBit ('0x100000000000000000000000000000003') is required, it should be set manually
+// in the returned transaction.
 //
 // Parameters:
 //   - nonce: The account's nonce


### PR DESCRIPTION
This PR aims to add a new optional parameter called `withQueryBitVersion` to the `BuildAndEstimateDeployAccountTxn`, `BuildAndSendInvokeTxn`, and `BuildAndSendDeclareTxn` methods, to allow the user to choose whether they want the transaction version to be in standard format (e.g. `0x3`) or in queryBit format (e.g. `0x100000000000000000000000000000003`)