### PR TITLE
fix: replace rpc from nm to blast api

### DIFF
--- a/www/docs/pages/docs/introduction/getting-started.mdx
+++ b/www/docs/pages/docs/introduction/getting-started.mdx
@@ -53,7 +53,7 @@ import (
 
 func main() {
     // Initialize connection to RPC provider
-    rpcUrl := "https://free-rpc.nethermind.io/mainnet-juno/"
+    rpcUrl := "https://starknet-mainnet.public.blastapi.io/rpc/v0_8"
     client, err := rpc.NewProvider(rpcUrl)
     if err != nil {
         log.Fatal(err)

--- a/www/docs/pages/docs/rpc/methods/add-deploy-account-transaction.mdx
+++ b/www/docs/pages/docs/rpc/methods/add-deploy-account-transaction.mdx
@@ -31,7 +31,7 @@ import (
 )
 
 func main() {
-	rpcUrl := "https://free-rpc.nethermind.io/mainnet-juno/"
+	rpcUrl := "https://starknet-mainnet.public.blastapi.io/rpc/v0_8"
 	client, err := rpc.NewClient(rpcUrl)
 	if err != nil {
 		log.Fatal(err)

--- a/www/docs/pages/docs/rpc/methods/add-invoke-transaction.mdx
+++ b/www/docs/pages/docs/rpc/methods/add-invoke-transaction.mdx
@@ -31,7 +31,7 @@ import (
 )
 
 func main() {
-	rpcUrl := "https://free-rpc.nethermind.io/mainnet-juno/"
+	rpcUrl := "https://starknet-mainnet.public.blastapi.io/rpc/v0_8"
 	client, err := rpc.NewClient(rpcUrl)
 	if err != nil {
 		log.Fatal(err)

--- a/www/docs/pages/docs/rpc/methods/block-hash-and-number.mdx
+++ b/www/docs/pages/docs/rpc/methods/block-hash-and-number.mdx
@@ -28,7 +28,7 @@ import (
 )
 
 func main() {
-	rpcUrl := "https://free-rpc.nethermind.io/mainnet-juno/"
+	rpcUrl := "https://starknet-mainnet.public.blastapi.io/rpc/v0_8"
 	provider, err := rpc.NewProvider(rpcUrl)
 	if err != nil {
 		log.Fatal(err)

--- a/www/docs/pages/docs/rpc/methods/block-number.mdx
+++ b/www/docs/pages/docs/rpc/methods/block-number.mdx
@@ -24,7 +24,7 @@ import (
 )
 
 func main() {
-	rpcUrl := "https://free-rpc.nethermind.io/mainnet-juno/"
+	rpcUrl := "https://starknet-mainnet.public.blastapi.io/rpc/v0_8"
 	provider, err := rpc.NewProvider(rpcUrl)
 	if err != nil {
 		log.Fatal(err)

--- a/www/docs/pages/docs/rpc/methods/call.mdx
+++ b/www/docs/pages/docs/rpc/methods/call.mdx
@@ -36,7 +36,7 @@ import (
 )
 
 func main() {
-	rpcUrl := "https://free-rpc.nethermind.io/mainnet-juno/"
+	rpcUrl := "https://starknet-mainnet.public.blastapi.io/rpc/v0_8"
 	provider, err := rpc.NewProvider(rpcUrl)
 	if err != nil {
 		log.Fatal(err)

--- a/www/docs/pages/docs/rpc/methods/chain-id.mdx
+++ b/www/docs/pages/docs/rpc/methods/chain-id.mdx
@@ -24,7 +24,7 @@ import (
 )
 
 func main() {
-	rpcUrl := "https://free-rpc.nethermind.io/mainnet-juno/"
+	rpcUrl := "https://starknet-mainnet.public.blastapi.io/rpc/v0_8"
 	provider, err := rpc.NewProvider(rpcUrl)
 	if err != nil {
 		log.Fatal(err)

--- a/www/docs/pages/docs/rpc/methods/get-block-transaction-count.mdx
+++ b/www/docs/pages/docs/rpc/methods/get-block-transaction-count.mdx
@@ -31,7 +31,7 @@ import (
 )
 
 func main() {
-	rpcUrl := "https://free-rpc.nethermind.io/mainnet-juno/"
+	rpcUrl := "https://starknet-mainnet.public.blastapi.io/rpc/v0_8"
 	provider, err := rpc.NewProvider(rpcUrl)
 	if err != nil {
 		log.Fatal(err)

--- a/www/docs/pages/docs/rpc/methods/get-block-with-receipts.mdx
+++ b/www/docs/pages/docs/rpc/methods/get-block-with-receipts.mdx
@@ -33,7 +33,7 @@ import (
 )
 
 func main() {
-	rpcUrl := "https://free-rpc.nethermind.io/mainnet-juno/"
+	rpcUrl := "https://starknet-mainnet.public.blastapi.io/rpc/v0_8"
 	provider, err := rpc.NewProvider(rpcUrl)
 	if err != nil {
 		log.Fatal(err)

--- a/www/docs/pages/docs/rpc/methods/get-block-with-tx-hashes.mdx
+++ b/www/docs/pages/docs/rpc/methods/get-block-with-tx-hashes.mdx
@@ -30,7 +30,7 @@ import (
 )
 
 func main() {
-	rpcUrl := "https://free-rpc.nethermind.io/mainnet-juno/"
+	rpcUrl := "https://starknet-mainnet.public.blastapi.io/rpc/v0_8"
 	client, err := rpc.NewClient(rpcUrl)
 	if err != nil {
 		log.Fatal(err)

--- a/www/docs/pages/docs/rpc/methods/get-block-with-txs.mdx
+++ b/www/docs/pages/docs/rpc/methods/get-block-with-txs.mdx
@@ -30,7 +30,7 @@ import (
 )
 
 func main() {
-	rpcUrl := "https://free-rpc.nethermind.io/mainnet-juno/"
+	rpcUrl := "https://starknet-mainnet.public.blastapi.io/rpc/v0_8"
 	client, err := rpc.NewClient(rpcUrl)
 	if err != nil {
 		log.Fatal(err)

--- a/www/docs/pages/docs/rpc/methods/get-class-at.mdx
+++ b/www/docs/pages/docs/rpc/methods/get-class-at.mdx
@@ -34,7 +34,7 @@ import (
 )
 
 func main() {
-	rpcUrl := "https://free-rpc.nethermind.io/mainnet-juno/"
+	rpcUrl := "https://starknet-mainnet.public.blastapi.io/rpc/v0_8"
 	provider, err := rpc.NewProvider(rpcUrl)
 	if err != nil {
 		log.Fatal(err)

--- a/www/docs/pages/docs/rpc/methods/get-class-hash-at.mdx
+++ b/www/docs/pages/docs/rpc/methods/get-class-hash-at.mdx
@@ -34,7 +34,7 @@ import (
 )
 
 func main() {
-	rpcUrl := "https://free-rpc.nethermind.io/mainnet-juno/"
+	rpcUrl := "https://starknet-mainnet.public.blastapi.io/rpc/v0_8"
 	provider, err := rpc.NewProvider(rpcUrl)
 	if err != nil {
 		log.Fatal(err)

--- a/www/docs/pages/docs/rpc/methods/get-class.mdx
+++ b/www/docs/pages/docs/rpc/methods/get-class.mdx
@@ -33,7 +33,7 @@ import (
 )
 
 func main() {
-	rpcUrl := "https://free-rpc.nethermind.io/mainnet-juno/"
+	rpcUrl := "https://starknet-mainnet.public.blastapi.io/rpc/v0_8"
 	provider, err := rpc.NewProvider(rpcUrl)
 	if err != nil {
 		log.Fatal(err)

--- a/www/docs/pages/docs/rpc/methods/get-events.mdx
+++ b/www/docs/pages/docs/rpc/methods/get-events.mdx
@@ -35,7 +35,7 @@ import (
 )
 
 func main() {
-	rpcUrl := "https://free-rpc.nethermind.io/mainnet-juno/"
+	rpcUrl := "https://starknet-mainnet.public.blastapi.io/rpc/v0_8"
 	client, err := rpc.NewClient(rpcUrl)
 	if err != nil {
 		log.Fatal(err)

--- a/www/docs/pages/docs/rpc/methods/get-nonce.mdx
+++ b/www/docs/pages/docs/rpc/methods/get-nonce.mdx
@@ -34,7 +34,7 @@ import (
 )
 
 func main() {
-	rpcUrl := "https://free-rpc.nethermind.io/mainnet-juno/"
+	rpcUrl := "https://starknet-mainnet.public.blastapi.io/rpc/v0_8"
 	provider, err := rpc.NewProvider(rpcUrl)
 	if err != nil {
 		log.Fatal(err)

--- a/www/docs/pages/docs/rpc/methods/get-state-update.mdx
+++ b/www/docs/pages/docs/rpc/methods/get-state-update.mdx
@@ -36,7 +36,7 @@ import (
 )
 
 func main() {
-	rpcUrl := "https://free-rpc.nethermind.io/mainnet-juno/"
+	rpcUrl := "https://starknet-mainnet.public.blastapi.io/rpc/v0_8"
 	provider, err := rpc.NewProvider(rpcUrl)
 	if err != nil {
 		log.Fatal(err)

--- a/www/docs/pages/docs/rpc/methods/get-storage-at.mdx
+++ b/www/docs/pages/docs/rpc/methods/get-storage-at.mdx
@@ -30,7 +30,7 @@ import (
 )
 
 func main() {
-	rpcUrl := "https://free-rpc.nethermind.io/mainnet-juno/"
+	rpcUrl := "https://starknet-mainnet.public.blastapi.io/rpc/v0_8"
 	client, err := rpc.NewClient(rpcUrl)
 	if err != nil {
 		log.Fatal(err)

--- a/www/docs/pages/docs/rpc/methods/get-transaction-by-block-id-and-indes.mdx
+++ b/www/docs/pages/docs/rpc/methods/get-transaction-by-block-id-and-indes.mdx
@@ -37,7 +37,7 @@ import (
 )
 
 func main() {
-	rpcUrl := "https://free-rpc.nethermind.io/mainnet-juno/"
+	rpcUrl := "https://starknet-mainnet.public.blastapi.io/rpc/v0_8"
 	client, err := rpc.NewClient(rpcUrl)
 	if err != nil {
 		log.Fatal(err)

--- a/www/docs/pages/docs/rpc/methods/get-transaction-by-hash.mdx
+++ b/www/docs/pages/docs/rpc/methods/get-transaction-by-hash.mdx
@@ -33,7 +33,7 @@ import (
 )
 
 func main() {
-	rpcUrl := "https://free-rpc.nethermind.io/mainnet-juno/"
+	rpcUrl := "https://starknet-mainnet.public.blastapi.io/rpc/v0_8"
 	client, err := rpc.NewClient(rpcUrl)
 	if err != nil {
 		log.Fatal(err)

--- a/www/docs/pages/docs/rpc/methods/get-transaction-receipt.mdx
+++ b/www/docs/pages/docs/rpc/methods/get-transaction-receipt.mdx
@@ -33,7 +33,7 @@ import (
 )
 
 func main() {
-	rpcUrl := "https://free-rpc.nethermind.io/mainnet-juno/"
+	rpcUrl := "https://starknet-mainnet.public.blastapi.io/rpc/v0_8"
 	client, err := rpc.NewClient(rpcUrl)
 	if err != nil {
 		log.Fatal(err)

--- a/www/docs/pages/docs/rpc/methods/get-transaction-status.mdx
+++ b/www/docs/pages/docs/rpc/methods/get-transaction-status.mdx
@@ -29,7 +29,7 @@ import (
 )
 
 func main() {
-	rpcUrl := "https://free-rpc.nethermind.io/mainnet-juno/"
+	rpcUrl := "https://starknet-mainnet.public.blastapi.io/rpc/v0_8"
 	client, err := rpc.NewClient(rpcUrl)
 	if err != nil {
 		log.Fatal(err)

--- a/www/docs/pages/docs/rpc/methods/syncing.mdx
+++ b/www/docs/pages/docs/rpc/methods/syncing.mdx
@@ -24,7 +24,7 @@ import (
 )
 
 func main() {
-	rpcUrl := "https://free-rpc.nethermind.io/mainnet-juno/"
+	rpcUrl := "https://starknet-mainnet.public.blastapi.io/rpc/v0_8"
 	provider, err := rpc.NewProvider(rpcUrl)
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
In light of sunsetting nethermind's rpc service, a PR to update example rpc urls to blast api

ref: https://data.voyager.online/