### PR TITLE
Fix bug report of starknet.go

### DIFF
--- a/curve/curve_test.go
+++ b/curve/curve_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/NethermindEth/juno/core/felt"
 	internalUtils "github.com/NethermindEth/starknet.go/internal/utils"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -513,14 +514,41 @@ func TestGeneral_Signature(t *testing.T) {
 //
 //	none
 func TestGeneral_SplitFactStr(t *testing.T) {
-	data := []map[string]string{
-		{"input": "0x3", "h": "0x0", "l": "0x3"},
-		{"input": "0x300000000000000000000000000000000", "h": "0x3", "l": "0x0"},
+	type tescase struct {
+		input string
+		h     string
+		l     string
+		err   bool
+	}
+	data := []tescase{
+		{
+			input: "0x3",
+			h:     "0x0",
+			l:     "0x3",
+		},
+		{
+			input: "0x300000000000000000000000000000000",
+			h:     "0x3",
+			l:     "0x0",
+		},
+		{
+			input: "11111111111111111111111111111111111111111111111111111111111111010",
+			err:   true,
+		},
+		{
+			input: "X",
+			err:   true,
+		},
 	}
 	for _, d := range data {
-		l, h := internalUtils.SplitFactStr(d["input"]) // 0x3
-		require.Equal(t, d["l"], l)
-		require.Equal(t, d["h"], h)
+		l, h, err := internalUtils.SplitFactStr(d.input)
+		if d.err {
+			require.Error(t, err)
+		} else {
+			require.NoError(t, err)
+			assert.Equal(t, d.l, l)
+			assert.Equal(t, d.h, h)
+		}
 	}
 }
 

--- a/utils/keccak.go
+++ b/utils/keccak.go
@@ -191,7 +191,7 @@ func ComputeFact(programHash *big.Int, programOutputs []*big.Int) *big.Int {
 	return internalUtils.ComputeFact(programHash, programOutputs)
 }
 
-// SplitFactStr splits a given fact string into two parts (felts): fact_low and fact_high.
+// SplitFactStr splits a given fact, with maximum 256 bits size, into two parts (felts): fact_low and fact_high.
 //
 // The function takes a fact string as input and converts it to a big number using the HexToBN function.
 // It then converts the big number to bytes using the Bytes method.
@@ -209,7 +209,8 @@ func ComputeFact(programHash *big.Int, programOutputs []*big.Int) *big.Int {
 // Return types:
 //   - fact_low: The low part of the fact string in hexadecimal format
 //   - fact_high: The high part of the fact string in hexadecimal format
-func SplitFactStr(fact string) (fact_low, fact_high string) {
+//   - err: An error if any
+func SplitFactStr(fact string) (fact_low, fact_high string, err error) {
 	return internalUtils.SplitFactStr(fact)
 }
 


### PR DESCRIPTION
Related to #638 

- `utils.SplitFactStr` - Invalid memory address or nil pointer dereferenc
  - If the provided `fact` isn’t checked before calling the function and the provided string is just alphabetic character(s), or any other invalid hex value, then calling the function leads to a crash. 
- `utils.SplitFactStr` - Negative Repeat count
  - If the provided `fact` isn’t checked before calling the function and the provided string length is above 32, then calling the function leads to a crash. 