### PR TITLE
Thiagodeev/small random changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,19 +6,39 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/NethermindEth/starknet.go/compare/v0.12.0...HEAD) <!-- Update the version number on each new release -->
+<!-- template to copy:
 ### Added
-- `Verify` method to the `account.Account` type and `account.AccountInterface` interface
+### Changed
+### Deprecated
+### Removed
+### Fixed
+### Security
+-->
+
+### Added
+- `account` pkg
+  - `Verify` method to the `Account` type and `AccountInterface` interface
+  - `CairoVersion` type
 - A warning message when calling `rpc.NewProvider` with a provider using a different RPC version than the one implemented by starknet.go.
 
+### Removed
+- `rpc.NewClient` function
+
 ### Changed
+- In `account.NewAccount` function, the `cairoVersion` parameter is now of type `account.CairoVersion` 
+- `setup.GetAccountCairoVersion` now returns `account.CairoVersion` instead of `int`
+- `rpc.WithBlockTag` now accepts `BlockTag` instead of `string` as parameter
 - Updated `examples/typedData/main.go` to use the new `Verify` method
 
 #### Dev updates:
+- Added tests:
+  - `rpc.TestVersionCompatibility`
+  - `account_test.TestVerify`
+- The `account` package has been refactored and split into multiple files.
+- New `testConfig` struct to the `account_test` package, for easier test configuration
 - Added "Warning" word in the logs when missing the .env file on `internal/test.go`
-- New `signature_test.go` file with the new `TestVerify` test
 - New `warnVersionCheckFailed` and `warnVersionMismatch` variables in `rpc/provider.go`
 - New `checkVersionCompatibility()` function in `rpc/provider.go` to check the version of the RPC provider. It is called inside `rpc.NewProvider`
-- New `TestVersionCompatibility` test in `rpc/provider_test.go`
 - `TestCookieManagement` modified to handle the `specVersion` call when creating a new provider
 - New `rpcVersion` constant in `rpc/provider.go`, representing the version of the RPC spec that starknet.go is compatible with
 - Updated `TestSpecVersion` to use the `rpcVersion` constant

--- a/account/account_test.go
+++ b/account/account_test.go
@@ -87,7 +87,7 @@ func TestFmtCallData(t *testing.T) {
 		var err error
 		if testEnv == "testnet" {
 			var client *rpc.Provider
-			client, err = rpc.NewProvider(base)
+			client, err = rpc.NewProvider(tConfig.providerURL)
 			require.NoError(t, err, "Error in rpc.NewClient")
 			acc, err = account.NewAccount(client, &felt.Zero, "pubkey", account.NewMemKeystore(), test.CairoVersion)
 			require.NoError(t, err)
@@ -183,7 +183,7 @@ func TestChainId(t *testing.T) {
 	}[testEnv]
 
 	for _, test := range testSet {
-		client, err := rpc.NewProvider(base)
+		client, err := rpc.NewProvider(tConfig.providerURL)
 		require.NoError(t, err, "Error in rpc.NewClient")
 
 		acc, err := account.NewAccount(client, &felt.Zero, "pubkey", account.NewMemKeystore(), 0)

--- a/account/account_test.go
+++ b/account/account_test.go
@@ -33,7 +33,7 @@ func TestFmtCallData(t *testing.T) {
 	mockRpcProvider := mocks.NewMockRpcProvider(mockCtrl)
 
 	type testSetType struct {
-		CairoVersion     int
+		CairoVersion     account.CairoVersion
 		ChainID          string
 		FnCall           rpc.FunctionCall
 		ExpectedCallData []*felt.Felt
@@ -43,7 +43,7 @@ func TestFmtCallData(t *testing.T) {
 		"mock":   {},
 		"testnet": {
 			{
-				CairoVersion: 2,
+				CairoVersion: account.CairoV2,
 				ChainID:      "SN_SEPOLIA",
 				FnCall: rpc.FunctionCall{
 					ContractAddress:    internalUtils.TestHexToFelt(t, "0x04daadb9d30c887e1ab2cf7d78dfe444a77aab5a49c3353d6d9977e7ed669902"),
@@ -61,7 +61,7 @@ func TestFmtCallData(t *testing.T) {
 				}),
 			},
 			{
-				CairoVersion: 2,
+				CairoVersion: account.CairoV2,
 				ChainID:      "SN_SEPOLIA",
 				FnCall: rpc.FunctionCall{
 					ContractAddress:    internalUtils.TestHexToFelt(t, "0x017cE9DffA7C87a03EB496c96e04ac36c4902085030763A83a35788d475e15CA"),
@@ -147,7 +147,7 @@ func TestChainIdMOCK(t *testing.T) {
 		mockRpcProvider.EXPECT().ChainID(context.Background()).Return(test.ChainID, nil)
 		// TODO: remove this once the braavos bug is fixed. Ref: https://github.com/NethermindEth/starknet.go/pull/691
 		mockRpcProvider.EXPECT().ClassHashAt(context.Background(), gomock.Any(), gomock.Any()).Return(internalUtils.RANDOM_FELT, nil)
-		acc, err := account.NewAccount(mockRpcProvider, &felt.Zero, "pubkey", account.NewMemKeystore(), 0)
+		acc, err := account.NewAccount(mockRpcProvider, &felt.Zero, "pubkey", account.NewMemKeystore(), account.CairoV0)
 		require.NoError(t, err)
 		require.Equal(t, test.ExpectedID, acc.ChainId.String())
 	}
@@ -186,7 +186,7 @@ func TestChainId(t *testing.T) {
 		client, err := rpc.NewProvider(tConfig.providerURL)
 		require.NoError(t, err, "Error in rpc.NewClient")
 
-		acc, err := account.NewAccount(client, &felt.Zero, "pubkey", account.NewMemKeystore(), 0)
+		acc, err := account.NewAccount(client, &felt.Zero, "pubkey", account.NewMemKeystore(), account.CairoV0)
 		require.NoError(t, err)
 		require.Equal(t, acc.ChainId.String(), test.ExpectedID)
 	}
@@ -242,7 +242,7 @@ func TestBraavosAccountWarning(t *testing.T) {
 			os.Stdout = w
 
 			// Create the account
-			_, err = account.NewAccount(mockRpcProvider, internalUtils.RANDOM_FELT, "pubkey", account.NewMemKeystore(), 2)
+			_, err = account.NewAccount(mockRpcProvider, internalUtils.RANDOM_FELT, "pubkey", account.NewMemKeystore(), account.CairoV2)
 			require.NoError(t, err)
 
 			// Close the writer and restore stdout

--- a/account/main_test.go
+++ b/account/main_test.go
@@ -102,7 +102,12 @@ func newDevnet(t *testing.T, url string) (*devnet.DevNet, []devnet.TestAccount, 
 // Returns:
 //   - *account.Account: The new devnet account
 //   - error: An error, if any
-func newDevnetAccount(t *testing.T, provider *rpc.Provider, accData devnet.TestAccount, cairoVersion account.CairoVersion) *account.Account {
+func newDevnetAccount(
+	t *testing.T,
+	provider *rpc.Provider,
+	accData devnet.TestAccount,
+	cairoVersion account.CairoVersion,
+) *account.Account {
 	t.Helper()
 	fakeUserAddr := internalUtils.TestHexToFelt(t, accData.Address)
 	fakeUserPriv := internalUtils.TestHexToFelt(t, accData.PrivateKey)

--- a/account/main_test.go
+++ b/account/main_test.go
@@ -66,7 +66,7 @@ func setupAcc(t *testing.T, provider rpc.RpcProvider) (*account.Account, error) 
 		return nil, fmt.Errorf("failed to convert accountAddress to felt: %w", err)
 	}
 
-	acc, err := account.NewAccount(provider, accAddress, tConfig.pubKey, ks, 2)
+	acc, err := account.NewAccount(provider, accAddress, tConfig.pubKey, ks, account.CairoV2)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create account: %w", err)
 	}
@@ -102,12 +102,7 @@ func newDevnet(t *testing.T, url string) (*devnet.DevNet, []devnet.TestAccount, 
 // Returns:
 //   - *account.Account: The new devnet account
 //   - error: An error, if any
-func newDevnetAccount(
-	t *testing.T,
-	provider *rpc.Provider,
-	accData devnet.TestAccount,
-	cairoVersion int,
-) *account.Account {
+func newDevnetAccount(t *testing.T, provider *rpc.Provider, accData devnet.TestAccount, cairoVersion account.CairoVersion) *account.Account {
 	t.Helper()
 	fakeUserAddr := internalUtils.TestHexToFelt(t, accData.Address)
 	fakeUserPriv := internalUtils.TestHexToFelt(t, accData.PrivateKey)

--- a/account/main_test.go
+++ b/account/main_test.go
@@ -15,66 +15,58 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type testConfig struct {
+	// the providerURL url for the test
+	providerURL string
+	// the test account data
+	privKey        string
+	pubKey         string
+	accountAddress string
+}
+
 var (
 	// the environment for the test, default: mock
 	testEnv = ""
-	// the base url for the test
-	base = ""
-	// the test account data
-	privKey        = ""
-	pubKey         = ""
-	accountAddress = ""
+	tConfig testConfig
 )
 
 // TestMain is used to trigger the tests and, in that case, check for the environment to use.
-//
-// It sets up the test environment by parsing command line flags and loading environment variables.
-// The test environment can be set using the "env" flag.
-// It then sets the base path for integration tests by reading the value from the "HTTP_PROVIDER_URL" environment variable.
-// If the base path is not set and the test environment is not "mock", it panics.
-// Finally, it exits with the return value of the test suite
-//
-// Parameters:
-//   - m: is the test main
-//
-// Returns:
-//
-//	none
 func TestMain(m *testing.M) {
 	testEnv = internal.LoadEnv()
 
 	if testEnv == "mock" {
 		os.Exit(m.Run())
 	}
-	base = os.Getenv("HTTP_PROVIDER_URL")
-	if base == "" {
+	tConfig.providerURL = os.Getenv("HTTP_PROVIDER_URL")
+	if tConfig.providerURL == "" {
 		panic("Failed to load HTTP_PROVIDER_URL, empty string")
 	}
 
 	// load the test account data, only required for some tests
-	privKey = os.Getenv("STARKNET_PRIVATE_KEY")
-	pubKey = os.Getenv("STARKNET_PUBLIC_KEY")
-	accountAddress = os.Getenv("STARKNET_ACCOUNT_ADDRESS")
+	tConfig.privKey = os.Getenv("STARKNET_PRIVATE_KEY")
+	tConfig.pubKey = os.Getenv("STARKNET_PUBLIC_KEY")
+	tConfig.accountAddress = os.Getenv("STARKNET_ACCOUNT_ADDRESS")
 
 	os.Exit(m.Run())
 }
 
+// returns a new account type from the provided account data in the tConfig
 func setupAcc(t *testing.T, provider rpc.RpcProvider) (*account.Account, error) {
 	t.Helper()
 
 	ks := account.NewMemKeystore()
-	privKeyBI, ok := new(big.Int).SetString(privKey, 0)
+	privKeyBI, ok := new(big.Int).SetString(tConfig.privKey, 0)
 	if !ok {
 		return nil, errors.New("failed to convert privKey to big.Int")
 	}
-	ks.Put(pubKey, privKeyBI)
+	ks.Put(tConfig.pubKey, privKeyBI)
 
-	accAddress, err := internalUtils.HexToFelt(accountAddress)
+	accAddress, err := internalUtils.HexToFelt(tConfig.accountAddress)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert accountAddress to felt: %w", err)
 	}
 
-	acc, err := account.NewAccount(provider, accAddress, pubKey, ks, 2)
+	acc, err := account.NewAccount(provider, accAddress, tConfig.pubKey, ks, 2)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create account: %w", err)
 	}
@@ -110,7 +102,12 @@ func newDevnet(t *testing.T, url string) (*devnet.DevNet, []devnet.TestAccount, 
 // Returns:
 //   - *account.Account: The new devnet account
 //   - error: An error, if any
-func newDevnetAccount(t *testing.T, provider *rpc.Provider, accData devnet.TestAccount, cairoVersion int) *account.Account {
+func newDevnetAccount(
+	t *testing.T,
+	provider *rpc.Provider,
+	accData devnet.TestAccount,
+	cairoVersion int,
+) *account.Account {
 	t.Helper()
 	fakeUserAddr := internalUtils.TestHexToFelt(t, accData.Address)
 	fakeUserPriv := internalUtils.TestHexToFelt(t, accData.PrivateKey)

--- a/account/transaction_test.go
+++ b/account/transaction_test.go
@@ -34,7 +34,7 @@ func TestBuildAndSendInvokeTxn(t *testing.T) {
 	}
 
 	provider, err := rpc.NewProvider(tConfig.providerURL)
-	require.NoError(t, err, "Error in rpc.NewClient")
+	require.NoError(t, err, "Error in rpc.NewProvider")
 
 	acc, err := setupAcc(t, provider)
 	require.NoError(t, err, "Error in setupAcc")
@@ -76,7 +76,7 @@ func TestBuildAndSendDeclareTxn(t *testing.T) {
 	}
 
 	provider, err := rpc.NewProvider(tConfig.providerURL)
-	require.NoError(t, err, "Error in rpc.NewClient")
+	require.NoError(t, err, "Error in rpc.NewProvider")
 
 	acc, err := setupAcc(t, provider)
 	require.NoError(t, err, "Error in setupAcc")
@@ -128,7 +128,7 @@ func TestBuildAndEstimateDeployAccountTxn(t *testing.T) {
 	}
 
 	provider, err := rpc.NewProvider(tConfig.providerURL)
-	require.NoError(t, err, "Error in rpc.NewClient")
+	require.NoError(t, err, "Error in rpc.NewProvider")
 
 	// we need this account to fund the new account with STRK tokens, in order to deploy it
 	acc, err := setupAcc(t, provider)
@@ -320,7 +320,7 @@ func TestBuildAndSendMethodsWithQueryBit(t *testing.T) {
 			t.Skip("Skipping test as it requires a devnet environment")
 		}
 		client, err := rpc.NewProvider(tConfig.providerURL)
-		require.NoError(t, err, "Error in rpc.NewClient")
+		require.NoError(t, err, "Error in rpc.NewProvider")
 
 		_, acnts, err := newDevnet(t, tConfig.providerURL)
 		require.NoError(t, err, "Error setting up Devnet")
@@ -466,7 +466,7 @@ func TestSendInvokeTxn(t *testing.T) {
 
 	for _, test := range testSet {
 		client, err := rpc.NewProvider(tConfig.providerURL)
-		require.NoError(t, err, "Error in rpc.NewClient")
+		require.NoError(t, err, "Error in rpc.NewProvider")
 
 		// Set up ks
 		ks := account.NewMemKeystore()
@@ -518,7 +518,7 @@ func TestSendDeclareTxn(t *testing.T) {
 	ks.Put(PubKey.String(), fakePrivKeyBI)
 
 	client, err := rpc.NewProvider(tConfig.providerURL)
-	require.NoError(t, err, "Error in rpc.NewClient")
+	require.NoError(t, err, "Error in rpc.NewProvider")
 
 	acnt, err := account.NewAccount(client, AccountAddress, PubKey.String(), ks, account.CairoV0)
 	require.NoError(t, err)
@@ -598,7 +598,7 @@ func TestSendDeployAccountDevnet(t *testing.T) {
 		t.Skip("Skipping test as it requires a devnet environment")
 	}
 	client, err := rpc.NewProvider(tConfig.providerURL)
-	require.NoError(t, err, "Error in rpc.NewClient")
+	require.NoError(t, err, "Error in rpc.NewProvider")
 
 	devnetClient, acnts, err := newDevnet(t, tConfig.providerURL)
 	require.NoError(t, err, "Error setting up Devnet")
@@ -769,7 +769,7 @@ func TestWaitForTransactionReceipt(t *testing.T) {
 		t.Skip("Skipping test as it requires a devnet environment")
 	}
 	client, err := rpc.NewProvider(tConfig.providerURL)
-	require.NoError(t, err, "Error in rpc.NewClient")
+	require.NoError(t, err, "Error in rpc.NewProvider")
 
 	acnt, err := account.NewAccount(client, &felt.Zero, "pubkey", account.NewMemKeystore(), account.CairoV0)
 	require.NoError(t, err, "error returned from account.NewAccount()")

--- a/account/transaction_test.go
+++ b/account/transaction_test.go
@@ -325,7 +325,7 @@ func TestBuildAndSendMethodsWithQueryBit(t *testing.T) {
 		_, acnts, err := newDevnet(t, tConfig.providerURL)
 		require.NoError(t, err, "Error setting up Devnet")
 
-		acnt := newDevnetAccount(t, client, acnts[0], 2)
+		acnt := newDevnetAccount(t, client, acnts[0], account.CairoV2)
 
 		t.Run("BuildAndSendDeclareTxn", func(t *testing.T) {
 			resp, err := acnt.BuildAndSendDeclareTxn(context.Background(), &casmClass, &class, 1.5, true)
@@ -605,7 +605,7 @@ func TestSendDeployAccountDevnet(t *testing.T) {
 
 	fakeUser := acnts[0]
 	fakeUserPub := internalUtils.TestHexToFelt(t, fakeUser.PublicKey)
-	acnt := newDevnetAccount(t, client, fakeUser, 2)
+	acnt := newDevnetAccount(t, client, fakeUser, account.CairoV2)
 
 	classHash := internalUtils.TestHexToFelt(
 		t,

--- a/account/transaction_test.go
+++ b/account/transaction_test.go
@@ -139,7 +139,7 @@ func TestBuildAndEstimateDeployAccountTxn(t *testing.T) {
 
 	// Set up the account passing random values to 'accountAddress' and 'cairoVersion' variables,
 	// as for this case we only need the 'ks' to sign the deploy transaction.
-	tempAcc, err := account.NewAccount(provider, pub, pub.String(), ks, 2)
+	tempAcc, err := account.NewAccount(provider, pub, pub.String(), ks, account.CairoV2)
 	if err != nil {
 		panic(err)
 	}
@@ -232,7 +232,7 @@ func TestBuildAndSendMethodsWithQueryBit(t *testing.T) {
 		// called when instantiating the account
 		mockRpcProvider.EXPECT().ClassHashAt(gomock.Any(), gomock.Any(), gomock.Any()).Return(internalUtils.RANDOM_FELT, nil).Times(1)
 		mockRpcProvider.EXPECT().ChainID(gomock.Any()).Return("SN_SEPOLIA", nil).Times(1)
-		acnt, err := account.NewAccount(mockRpcProvider, internalUtils.RANDOM_FELT, pub.String(), ks, 2)
+		acnt, err := account.NewAccount(mockRpcProvider, internalUtils.RANDOM_FELT, pub.String(), ks, account.CairoV2)
 		require.NoError(t, err)
 
 		// setting the expected behaviour for each call to EstimateFee,
@@ -364,7 +364,7 @@ func TestBuildAndSendMethodsWithQueryBit(t *testing.T) {
 		t.Run("BuildAndEstimateDeployAccountTxn", func(t *testing.T) {
 			// Get random keys to create the new account
 			ks, pub, _ := account.GetRandomKeys()
-			tempAcc, err := account.NewAccount(client, pub, pub.String(), ks, 2)
+			tempAcc, err := account.NewAccount(client, pub, pub.String(), ks, account.CairoV2)
 			require.NoError(t, err)
 
 			classHash := internalUtils.TestHexToFelt(
@@ -403,7 +403,7 @@ func TestBuildAndSendMethodsWithQueryBit(t *testing.T) {
 func TestSendInvokeTxn(t *testing.T) {
 	type testSetType struct {
 		ExpectedErr          error
-		CairoContractVersion int
+		CairoContractVersion account.CairoVersion
 		SetKS                bool
 		AccountAddress       *felt.Felt
 		PubKey               *felt.Felt
@@ -417,7 +417,7 @@ func TestSendInvokeTxn(t *testing.T) {
 			{
 				// https://sepolia.voyager.online/tx/0x7aac4792c8fd7578dd01b20ff04565f2e2ce6ea3c792c5e609a088704c1dd87
 				ExpectedErr:          rpc.ErrDuplicateTx,
-				CairoContractVersion: 2,
+				CairoContractVersion: account.CairoV2,
 				AccountAddress:       internalUtils.TestHexToFelt(t, "0x01AE6Fe02FcD9f61A3A8c30D68a8a7c470B0d7dD6F0ee685d5BBFa0d79406ff9"),
 				SetKS:                true,
 				PubKey:               internalUtils.TestHexToFelt(t, "0x022288424ec8116c73d2e2ed3b0663c5030d328d9c0fb44c2b54055db467f31e"),
@@ -476,7 +476,7 @@ func TestSendInvokeTxn(t *testing.T) {
 			ks.Put(test.PubKey.String(), fakePrivKeyBI)
 		}
 
-		acnt, err := account.NewAccount(client, test.AccountAddress, test.PubKey.String(), ks, 2)
+		acnt, err := account.NewAccount(client, test.AccountAddress, test.PubKey.String(), ks, account.CairoV2)
 		require.NoError(t, err)
 
 		err = acnt.SignInvokeTransaction(context.Background(), &test.InvokeTx)
@@ -520,7 +520,7 @@ func TestSendDeclareTxn(t *testing.T) {
 	client, err := rpc.NewProvider(tConfig.providerURL)
 	require.NoError(t, err, "Error in rpc.NewClient")
 
-	acnt, err := account.NewAccount(client, AccountAddress, PubKey.String(), ks, 0)
+	acnt, err := account.NewAccount(client, AccountAddress, PubKey.String(), ks, account.CairoV0)
 	require.NoError(t, err)
 
 	// Class
@@ -682,7 +682,7 @@ func TestWaitForTransactionReceiptMOCK(t *testing.T) {
 	mockRpcProvider.EXPECT().ChainID(context.Background()).Return("SN_SEPOLIA", nil)
 	// TODO: remove this once the braavos bug is fixed. Ref: https://github.com/NethermindEth/starknet.go/pull/691
 	mockRpcProvider.EXPECT().ClassHashAt(context.Background(), gomock.Any(), gomock.Any()).Return(internalUtils.RANDOM_FELT, nil)
-	acnt, err := account.NewAccount(mockRpcProvider, &felt.Zero, "", account.NewMemKeystore(), 0)
+	acnt, err := account.NewAccount(mockRpcProvider, &felt.Zero, "", account.NewMemKeystore(), account.CairoV0)
 	require.NoError(t, err, "error returned from account.NewAccount()")
 
 	type testSetType struct {
@@ -771,7 +771,7 @@ func TestWaitForTransactionReceipt(t *testing.T) {
 	client, err := rpc.NewProvider(tConfig.providerURL)
 	require.NoError(t, err, "Error in rpc.NewClient")
 
-	acnt, err := account.NewAccount(client, &felt.Zero, "pubkey", account.NewMemKeystore(), 0)
+	acnt, err := account.NewAccount(client, &felt.Zero, "pubkey", account.NewMemKeystore(), account.CairoV0)
 	require.NoError(t, err, "error returned from account.NewAccount()")
 
 	type testSetType struct {

--- a/account/transaction_test.go
+++ b/account/transaction_test.go
@@ -33,7 +33,7 @@ func TestBuildAndSendInvokeTxn(t *testing.T) {
 		t.Skip("test environment not supported")
 	}
 
-	provider, err := rpc.NewProvider(base)
+	provider, err := rpc.NewProvider(tConfig.providerURL)
 	require.NoError(t, err, "Error in rpc.NewClient")
 
 	acc, err := setupAcc(t, provider)
@@ -75,7 +75,7 @@ func TestBuildAndSendDeclareTxn(t *testing.T) {
 		t.Skip("test environment not supported")
 	}
 
-	provider, err := rpc.NewProvider(base)
+	provider, err := rpc.NewProvider(tConfig.providerURL)
 	require.NoError(t, err, "Error in rpc.NewClient")
 
 	acc, err := setupAcc(t, provider)
@@ -127,7 +127,7 @@ func TestBuildAndEstimateDeployAccountTxn(t *testing.T) {
 		t.Skip("test environment not supported")
 	}
 
-	provider, err := rpc.NewProvider(base)
+	provider, err := rpc.NewProvider(tConfig.providerURL)
 	require.NoError(t, err, "Error in rpc.NewClient")
 
 	// we need this account to fund the new account with STRK tokens, in order to deploy it
@@ -319,10 +319,10 @@ func TestBuildAndSendMethodsWithQueryBit(t *testing.T) {
 		if testEnv != "devnet" {
 			t.Skip("Skipping test as it requires a devnet environment")
 		}
-		client, err := rpc.NewProvider(base)
+		client, err := rpc.NewProvider(tConfig.providerURL)
 		require.NoError(t, err, "Error in rpc.NewClient")
 
-		_, acnts, err := newDevnet(t, base)
+		_, acnts, err := newDevnet(t, tConfig.providerURL)
 		require.NoError(t, err, "Error setting up Devnet")
 
 		acnt := newDevnetAccount(t, client, acnts[0], 2)
@@ -465,7 +465,7 @@ func TestSendInvokeTxn(t *testing.T) {
 	}[testEnv]
 
 	for _, test := range testSet {
-		client, err := rpc.NewProvider(base)
+		client, err := rpc.NewProvider(tConfig.providerURL)
 		require.NoError(t, err, "Error in rpc.NewClient")
 
 		// Set up ks
@@ -517,7 +517,7 @@ func TestSendDeclareTxn(t *testing.T) {
 	require.True(t, ok)
 	ks.Put(PubKey.String(), fakePrivKeyBI)
 
-	client, err := rpc.NewProvider(base)
+	client, err := rpc.NewProvider(tConfig.providerURL)
 	require.NoError(t, err, "Error in rpc.NewClient")
 
 	acnt, err := account.NewAccount(client, AccountAddress, PubKey.String(), ks, 0)
@@ -597,10 +597,10 @@ func TestSendDeployAccountDevnet(t *testing.T) {
 	if testEnv != "devnet" {
 		t.Skip("Skipping test as it requires a devnet environment")
 	}
-	client, err := rpc.NewProvider(base)
+	client, err := rpc.NewProvider(tConfig.providerURL)
 	require.NoError(t, err, "Error in rpc.NewClient")
 
-	devnetClient, acnts, err := newDevnet(t, base)
+	devnetClient, acnts, err := newDevnet(t, tConfig.providerURL)
 	require.NoError(t, err, "Error setting up Devnet")
 
 	fakeUser := acnts[0]
@@ -768,7 +768,7 @@ func TestWaitForTransactionReceipt(t *testing.T) {
 	if testEnv != "devnet" {
 		t.Skip("Skipping test as it requires a devnet environment")
 	}
-	client, err := rpc.NewProvider(base)
+	client, err := rpc.NewProvider(tConfig.providerURL)
 	require.NoError(t, err, "Error in rpc.NewClient")
 
 	acnt, err := account.NewAccount(client, &felt.Zero, "pubkey", account.NewMemKeystore(), 0)

--- a/account/txn_hash_test.go
+++ b/account/txn_hash_test.go
@@ -126,7 +126,7 @@ func TestTransactionHashInvoke(t *testing.T) {
 				var client *rpc.Provider
 				client, err = rpc.NewProvider(tConfig.providerURL)
 				require.NoError(t, err, "Error in rpc.NewClient")
-				acc, err = account.NewAccount(client, test.AccountAddress, test.PubKey, ks, 0)
+				acc, err = account.NewAccount(client, test.AccountAddress, test.PubKey, ks, account.CairoV0)
 				require.NoError(t, err, "error returned from account.NewAccount()")
 			}
 			if testEnv == "mock" {
@@ -135,7 +135,7 @@ func TestTransactionHashInvoke(t *testing.T) {
 				mockRpcProvider.EXPECT().
 					ClassHashAt(context.Background(), gomock.Any(), gomock.Any()).
 					Return(internalUtils.RANDOM_FELT, nil)
-				acc, err = account.NewAccount(mockRpcProvider, test.AccountAddress, test.PubKey, ks, 0)
+				acc, err = account.NewAccount(mockRpcProvider, test.AccountAddress, test.PubKey, ks, account.CairoV0)
 				require.NoError(t, err, "error returned from account.NewAccount()")
 			}
 			invokeTxn := rpc.InvokeTxnV1{
@@ -186,13 +186,13 @@ func TestTransactionHashDeclare(t *testing.T) {
 		mockRpcProvider.EXPECT().ChainID(context.Background()).Return("SN_SEPOLIA", nil)
 		// TODO: remove this once the braavos bug is fixed. Ref: https://github.com/NethermindEth/starknet.go/pull/691
 		mockRpcProvider.EXPECT().ClassHashAt(context.Background(), gomock.Any(), gomock.Any()).Return(internalUtils.RANDOM_FELT, nil)
-		acnt, err = account.NewAccount(mockRpcProvider, &felt.Zero, "", account.NewMemKeystore(), 0)
+		acnt, err = account.NewAccount(mockRpcProvider, &felt.Zero, "", account.NewMemKeystore(), account.CairoV0)
 		require.NoError(t, err)
 	}
 	if testEnv == "testnet" {
 		client, err := rpc.NewProvider(tConfig.providerURL)
 		require.NoError(t, err, "Error in rpc.NewClient")
-		acnt, err = account.NewAccount(client, &felt.Zero, "", account.NewMemKeystore(), 0)
+		acnt, err = account.NewAccount(client, &felt.Zero, "", account.NewMemKeystore(), account.CairoV0)
 		require.NoError(t, err)
 	}
 
@@ -306,13 +306,13 @@ func TestTransactionHashInvokeV3(t *testing.T) {
 		mockRpcProvider.EXPECT().ChainID(context.Background()).Return("SN_SEPOLIA", nil)
 		// TODO: remove this once the braavos bug is fixed. Ref: https://github.com/NethermindEth/starknet.go/pull/691
 		mockRpcProvider.EXPECT().ClassHashAt(context.Background(), gomock.Any(), gomock.Any()).Return(internalUtils.RANDOM_FELT, nil)
-		acnt, err = account.NewAccount(mockRpcProvider, &felt.Zero, "", account.NewMemKeystore(), 0)
+		acnt, err = account.NewAccount(mockRpcProvider, &felt.Zero, "", account.NewMemKeystore(), account.CairoV0)
 		require.NoError(t, err)
 	}
 	if testEnv == "testnet" {
 		client, err := rpc.NewProvider(tConfig.providerURL)
 		require.NoError(t, err, "Error in rpc.NewClient")
-		acnt, err = account.NewAccount(client, &felt.Zero, "", account.NewMemKeystore(), 0)
+		acnt, err = account.NewAccount(client, &felt.Zero, "", account.NewMemKeystore(), account.CairoV0)
 		require.NoError(t, err)
 	}
 
@@ -387,13 +387,13 @@ func TestTransactionHashdeployAccount(t *testing.T) {
 		// TODO: remove this once the braavos bug is fixed. Ref: https://github.com/NethermindEth/starknet.go/pull/691
 		mockRpcProvider.EXPECT().ClassHashAt(context.Background(), gomock.Any(), gomock.Any()).Return(internalUtils.RANDOM_FELT, nil)
 
-		acnt, err = account.NewAccount(mockRpcProvider, &felt.Zero, "", account.NewMemKeystore(), 0)
+		acnt, err = account.NewAccount(mockRpcProvider, &felt.Zero, "", account.NewMemKeystore(), account.CairoV0)
 		require.NoError(t, err)
 	}
 	if testEnv == "testnet" {
 		client, err := rpc.NewProvider(tConfig.providerURL)
 		require.NoError(t, err, "Error in rpc.NewClient")
-		acnt, err = account.NewAccount(client, &felt.Zero, "", account.NewMemKeystore(), 0)
+		acnt, err = account.NewAccount(client, &felt.Zero, "", account.NewMemKeystore(), account.CairoV0)
 		require.NoError(t, err)
 	}
 	type testSetType struct {

--- a/account/txn_hash_test.go
+++ b/account/txn_hash_test.go
@@ -124,7 +124,7 @@ func TestTransactionHashInvoke(t *testing.T) {
 			var err error
 			if testEnv == "testnet" {
 				var client *rpc.Provider
-				client, err = rpc.NewProvider(base)
+				client, err = rpc.NewProvider(tConfig.providerURL)
 				require.NoError(t, err, "Error in rpc.NewClient")
 				acc, err = account.NewAccount(client, test.AccountAddress, test.PubKey, ks, 0)
 				require.NoError(t, err, "error returned from account.NewAccount()")
@@ -161,7 +161,7 @@ func TestTransactionHashInvoke(t *testing.T) {
 // This function verifies that the TransactionHashDeclare function returns the
 // expected hash value for a given transaction.
 // The function requires a testnet environment to run.
-// It creates a new client using the provided base URL and verifies that no
+// It creates a new client using the provided tConfig.base URL and verifies that no
 // error occurs.
 // It then creates a new account using the provider and verifies that no error
 // occurs.
@@ -190,7 +190,7 @@ func TestTransactionHashDeclare(t *testing.T) {
 		require.NoError(t, err)
 	}
 	if testEnv == "testnet" {
-		client, err := rpc.NewProvider(base)
+		client, err := rpc.NewProvider(tConfig.providerURL)
 		require.NoError(t, err, "Error in rpc.NewClient")
 		acnt, err = account.NewAccount(client, &felt.Zero, "", account.NewMemKeystore(), 0)
 		require.NoError(t, err)
@@ -310,7 +310,7 @@ func TestTransactionHashInvokeV3(t *testing.T) {
 		require.NoError(t, err)
 	}
 	if testEnv == "testnet" {
-		client, err := rpc.NewProvider(base)
+		client, err := rpc.NewProvider(tConfig.providerURL)
 		require.NoError(t, err, "Error in rpc.NewClient")
 		acnt, err = account.NewAccount(client, &felt.Zero, "", account.NewMemKeystore(), 0)
 		require.NoError(t, err)
@@ -391,7 +391,7 @@ func TestTransactionHashdeployAccount(t *testing.T) {
 		require.NoError(t, err)
 	}
 	if testEnv == "testnet" {
-		client, err := rpc.NewProvider(base)
+		client, err := rpc.NewProvider(tConfig.providerURL)
 		require.NoError(t, err, "Error in rpc.NewClient")
 		acnt, err = account.NewAccount(client, &felt.Zero, "", account.NewMemKeystore(), 0)
 		require.NoError(t, err)

--- a/examples/deployAccount/main.go
+++ b/examples/deployAccount/main.go
@@ -38,7 +38,7 @@ func main() {
 
 	// Set up the account passing random values to 'accountAddress' and 'cairoVersion' variables,
 	// as for this case we only need the 'ks' to sign the deploy transaction.
-	accnt, err := account.NewAccount(client, pub, pub.String(), ks, 2)
+	accnt, err := account.NewAccount(client, pub, pub.String(), ks, account.CairoV2)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/internal/setup.go
+++ b/examples/internal/setup.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/starknet.go/account"
 	"github.com/joho/godotenv"
 )
 
@@ -45,13 +46,20 @@ func GetAccountAddress() string {
 }
 
 // Validates whether the ACCOUNT_CAIRO_VERSION variable has been set in the '.env' file and returns it; panics otherwise.
-func GetAccountCairoVersion() int {
+func GetAccountCairoVersion() account.CairoVersion {
 	num, err := strconv.Atoi(getEnv("ACCOUNT_CAIRO_VERSION"))
 	if err != nil {
 		panic("Invalid ACCOUNT_CAIRO_VERSION number set in the '.env' file")
 	}
 
-	return num
+	switch num {
+	case 0:
+		return account.CairoV0
+	case 2:
+		return account.CairoV2
+	default:
+		panic("Invalid ACCOUNT_CAIRO_VERSION number set in the '.env' file")
+	}
 }
 
 // Loads an env variable by name and returns it; panics otherwise.

--- a/rpc/block.go
+++ b/rpc/block.go
@@ -81,11 +81,10 @@ func WithBlockHash(h *felt.Felt) BlockID {
 //
 // Returns:
 //   - BlockID: A BlockID struct with the specified tag
-func WithBlockTag(tag string) BlockID {
-	// TODO: accept a BlockTag instead of a string
+func WithBlockTag(tag BlockTag) BlockID {
 	//nolint:exhaustruct
 	return BlockID{
-		Tag: BlockTag(tag),
+		Tag: tag,
 	}
 }
 

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -98,15 +98,3 @@ func doAsObject(ctx context.Context, call callCloser, method string, data, arg i
 
 	return nil
 }
-
-// NewClient creates a new ethrpc.Client instance.
-//
-// Parameters:
-//   - url: the URL of the RPC endpoint
-//
-// Returns:
-//   - *ethrpc.Client: a new ethrpc.Client
-//   - error: an error if any occurred
-func NewClient(url string) (*client.Client, error) {
-	return client.DialContext(context.Background(), url)
-}


### PR DESCRIPTION
This PR is a result of some changes made in the https://github.com/NethermindEth/starknet.go/pull/729 PR, but in order to achieve better organization, they are being split on this new PR.

Changes:
- new `account.CairoVersion` type
- removed `rpc.NewClient` function
- `rpc.WithBlockTag` now accepts `BlockTag` instead of `string` as parameter
- New `testConfig` struct to the `account_test` package, for easier test configuration