### PR TITLE
Fix: increase block range for websocket tests

### DIFF
--- a/rpc/websocket_test.go
+++ b/rpc/websocket_test.go
@@ -217,7 +217,7 @@ func TestSubscribeEvents(t *testing.T) {
 		events := make(chan *EmittedEvent)
 		sub, err := wsProvider.SubscribeEvents(context.Background(), events, &EventSubscriptionInput{
 			FromAddress: testSet.fromAddressExample,
-			BlockID:     WithBlockNumber(blockNumber - 1023),
+			BlockID:     WithBlockNumber(blockNumber - 1000),
 		})
 		if sub != nil {
 			defer sub.Unsubscribe()
@@ -260,7 +260,7 @@ func TestSubscribeEvents(t *testing.T) {
 		events := make(chan *EmittedEvent)
 		sub, err := wsProvider.SubscribeEvents(context.Background(), events, &EventSubscriptionInput{
 			Keys:    [][]*felt.Felt{{testSet.keyExample}},
-			BlockID: WithBlockNumber(blockNumber - 1023),
+			BlockID: WithBlockNumber(blockNumber - 1000),
 		})
 		if sub != nil {
 			defer sub.Unsubscribe()


### PR DESCRIPTION
Sometimes these tests fail due to a very short window range. Only 1024 blocks back are allowed, and we tried to query the latest - (minus) 1023, but sometimes the latest were outdated, so the result was the 1025 block