### PR TITLE
 Add DeployContractWithUDC method to improve contract deployment experience.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,12 +20,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `Verify` method to the `Account` type and `AccountInterface` interface
   - `CairoVersion` type
   - `TxnOptions` type, allowing optional settings when building/estimating/sending a transaction with the Build* methods
+  - `DeployContractWithUDC` method for deploying contracts using the Universal Deployer Contract (UDC)
 - `utils` pkg
   - `TxnOptions` type, allowing optional settings when building a transaction (set tip and query bit version)
+  - `BuildUDCCalldata` function to build calldata for UDC contract deployments
+  - `PrecomputeAddressForUDC` function to compute contract addresses deployed with UDC
+  - `UDCOptions` type and `UDCVersion` enum for configuring UDC deployments
 - A warning message when calling `rpc.NewProvider` with a provider using a different RPC version than the one implemented by starknet.go.
-
-### Removed
-- `rpc.NewClient` function
 
 ### Removed
 - `rpc.NewClient` function
@@ -41,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `setup.GetAccountCairoVersion` now returns `account.CairoVersion` instead of `int`
 - examples in `examples` folder updated to use `utils.TxnOptions` and `account.CairoVersion`
 - Updated `examples/typedData/main.go` to use the new `Verify` method
+- Updated `examples/deployContractUDC/main.go` to use the new `DeployContractWithUDC` method and UDC utilities
 
 ### Dev updates
 - Added tests:
@@ -48,8 +50,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `rpc.TestVersionCompatibility`
   - `account_test.TestTxnOptions`
   - `account_test.TestVerify`
-- New `testConfig` struct to the `account_test` package, for easier test configuration
-- The `account` package has been refactored and split into multiple files.
+  - `account_test.TestDeployContractWithUDC` with comprehensive test cases for ERC20 and no-constructor deployments
+  - `utils_test.TestBuildUDCCalldata` + others, covering various UDC scenarios and options
+  - `utils_test.TestPrecomputeAddressForUDC` for origin-dependent and independent address computation
 - RPC pkg:
   - Added "Warning" word in the logs when missing the .env file on `internal/test.go`
   - New `warnVersionCheckFailed` and `warnVersionMismatch` variables in `rpc/provider.go`
@@ -58,9 +61,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - New `rpcVersion` constant in `rpc/provider.go`, representing the version of the RPC spec that starknet.go is compatible with
   - Updated `TestSpecVersion` to use the `rpcVersion` constant
 - In `account.NewAccount` function, the `cairoVersion` parameter is now of type `account.CairoVersion` 
-- `setup.GetAccountCairoVersion` now returns `account.CairoVersion` instead of `int`
+- New `testConfig` struct to the `account_test` package, for easier test configuration
+- The `account` package has been refactored and split into multiple files.
+- Regenerated mocks for Account interface
 - `rpc.WithBlockTag` now accepts `BlockTag` instead of `string` as parameter
 - Updated `examples/typedData/main.go` to use the new `Verify` method
+- `setup.GetAccountCairoVersion` now returns `account.CairoVersion` instead of `int`
 
 ## [0.12.0](https://github.com/NethermindEth/starknet.go/releases/tag/v0.12.0) - 2025-06-02
 ### Added

--- a/account/account.go
+++ b/account/account.go
@@ -10,6 +10,7 @@ import (
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/starknet.go/contracts"
 	"github.com/NethermindEth/starknet.go/rpc"
+	"github.com/NethermindEth/starknet.go/utils"
 )
 
 var (
@@ -42,9 +43,9 @@ type AccountInterface interface {
 	DeployContractWithUDC(
 		ctx context.Context,
 		classHash *felt.Felt,
-		salt *felt.Felt,
 		constructorCalldata []*felt.Felt,
-		udcAddress *felt.Felt,
+		txnOpts *TxnOptions,
+		udcOpts *utils.UDCOptions,
 	) (*rpc.AddInvokeTransactionResponse, error)
 	Nonce(ctx context.Context) (*felt.Felt, error)
 	SendTransaction(ctx context.Context, txn rpc.BroadcastTxn) (*rpc.TransactionResponse, error)

--- a/account/account.go
+++ b/account/account.go
@@ -49,6 +49,13 @@ type AccountInterface interface {
 	TransactionHashInvoke(invokeTxn rpc.InvokeTxnType) (*felt.Felt, error)
 	TransactionHashDeployAccount(tx rpc.DeployAccountType, contractAddress *felt.Felt) (*felt.Felt, error)
 	TransactionHashDeclare(tx rpc.DeclareTxnType) (*felt.Felt, error)
+	DeployContractUDC(
+		ctx context.Context,
+		classHash *felt.Felt,
+		salt *felt.Felt,
+		constructorCalldata []*felt.Felt,
+		udcAddress *felt.Felt,
+	) (*rpc.AddInvokeTransactionResponse, error)
 	WaitForTransactionReceipt(
 		ctx context.Context,
 		transactionHash *felt.Felt,

--- a/account/account.go
+++ b/account/account.go
@@ -10,7 +10,6 @@ import (
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/starknet.go/contracts"
 	"github.com/NethermindEth/starknet.go/rpc"
-	"github.com/NethermindEth/starknet.go/utils"
 )
 
 var (
@@ -45,7 +44,7 @@ type AccountInterface interface {
 		classHash *felt.Felt,
 		constructorCalldata []*felt.Felt,
 		txnOpts *TxnOptions,
-		udcOpts *utils.UDCOptions,
+		udcOpts *UDCOptions,
 	) (*rpc.AddInvokeTransactionResponse, error)
 	Nonce(ctx context.Context) (*felt.Felt, error)
 	SendTransaction(ctx context.Context, txn rpc.BroadcastTxn) (*rpc.TransactionResponse, error)

--- a/account/account.go
+++ b/account/account.go
@@ -45,7 +45,7 @@ type AccountInterface interface {
 		constructorCalldata []*felt.Felt,
 		txnOpts *TxnOptions,
 		udcOpts *UDCOptions,
-	) (*rpc.AddInvokeTransactionResponse, error)
+	) (*rpc.AddInvokeTransactionResponse, *felt.Felt, error)
 	Nonce(ctx context.Context) (*felt.Felt, error)
 	SendTransaction(ctx context.Context, txn rpc.BroadcastTxn) (*rpc.TransactionResponse, error)
 	Sign(ctx context.Context, msg *felt.Felt) ([]*felt.Felt, error)

--- a/account/account.go
+++ b/account/account.go
@@ -39,7 +39,7 @@ type AccountInterface interface {
 		contractClass *contracts.ContractClass,
 		opts *TxnOptions,
 	) (*rpc.AddDeclareTransactionResponse, error)
-	DeployContractUDC(
+	DeployContractWithUDC(
 		ctx context.Context,
 		classHash *felt.Felt,
 		salt *felt.Felt,

--- a/account/transaction.go
+++ b/account/transaction.go
@@ -248,12 +248,13 @@ func (account *Account) BuildAndEstimateDeployAccountTxn(
 // Parameters:
 //   - ctx: The context.Context for the request.
 //   - classHash: The class hash of the contract to be deployed.
-//   - constructorCalldata: The parameters passed to the constructor. Leave empty if the constructor has no arguments.
+//   - constructorCalldata: The parameters passed to the constructor. Pass `nil` if the constructor has no arguments.
 //   - txnOpts: The options for building/estimating the transaction. Pass `nil` to use default values.
 //   - udcOpts: The options for building the UDC calldata. Pass `nil` to use default values.
 //
 // Returns:
 //   - *rpc.AddInvokeTransactionResponse: the response of the submitted UDC transaction.
+//   - *felt.Felt: the salt used for the UDC deployment (either the provided one or the random one)
 //   - error: An error if any.
 func (account *Account) DeployContractWithUDC(
 	ctx context.Context,
@@ -261,13 +262,18 @@ func (account *Account) DeployContractWithUDC(
 	constructorCalldata []*felt.Felt,
 	txnOpts *TxnOptions,
 	udcOpts *UDCOptions,
-) (*rpc.AddInvokeTransactionResponse, error) {
-	udcCallData, err := utils.BuildUDCCalldata(classHash, constructorCalldata, udcOpts)
+) (*rpc.AddInvokeTransactionResponse, *felt.Felt, error) {
+	udcCallData, salt, err := utils.BuildUDCCalldata(classHash, constructorCalldata, udcOpts)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	return account.BuildAndSendInvokeTxn(context.Background(), []rpc.InvokeFunctionCall{udcCallData}, txnOpts)
+	txnResponse, err := account.BuildAndSendInvokeTxn(context.Background(), []rpc.InvokeFunctionCall{udcCallData}, txnOpts)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return txnResponse, salt, nil
 }
 
 // SendTransaction can send Invoke, Declare, and Deploy transactions. It provides a unified way to send different transactions.

--- a/account/transaction.go
+++ b/account/transaction.go
@@ -255,36 +255,39 @@ func (account *Account) BuildAndEstimateDeployAccountTxn(
 // It returns:
 //   - *rpc.AddInvokeTransactionResponse: the response from the provider
 //   - error: an error if any
+//
+// TODO: improve docs
 func (account *Account) DeployContractWithUDC(
 	ctx context.Context,
 	classHash *felt.Felt,
-	salt *felt.Felt,
 	constructorCalldata []*felt.Felt,
-	udcAddress *felt.Felt,
+	txnOpts *TxnOptions,
+	udcOpts *utils.UDCOptions,
 ) (*rpc.AddInvokeTransactionResponse, error) {
+	// TODO: implement this
 
-	fromZeroFelt := new(felt.Felt).SetUint64(1)
+	// fromZeroFelt := new(felt.Felt).SetUint64(1)
 
-	calldataLen := new(felt.Felt).SetUint64(uint64(len(constructorCalldata)))
-	udcCallData := append([]*felt.Felt{classHash, salt, fromZeroFelt, calldataLen}, constructorCalldata...)
+	// calldataLen := new(felt.Felt).SetUint64(uint64(len(constructorCalldata)))
+	// udcCallData := append([]*felt.Felt{classHash, salt, fromZeroFelt, calldataLen}, constructorCalldata...)
 
-	var finalUdcAddress *felt.Felt
-	if udcAddress != nil {
-		finalUdcAddress = udcAddress
-	} else {
-		var err error
-		// Default address is same for Mainnet and Sepolia testnet.
-		// https://docs.openzeppelin.com/contracts-cairo/0.14.0/udc
-		finalUdcAddress, err = new(felt.Felt).SetString("0x04a64cd09a853868621d94cae9952b106f2c36a3f81260f85de6696c6b050221")
-		if err != nil {
-			return nil, err
-		}
-	}
+	// var finalUdcAddress *felt.Felt
+	// if udcAddress != nil {
+	// 	finalUdcAddress = udcAddress
+	// } else {
+	// 	var err error
+	// 	// Default address is same for Mainnet and Sepolia testnet.
+	// 	// https://docs.openzeppelin.com/contracts-cairo/0.14.0/udc
+	// 	finalUdcAddress, err = new(felt.Felt).SetString("0x04a64cd09a853868621d94cae9952b106f2c36a3f81260f85de6696c6b050221")
+	// 	if err != nil {
+	// 		return nil, err
+	// 	}
+	// }
 
 	fnCall := rpc.InvokeFunctionCall{
-		ContractAddress: finalUdcAddress,
-		FunctionName:    "deploy_contract",
-		CallData:        udcCallData,
+		// ContractAddress: finalUdcAddress,
+		// FunctionName:    "deploy_contract",
+		// CallData:        udcCallData,
 	}
 
 	// Setting multiplier to 1.5 for now, I think ideally the user should be able to set it.

--- a/account/transaction.go
+++ b/account/transaction.go
@@ -243,7 +243,7 @@ func (account *Account) BuildAndEstimateDeployAccountTxn(
 	return broadcastDepAccTxnV3, precomputedAddress, nil
 }
 
-// DeployContractUDC deploys a contract using UDC.
+// DeployContractWithUDC deploys a contract using UDC.
 //
 // Parameters:
 //   - ctx: the context
@@ -255,7 +255,7 @@ func (account *Account) BuildAndEstimateDeployAccountTxn(
 // It returns:
 //   - *rpc.AddInvokeTransactionResponse: the response from the provider
 //   - error: an error if any
-func (account *Account) DeployContractUDC(
+func (account *Account) DeployContractWithUDC(
 	ctx context.Context,
 	classHash *felt.Felt,
 	salt *felt.Felt,

--- a/account/transaction.go
+++ b/account/transaction.go
@@ -295,7 +295,7 @@ func (account *Account) DeployContractUDC(
 		CallData:        udcCallData,
 	}
 
-	// Setting multiplier to 1.5 for now, maybe expose this to the user in the future
+	// Setting multiplier to 1.5 for now, I think ideally the user should be able to set it.
 	return account.BuildAndSendInvokeTxn(context.Background(), []rpc.InvokeFunctionCall{fnCall}, 1.5, false)
 }
 

--- a/account/transaction.go
+++ b/account/transaction.go
@@ -262,7 +262,7 @@ func (account *Account) DeployContractWithUDC(
 	classHash *felt.Felt,
 	constructorCalldata []*felt.Felt,
 	txnOpts *TxnOptions,
-	udcOpts *utils.UDCOptions,
+	udcOpts *UDCOptions,
 ) (*rpc.AddInvokeTransactionResponse, error) {
 	// TODO: implement this
 

--- a/account/transaction.go
+++ b/account/transaction.go
@@ -288,7 +288,7 @@ func (account *Account) DeployContractUDC(
 	}
 
 	// Setting multiplier to 1.5 for now, I think ideally the user should be able to set it.
-	return account.BuildAndSendInvokeTxn(context.Background(), []rpc.InvokeFunctionCall{fnCall}, 1.5, false)
+	return account.BuildAndSendInvokeTxn(context.Background(), []rpc.InvokeFunctionCall{fnCall}, nil)
 }
 
 // SendTransaction can send Invoke, Declare, and Deploy transactions. It provides a unified way to send different transactions.

--- a/account/transaction.go
+++ b/account/transaction.go
@@ -18,7 +18,7 @@ import (
 //   - ctx: The context.Context for the request.
 //   - functionCalls: A slice of rpc.InvokeFunctionCall representing the function calls for the transaction, allowing either single or
 //     multiple function calls in the same transaction.
-//   - opts: options for building/estimating the transaction. See more info in the TxnOptions type description.
+//   - opts: options for building/estimating the transaction. Pass `nil` to use default values.
 //
 // Returns:
 //   - *rpc.AddInvokeTransactionResponse: the response of the submitted transaction.
@@ -97,7 +97,7 @@ func (account *Account) BuildAndSendInvokeTxn(
 //   - ctx: The context.Context for the request.
 //   - casmClass: The casm class of the contract to be declared
 //   - contractClass: The sierra contract class of the contract to be declared
-//   - opts: options for building/estimating the transaction. See more info in the TxnOptions type description.
+//   - opts: options for building/estimating the transaction. Pass `nil` to use default values.
 //
 // Returns:
 //   - *rpc.AddDeclareTransactionResponse: the response of the submitted transaction.
@@ -180,7 +180,7 @@ func (account *Account) BuildAndSendDeclareTxn(
 //   - salt: the salt for the address of the deployed contract
 //   - classHash: the class hash of the contract to be deployed
 //   - constructorCalldata: the parameters passed to the constructor
-//   - opts: options for building/estimating the transaction. See more info in the TxnOptions type description.
+//   - opts: options for building/estimating the transaction. Pass `nil` to use default values.
 //
 // Returns:
 //   - *rpc.BroadcastDeployAccountTxnV3: the transaction to be broadcasted, signed and with the estimated fee based on the multiplier
@@ -249,8 +249,8 @@ func (account *Account) BuildAndEstimateDeployAccountTxn(
 //   - ctx: The context.Context for the request.
 //   - classHash: The class hash of the contract to be deployed.
 //   - constructorCalldata: The parameters passed to the constructor. Leave empty if the constructor has no arguments.
-//   - txnOpts: The options for building/estimating the transaction. See more info in the TxnOptions type description.
-//   - udcOpts: The options for building the UDC calldata. See more info in the UDCOptions type description.
+//   - txnOpts: The options for building/estimating the transaction. Pass `nil` to use default values.
+//   - udcOpts: The options for building the UDC calldata. Pass `nil` to use default values.
 //
 // Returns:
 //   - *rpc.AddInvokeTransactionResponse: the response of the submitted UDC transaction.

--- a/account/transaction.go
+++ b/account/transaction.go
@@ -243,20 +243,18 @@ func (account *Account) BuildAndEstimateDeployAccountTxn(
 	return broadcastDepAccTxnV3, precomputedAddress, nil
 }
 
-// DeployContractWithUDC deploys a contract using UDC.
+// A helper to deploy a contract from an existing class using UDC.
 //
 // Parameters:
-//   - ctx: the context
-//   - classHash: the class hash of the contract to be deployed
-//   - salt: the salt for the address of the deployed contract
-//   - constructorCalldata: the parameters passed to the constructor
-//   - udcAddress: the address of the UDC contract. If nil, the default address will be used.
+//   - ctx: The context.Context for the request.
+//   - classHash: The class hash of the contract to be deployed.
+//   - constructorCalldata: The parameters passed to the constructor. Leave empty if the constructor has no arguments.
+//   - txnOpts: The options for building/estimating the transaction. See more info in the TxnOptions type description.
+//   - udcOpts: The options for building the UDC calldata. See more info in the UDCOptions type description.
 //
-// It returns:
-//   - *rpc.AddInvokeTransactionResponse: the response from the provider
-//   - error: an error if any
-//
-// TODO: improve docs
+// Returns:
+//   - *rpc.AddInvokeTransactionResponse: the response of the submitted UDC transaction.
+//   - error: An error if any.
 func (account *Account) DeployContractWithUDC(
 	ctx context.Context,
 	classHash *felt.Felt,
@@ -264,34 +262,12 @@ func (account *Account) DeployContractWithUDC(
 	txnOpts *TxnOptions,
 	udcOpts *UDCOptions,
 ) (*rpc.AddInvokeTransactionResponse, error) {
-	// TODO: implement this
-
-	// fromZeroFelt := new(felt.Felt).SetUint64(1)
-
-	// calldataLen := new(felt.Felt).SetUint64(uint64(len(constructorCalldata)))
-	// udcCallData := append([]*felt.Felt{classHash, salt, fromZeroFelt, calldataLen}, constructorCalldata...)
-
-	// var finalUdcAddress *felt.Felt
-	// if udcAddress != nil {
-	// 	finalUdcAddress = udcAddress
-	// } else {
-	// 	var err error
-	// 	// Default address is same for Mainnet and Sepolia testnet.
-	// 	// https://docs.openzeppelin.com/contracts-cairo/0.14.0/udc
-	// 	finalUdcAddress, err = new(felt.Felt).SetString("0x04a64cd09a853868621d94cae9952b106f2c36a3f81260f85de6696c6b050221")
-	// 	if err != nil {
-	// 		return nil, err
-	// 	}
-	// }
-
-	fnCall := rpc.InvokeFunctionCall{
-		// ContractAddress: finalUdcAddress,
-		// FunctionName:    "deploy_contract",
-		// CallData:        udcCallData,
+	udcCallData, err := utils.BuildUDCCalldata(classHash, constructorCalldata, udcOpts)
+	if err != nil {
+		return nil, err
 	}
 
-	// Setting multiplier to 1.5 for now, I think ideally the user should be able to set it.
-	return account.BuildAndSendInvokeTxn(context.Background(), []rpc.InvokeFunctionCall{fnCall}, nil)
+	return account.BuildAndSendInvokeTxn(context.Background(), []rpc.InvokeFunctionCall{udcCallData}, txnOpts)
 }
 
 // SendTransaction can send Invoke, Declare, and Deploy transactions. It provides a unified way to send different transactions.

--- a/account/transaction_test.go
+++ b/account/transaction_test.go
@@ -841,7 +841,7 @@ func TestDeployContractWithUDC(t *testing.T) {
 	t.Run("UDCCairoV0, no constructor, udcOptions nil", func(t *testing.T) {
 		classHash, _ := utils.HexToFelt("0x0387edd4804deba7af741953fdf64189468f37593a66b618d00d2476be3168f8")
 
-		resp, err := accnt.DeployContractWithUDC(context.Background(), classHash, nil, nil, nil)
+		resp, _, err := accnt.DeployContractWithUDC(context.Background(), classHash, nil, nil, nil)
 		require.NoError(t, err, "DeployContractUDC failed")
 
 		t.Logf("Transaction hash: %s", resp.Hash)
@@ -856,7 +856,7 @@ func TestDeployContractWithUDC(t *testing.T) {
 	t.Run("error, UDCCairoV0, no constructor, all udcOptions set", func(t *testing.T) {
 		classHash, _ := utils.HexToFelt("0x0387edd4804deba7af741953fdf64189468f37593a66b618d00d2476be3168f8")
 
-		_, err := accnt.DeployContractWithUDC(context.Background(), classHash, nil, nil, &utils.UDCOptions{
+		_, _, err := accnt.DeployContractWithUDC(context.Background(), classHash, nil, nil, &utils.UDCOptions{
 			Salt:              internalUtils.RANDOM_FELT,
 			UDCVersion:        utils.UDCCairoV0,
 			OriginIndependent: true,
@@ -867,7 +867,7 @@ func TestDeployContractWithUDC(t *testing.T) {
 	t.Run("UDCCairoV2, no constructor, only UDCVersion set", func(t *testing.T) {
 		classHash, _ := utils.HexToFelt("0x0387edd4804deba7af741953fdf64189468f37593a66b618d00d2476be3168f8")
 
-		resp, err := accnt.DeployContractWithUDC(context.Background(), classHash, nil, nil, &utils.UDCOptions{
+		resp, _, err := accnt.DeployContractWithUDC(context.Background(), classHash, nil, nil, &utils.UDCOptions{
 			UDCVersion: utils.UDCCairoV2,
 		})
 		require.NoError(t, err, "DeployContractUDC failed")
@@ -884,7 +884,7 @@ func TestDeployContractWithUDC(t *testing.T) {
 	t.Run("error, UDCCairoV2, no constructor, all udcOptions set", func(t *testing.T) {
 		classHash, _ := utils.HexToFelt("0x0387edd4804deba7af741953fdf64189468f37593a66b618d00d2476be3168f8")
 
-		_, err := accnt.DeployContractWithUDC(context.Background(), classHash, nil, nil, &utils.UDCOptions{
+		_, _, err := accnt.DeployContractWithUDC(context.Background(), classHash, nil, nil, &utils.UDCOptions{
 			Salt:              internalUtils.RANDOM_FELT,
 			UDCVersion:        utils.UDCCairoV2,
 			OriginIndependent: true,
@@ -909,7 +909,7 @@ func TestDeployContractWithUDC(t *testing.T) {
 	constructorCalldata = append(constructorCalldata, owner)
 
 	t.Run("UDCCairoV0, with constructor - ERC20, udcOptions nil", func(t *testing.T) {
-		resp, err := accnt.DeployContractWithUDC(context.Background(), classHash, constructorCalldata, nil, nil)
+		resp, _, err := accnt.DeployContractWithUDC(context.Background(), classHash, constructorCalldata, nil, nil)
 		require.NoError(t, err, "DeployContractUDC failed")
 
 		t.Logf("Transaction hash: %s", resp.Hash)
@@ -922,7 +922,7 @@ func TestDeployContractWithUDC(t *testing.T) {
 	})
 
 	t.Run("error, UDCCairoV0, with constructor - ERC20, all udcOptions set", func(t *testing.T) {
-		_, err := accnt.DeployContractWithUDC(context.Background(), classHash, constructorCalldata, nil, &utils.UDCOptions{
+		_, _, err := accnt.DeployContractWithUDC(context.Background(), classHash, constructorCalldata, nil, &utils.UDCOptions{
 			Salt:              internalUtils.RANDOM_FELT,
 			UDCVersion:        utils.UDCCairoV0,
 			OriginIndependent: true,
@@ -931,7 +931,7 @@ func TestDeployContractWithUDC(t *testing.T) {
 	})
 
 	t.Run("UDCCairoV2, with constructor - ERC20, udcOptions nil", func(t *testing.T) {
-		resp, err := accnt.DeployContractWithUDC(context.Background(), classHash, constructorCalldata, nil, &utils.UDCOptions{
+		resp, _, err := accnt.DeployContractWithUDC(context.Background(), classHash, constructorCalldata, nil, &utils.UDCOptions{
 			UDCVersion: utils.UDCCairoV2,
 		})
 		require.NoError(t, err, "DeployContractUDC failed")
@@ -946,7 +946,7 @@ func TestDeployContractWithUDC(t *testing.T) {
 	})
 
 	t.Run("error, UDCCairoV2, with constructor - ERC20, all udcOptions set", func(t *testing.T) {
-		_, err := accnt.DeployContractWithUDC(context.Background(), classHash, constructorCalldata, nil, &utils.UDCOptions{
+		_, _, err := accnt.DeployContractWithUDC(context.Background(), classHash, constructorCalldata, nil, &utils.UDCOptions{
 			Salt:              internalUtils.RANDOM_FELT,
 			UDCVersion:        utils.UDCCairoV2,
 			OriginIndependent: true,

--- a/account/transaction_test.go
+++ b/account/transaction_test.go
@@ -875,7 +875,7 @@ func TestDeployContractUDC(t *testing.T) {
 	constructorCalldata := append(nameAsFelts, symbolAsFelts...)
 	constructorCalldata = append(constructorCalldata, low, high, recipient, recipient)
 
-	resp, err := accnt.DeployContractUDC(context.Background(), classHash, salt, constructorCalldata, nil)
+	resp, err := accnt.DeployContractWithUDC(context.Background(), classHash, salt, constructorCalldata, nil)
 	require.NoError(t, err, "DeployContractUDC failed")
 
 	t.Logf("Transaction hash: %s", resp.Hash)

--- a/account/transaction_test.go
+++ b/account/transaction_test.go
@@ -905,8 +905,7 @@ func TestDeployContractWithUDC(t *testing.T) {
 	constructorCalldata = append(constructorCalldata, name...)
 	constructorCalldata = append(constructorCalldata, symbol...)
 	constructorCalldata = append(constructorCalldata, supply...)
-	constructorCalldata = append(constructorCalldata, recipient)
-	constructorCalldata = append(constructorCalldata, owner)
+	constructorCalldata = append(constructorCalldata, recipient, owner)
 
 	t.Run("UDCCairoV0, with constructor - ERC20, udcOptions nil", func(t *testing.T) {
 		resp, _, err := accnt.DeployContractWithUDC(context.Background(), classHash, constructorCalldata, nil, nil)

--- a/account/transaction_test.go
+++ b/account/transaction_test.go
@@ -882,11 +882,29 @@ func TestDeployContractWithUDC(t *testing.T) {
 		assert.Equal(t, rpc.TxnFinalityStatusAcceptedOnL2, txReceipt.FinalityStatus)
 	})
 
-	t.Run("deploy contract with no constructor, UDCCairoV2", func(t *testing.T) {
+	t.Run("no constructor, UDCCairoV2, origin-dependent", func(t *testing.T) {
 		classHash, _ := utils.HexToFelt("0x0387edd4804deba7af741953fdf64189468f37593a66b618d00d2476be3168f8")
 
 		resp, err := accnt.DeployContractWithUDC(context.Background(), classHash, nil, nil, &utils.UDCOptions{
 			UDCVersion: utils.UDCCairoV2,
+		})
+		require.NoError(t, err, "DeployContractUDC failed")
+
+		t.Logf("Transaction hash: %s", resp.Hash)
+
+		txReceipt, err := accnt.WaitForTransactionReceipt(context.Background(), resp.Hash, time.Second)
+		require.NoError(t, err, "Waiting for tx receipt failed")
+
+		assert.Equal(t, rpc.TxnExecutionStatusSUCCEEDED, txReceipt.ExecutionStatus)
+		assert.Equal(t, rpc.TxnFinalityStatusAcceptedOnL2, txReceipt.FinalityStatus)
+	})
+
+	t.Run("no constructor, UDCCairoV2, origin-independent", func(t *testing.T) {
+		classHash, _ := utils.HexToFelt("0x0387edd4804deba7af741953fdf64189468f37593a66b618d00d2476be3168f8")
+
+		resp, err := accnt.DeployContractWithUDC(context.Background(), classHash, nil, nil, &utils.UDCOptions{
+			UDCVersion:        utils.UDCCairoV2,
+			OriginIndependent: true,
 		})
 		require.NoError(t, err, "DeployContractUDC failed")
 

--- a/account/transaction_test.go
+++ b/account/transaction_test.go
@@ -881,6 +881,23 @@ func TestDeployContractWithUDC(t *testing.T) {
 		assert.Equal(t, rpc.TxnExecutionStatusSUCCEEDED, txReceipt.ExecutionStatus)
 		assert.Equal(t, rpc.TxnFinalityStatusAcceptedOnL2, txReceipt.FinalityStatus)
 	})
+
+	t.Run("deploy contract with no constructor, UDCCairoV2", func(t *testing.T) {
+		classHash, _ := utils.HexToFelt("0x0387edd4804deba7af741953fdf64189468f37593a66b618d00d2476be3168f8")
+
+		resp, err := accnt.DeployContractWithUDC(context.Background(), classHash, nil, nil, &utils.UDCOptions{
+			UDCVersion: utils.UDCCairoV2,
+		})
+		require.NoError(t, err, "DeployContractUDC failed")
+
+		t.Logf("Transaction hash: %s", resp.Hash)
+
+		txReceipt, err := accnt.WaitForTransactionReceipt(context.Background(), resp.Hash, time.Second)
+		require.NoError(t, err, "Waiting for tx receipt failed")
+
+		assert.Equal(t, rpc.TxnExecutionStatusSUCCEEDED, txReceipt.ExecutionStatus)
+		assert.Equal(t, rpc.TxnFinalityStatusAcceptedOnL2, txReceipt.FinalityStatus)
+	})
 }
 
 // TODO: add more tests for the BuildAnd* functions, testing each of them with different TxnOption's

--- a/account/transaction_test.go
+++ b/account/transaction_test.go
@@ -838,7 +838,7 @@ func TestDeployContractWithUDC(t *testing.T) {
 	accnt, err := setupAcc(t, provider)
 	require.NoError(t, err, "Error in setupAcc")
 
-	t.Run("deploy contract with constructor data - ERC20, udcOptions nil", func(t *testing.T) {
+	t.Run("UDCCairoV0, with constructor - ERC20, udcOptions nil", func(t *testing.T) {
 		// udc calldata:
 		classHash, _ := utils.HexToFelt("0x73d71c37e20c569186445d2c497d2195b4c0be9a255d72dbad86662fcc63ae6")
 		name, _ := utils.StringToByteArrFelt("My Test Token")
@@ -867,7 +867,7 @@ func TestDeployContractWithUDC(t *testing.T) {
 		assert.Equal(t, rpc.TxnFinalityStatusAcceptedOnL2, txReceipt.FinalityStatus)
 	})
 
-	t.Run("deploy contract with no constructor, udcOptions nil", func(t *testing.T) {
+	t.Run("UDCCairoV0, no constructor, udcOptions nil", func(t *testing.T) {
 		classHash, _ := utils.HexToFelt("0x0387edd4804deba7af741953fdf64189468f37593a66b618d00d2476be3168f8")
 
 		resp, err := accnt.DeployContractWithUDC(context.Background(), classHash, nil, nil, nil)
@@ -882,7 +882,7 @@ func TestDeployContractWithUDC(t *testing.T) {
 		assert.Equal(t, rpc.TxnFinalityStatusAcceptedOnL2, txReceipt.FinalityStatus)
 	})
 
-	t.Run("no constructor, UDCCairoV2, origin-dependent", func(t *testing.T) {
+	t.Run("UDCCairoV2, no constructor, origin-dependent", func(t *testing.T) {
 		classHash, _ := utils.HexToFelt("0x0387edd4804deba7af741953fdf64189468f37593a66b618d00d2476be3168f8")
 
 		resp, err := accnt.DeployContractWithUDC(context.Background(), classHash, nil, nil, &utils.UDCOptions{
@@ -899,12 +899,43 @@ func TestDeployContractWithUDC(t *testing.T) {
 		assert.Equal(t, rpc.TxnFinalityStatusAcceptedOnL2, txReceipt.FinalityStatus)
 	})
 
-	t.Run("no constructor, UDCCairoV2, origin-independent", func(t *testing.T) {
+	t.Run("UDCCairoV2, no constructor, origin-independent", func(t *testing.T) {
 		classHash, _ := utils.HexToFelt("0x0387edd4804deba7af741953fdf64189468f37593a66b618d00d2476be3168f8")
 
 		resp, err := accnt.DeployContractWithUDC(context.Background(), classHash, nil, nil, &utils.UDCOptions{
 			UDCVersion:        utils.UDCCairoV2,
 			OriginIndependent: true,
+		})
+		require.NoError(t, err, "DeployContractUDC failed")
+
+		t.Logf("Transaction hash: %s", resp.Hash)
+
+		txReceipt, err := accnt.WaitForTransactionReceipt(context.Background(), resp.Hash, time.Second)
+		require.NoError(t, err, "Waiting for tx receipt failed")
+
+		assert.Equal(t, rpc.TxnExecutionStatusSUCCEEDED, txReceipt.ExecutionStatus)
+		assert.Equal(t, rpc.TxnFinalityStatusAcceptedOnL2, txReceipt.FinalityStatus)
+	})
+
+	t.Run("UDCCairoV2, with constructor - ERC20, udcOptions nil", func(t *testing.T) {
+		// udc calldata:
+		classHash, _ := utils.HexToFelt("0x73d71c37e20c569186445d2c497d2195b4c0be9a255d72dbad86662fcc63ae6")
+		name, _ := utils.StringToByteArrFelt("My Test Token")
+		symbol, _ := utils.StringToByteArrFelt("MTT")
+		supply, _ := utils.HexToU256Felt("0x200000000000000000")
+		recipient := accnt.Address
+		owner := accnt.Address
+
+		// https://docs.openzeppelin.com/contracts-cairo/1.0.0/api/erc20#ERC20Upgradeable-constructor
+		constructorCalldata := make([]*felt.Felt, 0, 10)
+		constructorCalldata = append(constructorCalldata, name...)
+		constructorCalldata = append(constructorCalldata, symbol...)
+		constructorCalldata = append(constructorCalldata, supply...)
+		constructorCalldata = append(constructorCalldata, recipient)
+		constructorCalldata = append(constructorCalldata, owner)
+
+		resp, err := accnt.DeployContractWithUDC(context.Background(), classHash, constructorCalldata, nil, &utils.UDCOptions{
+			UDCVersion: utils.UDCCairoV2,
 		})
 		require.NoError(t, err, "DeployContractUDC failed")
 

--- a/account/transaction_test.go
+++ b/account/transaction_test.go
@@ -3,6 +3,7 @@ package account_test
 import (
 	"context"
 	"math/big"
+	"math/rand"
 	"testing"
 	"time"
 
@@ -811,4 +812,64 @@ func TestWaitForTransactionReceipt(t *testing.T) {
 			}
 		}()
 	}
+}
+
+
+func TestDeployContractUDC(t *testing.T) {
+	if testEnv != "testnet" {
+		t.Skip("This test is only for testnet")
+	}
+
+	// Hardcoded values
+	rpcProviderUrl := "https://rpc.starknet-testnet.lava.build:443"
+	accountAddress := "0x0575c24e48d311ed9bc4a3f1c9b582eff44998ebb52b52fe4c57600c732d8bc5"
+	publicKey := "0xdc2d920a58c7744a7f254441753d64b2484b0cff2d14aae2bc902fe3de6f7"
+	privateKey := "0x2bbabfb2505bce3fbe1898dfcf7a5579d55aea40ed8a5d06e19db90e4746aa4" 
+	accountCairoVersion := 2
+
+	client, err := rpc.NewProvider(rpcProviderUrl)
+	require.NoError(t, err, "Error dialing RPC provider")
+
+	accountAddressFelt, err := utils.HexToFelt(accountAddress)
+	require.NoError(t, err, "Invalid account address")
+
+	ks := account.NewMemKeystore()
+	privKeyBI, ok := new(big.Int).SetString(privateKey, 0)
+	require.True(t, ok, "Failed to convert private key to big.Int")
+	ks.Put(publicKey, privKeyBI)
+
+	accnt, err := account.NewAccount(client, accountAddressFelt, publicKey, ks, accountCairoVersion)
+	require.NoError(t, err, "Failed to create account")
+
+	classHash, err := utils.HexToFelt("0x73d71c37e20c569186445d2c497d2195b4c0be9a255d72dbad86662fcc63ae6")
+	require.NoError(t, err, "Invalid class hash")
+
+	salt := new(felt.Felt).SetUint64(rand.Uint64())
+
+	nameAsFelts, err := utils.StringToByteArrFelt("My Test Token")
+	require.NoError(t, err, "Failed converting name to felts")
+
+	symbolAsFelts, err := utils.StringToByteArrFelt("MTT")
+	require.NoError(t, err, "Failed converting symbol to felts")
+
+	recipient := accountAddressFelt
+
+	// Same as DeployContractUDC example
+	supply := new(big.Int).Exp(big.NewInt(10), big.NewInt(21), nil)
+	low := new(felt.Felt).SetBigInt(new(big.Int).And(supply, new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 128), big.NewInt(1))))
+	high := new(felt.Felt).SetBigInt(new(big.Int).Rsh(supply, 128))
+
+	constructorCalldata := append(nameAsFelts, symbolAsFelts...)
+	constructorCalldata = append(constructorCalldata, low, high, recipient, recipient)
+
+	resp, err := accnt.DeployContractUDC(context.Background(), classHash, salt, constructorCalldata, nil)
+	require.NoError(t, err, "DeployContractUDC failed")
+
+	t.Logf("Transaction hash: %s", resp.Hash)
+
+	txReceipt, err := accnt.WaitForTransactionReceipt(context.Background(), resp.Hash, 2*time.Second)
+	require.NoError(t, err, "Waiting for tx receipt failed")
+
+	assert.Equal(t, rpc.TxnExecutionStatusSUCCEEDED, txReceipt.ExecutionStatus)
+	assert.Equal(t, rpc.TxnFinalityStatusAcceptedOnL2, txReceipt.FinalityStatus)
 }

--- a/account/transaction_test.go
+++ b/account/transaction_test.go
@@ -3,7 +3,6 @@ package account_test
 import (
 	"context"
 	"math/big"
-	"math/rand"
 	"testing"
 	"time"
 
@@ -857,7 +856,7 @@ func TestDeployContractUDC(t *testing.T) {
 	classHash, err := utils.HexToFelt("0x73d71c37e20c569186445d2c497d2195b4c0be9a255d72dbad86662fcc63ae6")
 	require.NoError(t, err, "Invalid class hash")
 
-	salt := new(felt.Felt).SetUint64(rand.Uint64())
+	// salt := new(felt.Felt).SetUint64(rand.Uint64())
 
 	nameAsFelts, err := utils.StringToByteArrFelt("My Test Token")
 	require.NoError(t, err, "Failed converting name to felts")
@@ -875,7 +874,7 @@ func TestDeployContractUDC(t *testing.T) {
 	constructorCalldata := append(nameAsFelts, symbolAsFelts...)
 	constructorCalldata = append(constructorCalldata, low, high, recipient, recipient)
 
-	resp, err := accnt.DeployContractWithUDC(context.Background(), classHash, salt, constructorCalldata, nil)
+	resp, err := accnt.DeployContractWithUDC(context.Background(), classHash, constructorCalldata, nil, nil)
 	require.NoError(t, err, "DeployContractUDC failed")
 
 	t.Logf("Transaction hash: %s", resp.Hash)

--- a/account/transaction_test.go
+++ b/account/transaction_test.go
@@ -838,14 +838,14 @@ func TestDeployContractWithUDC(t *testing.T) {
 	accnt, err := setupAcc(t, provider)
 	require.NoError(t, err, "Error in setupAcc")
 
-	t.Run("deploy contract with constructor data - ERC20", func(t *testing.T) {
+	t.Run("deploy contract with constructor data - ERC20, udcOptions nil", func(t *testing.T) {
 		// udc calldata:
 		classHash, _ := utils.HexToFelt("0x73d71c37e20c569186445d2c497d2195b4c0be9a255d72dbad86662fcc63ae6")
 		name, _ := utils.StringToByteArrFelt("My Test Token")
 		symbol, _ := utils.StringToByteArrFelt("MTT")
+		supply, _ := utils.HexToU256Felt("0x200000000000000000")
 		recipient := accnt.Address
 		owner := accnt.Address
-		supply, _ := utils.HexToU256Felt("0x200000000000000000")
 
 		// https://docs.openzeppelin.com/contracts-cairo/1.0.0/api/erc20#ERC20Upgradeable-constructor
 		constructorCalldata := make([]*felt.Felt, 0, 10)
@@ -867,7 +867,7 @@ func TestDeployContractWithUDC(t *testing.T) {
 		assert.Equal(t, rpc.TxnFinalityStatusAcceptedOnL2, txReceipt.FinalityStatus)
 	})
 
-	t.Run("deploy contract with no constructor", func(t *testing.T) {
+	t.Run("deploy contract with no constructor, udcOptions nil", func(t *testing.T) {
 		classHash, _ := utils.HexToFelt("0x0387edd4804deba7af741953fdf64189468f37593a66b618d00d2476be3168f8")
 
 		resp, err := accnt.DeployContractWithUDC(context.Background(), classHash, nil, nil, nil)

--- a/account/transaction_test.go
+++ b/account/transaction_test.go
@@ -814,7 +814,6 @@ func TestWaitForTransactionReceipt(t *testing.T) {
 	}
 }
 
-
 func TestDeployContractUDC(t *testing.T) {
 	if testEnv != "testnet" {
 		t.Skip("This test is only for testnet")
@@ -824,8 +823,8 @@ func TestDeployContractUDC(t *testing.T) {
 	rpcProviderUrl := "https://rpc.starknet-testnet.lava.build:443"
 	accountAddress := "0x0575c24e48d311ed9bc4a3f1c9b582eff44998ebb52b52fe4c57600c732d8bc5"
 	publicKey := "0xdc2d920a58c7744a7f254441753d64b2484b0cff2d14aae2bc902fe3de6f7"
-	privateKey := "0x2bbabfb2505bce3fbe1898dfcf7a5579d55aea40ed8a5d06e19db90e4746aa4" 
-	accountCairoVersion := 2
+	privateKey := "0x2bbabfb2505bce3fbe1898dfcf7a5579d55aea40ed8a5d06e19db90e4746aa4"
+	accountCairoVersion := account.CairoV2
 
 	client, err := rpc.NewProvider(rpcProviderUrl)
 	require.NoError(t, err, "Error dialing RPC provider")

--- a/account/transaction_test.go
+++ b/account/transaction_test.go
@@ -838,32 +838,49 @@ func TestDeployContractWithUDC(t *testing.T) {
 	accnt, err := setupAcc(t, provider)
 	require.NoError(t, err, "Error in setupAcc")
 
-	// udc calldata:
-	classHash, _ := utils.HexToFelt("0x73d71c37e20c569186445d2c497d2195b4c0be9a255d72dbad86662fcc63ae6")
-	name, _ := utils.StringToByteArrFelt("My Test Token")
-	symbol, _ := utils.StringToByteArrFelt("MTT")
-	recipient := accnt.Address
-	owner := accnt.Address
-	supply, _ := utils.HexToU256Felt("0x200000000000000000")
+	t.Run("deploy contract with constructor data - ERC20", func(t *testing.T) {
+		// udc calldata:
+		classHash, _ := utils.HexToFelt("0x73d71c37e20c569186445d2c497d2195b4c0be9a255d72dbad86662fcc63ae6")
+		name, _ := utils.StringToByteArrFelt("My Test Token")
+		symbol, _ := utils.StringToByteArrFelt("MTT")
+		recipient := accnt.Address
+		owner := accnt.Address
+		supply, _ := utils.HexToU256Felt("0x200000000000000000")
 
-	// https://docs.openzeppelin.com/contracts-cairo/1.0.0/api/erc20#ERC20Upgradeable-constructor
-	constructorCalldata := make([]*felt.Felt, 0, 10)
-	constructorCalldata = append(constructorCalldata, name...)
-	constructorCalldata = append(constructorCalldata, symbol...)
-	constructorCalldata = append(constructorCalldata, supply...)
-	constructorCalldata = append(constructorCalldata, recipient)
-	constructorCalldata = append(constructorCalldata, owner)
+		// https://docs.openzeppelin.com/contracts-cairo/1.0.0/api/erc20#ERC20Upgradeable-constructor
+		constructorCalldata := make([]*felt.Felt, 0, 10)
+		constructorCalldata = append(constructorCalldata, name...)
+		constructorCalldata = append(constructorCalldata, symbol...)
+		constructorCalldata = append(constructorCalldata, supply...)
+		constructorCalldata = append(constructorCalldata, recipient)
+		constructorCalldata = append(constructorCalldata, owner)
 
-	resp, err := accnt.DeployContractWithUDC(context.Background(), classHash, constructorCalldata, nil, nil)
-	require.NoError(t, err, "DeployContractUDC failed")
+		resp, err := accnt.DeployContractWithUDC(context.Background(), classHash, constructorCalldata, nil, nil)
+		require.NoError(t, err, "DeployContractUDC failed")
 
-	t.Logf("Transaction hash: %s", resp.Hash)
+		t.Logf("Transaction hash: %s", resp.Hash)
 
-	txReceipt, err := accnt.WaitForTransactionReceipt(context.Background(), resp.Hash, time.Second)
-	require.NoError(t, err, "Waiting for tx receipt failed")
+		txReceipt, err := accnt.WaitForTransactionReceipt(context.Background(), resp.Hash, time.Second)
+		require.NoError(t, err, "Waiting for tx receipt failed")
 
-	assert.Equal(t, rpc.TxnExecutionStatusSUCCEEDED, txReceipt.ExecutionStatus)
-	assert.Equal(t, rpc.TxnFinalityStatusAcceptedOnL2, txReceipt.FinalityStatus)
+		assert.Equal(t, rpc.TxnExecutionStatusSUCCEEDED, txReceipt.ExecutionStatus)
+		assert.Equal(t, rpc.TxnFinalityStatusAcceptedOnL2, txReceipt.FinalityStatus)
+	})
+
+	t.Run("deploy contract with no constructor", func(t *testing.T) {
+		classHash, _ := utils.HexToFelt("0x0387edd4804deba7af741953fdf64189468f37593a66b618d00d2476be3168f8")
+
+		resp, err := accnt.DeployContractWithUDC(context.Background(), classHash, nil, nil, nil)
+		require.NoError(t, err, "DeployContractUDC failed")
+
+		t.Logf("Transaction hash: %s", resp.Hash)
+
+		txReceipt, err := accnt.WaitForTransactionReceipt(context.Background(), resp.Hash, time.Second)
+		require.NoError(t, err, "Waiting for tx receipt failed")
+
+		assert.Equal(t, rpc.TxnExecutionStatusSUCCEEDED, txReceipt.ExecutionStatus)
+		assert.Equal(t, rpc.TxnFinalityStatusAcceptedOnL2, txReceipt.FinalityStatus)
+	})
 }
 
 // TODO: add more tests for the BuildAnd* functions, testing each of them with different TxnOption's

--- a/account/txn_options.go
+++ b/account/txn_options.go
@@ -1,6 +1,12 @@
 package account
 
-import "github.com/NethermindEth/starknet.go/rpc"
+import (
+	"github.com/NethermindEth/starknet.go/rpc"
+)
+
+// The `TxnOptions` struct is equal to the `utils.TxnOptions` struct + some new fields.
+// Composition wasn't used to avoid the need to create a struct inside another struct
+// when building the options.
 
 // Optional settings for building/sending/estimating a transaction
 // in the BuildAndSend* account methods.

--- a/account/txn_options.go
+++ b/account/txn_options.go
@@ -13,6 +13,7 @@ import (
 // in the BuildAndSend* account methods.
 type TxnOptions struct {
 	// Tip amount in FRI for the transaction. Default: `"0x0"`.
+	// Note: only ready to be used after Starknet v0.14.0 upgrade.
 	Tip rpc.U64
 
 	// A boolean flag indicating whether the transaction version should have

--- a/account/txn_options.go
+++ b/account/txn_options.go
@@ -2,6 +2,7 @@ package account
 
 import (
 	"github.com/NethermindEth/starknet.go/rpc"
+	"github.com/NethermindEth/starknet.go/utils"
 )
 
 // The `TxnOptions` struct is equal to the `utils.TxnOptions` struct + some new fields.
@@ -68,3 +69,5 @@ func fmtTipAndMultiplier(opts *TxnOptions) {
 		opts.Tip = "0x0"
 	}
 }
+
+type UDCOptions = utils.UDCOptions

--- a/examples/README.md
+++ b/examples/README.md
@@ -17,8 +17,12 @@ To run an example:
 #### Some FAQ answered by these examples
 1. How to deploy an account? How to send a `DEPLOY_ACCOUNT_TXN`?  
   R: See [deployAccount](./deployAccount/main.go)
+1. How to use my existing account importing my account address, and public and private keys?  
+  R: See [deployContractUDC](./simpleDeclare/main.go), lines 47 and 61.
 1. How to declare a Cairo contract? How to send a `DECLARE_TXN`?  
   R: See [simpleDeclare](./simpleDeclare/main.go).
+1. How to deploy a smart contract using UDC?  
+  R: See [deployContractUDC](./deployContractUDC/main.go).
 1. How to interact with a deployed Cairo contract? How to send an `INVOKE_TXN`?  
   R: See [invoke](./invoke/main.go).
 1. How to make multiple function calls in the same transaction?  
@@ -27,12 +31,8 @@ To run an example:
   R: See [invoke](./invoke/verboseInvoke.go), line 67.
 1. How to generate random public and private keys?  
   R: See [deployAccount](./deployAccount/main.go), line 38.
-1. How to use my existing account importing my account address, and public and private keys?  
-  R: See [deployContractUDC](./deployContractUDC/main.go), lines 54 and 64.
 1. How to get my nonce?  
   R: See [invoke](./invoke/verboseInvoke.go), line 18.
-1. How to deploy a smart contract using UDC?  
-  R: See [deployContractUDC](./deployContractUDC/main.go).
 1. How to get the transaction receipt?  
   R: See [invoke](./invoke/verboseInvoke.go), line 89.
 1. How to deploy an ERC20 token?  

--- a/examples/deployContractUDC/README.md
+++ b/examples/deployContractUDC/README.md
@@ -9,4 +9,4 @@ Steps:
 1. Make sure you are in the "deployAccountUDC" directory
 1. Execute `go run main.go`
 
-The transaction hash and status will be returned at the end of the execution.
+The transaction hash, status, and the deployed contract address will be returned at the end of the execution.

--- a/examples/deployContractUDC/main.go
+++ b/examples/deployContractUDC/main.go
@@ -93,7 +93,7 @@ func main() {
 		recipient, // owner
 	)
 
-	resp, err := accnt.DeployContractUDC(context.Background(), classHash, salt, constructorCalldata, nil)
+	resp, err := accnt.DeployContractWithUDC(context.Background(), classHash, salt, constructorCalldata, nil)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/deployContractUDC/main.go
+++ b/examples/deployContractUDC/main.go
@@ -81,8 +81,7 @@ func main() {
 	constructorCalldata = append(constructorCalldata, name...)
 	constructorCalldata = append(constructorCalldata, symbol...)
 	constructorCalldata = append(constructorCalldata, supply...)
-	constructorCalldata = append(constructorCalldata, recipient)
-	constructorCalldata = append(constructorCalldata, owner)
+	constructorCalldata = append(constructorCalldata, recipient, owner)
 
 	// Deploy the contract with UDC
 	resp, salt, err := accnt.DeployContractWithUDC(context.Background(), erc20ContractHash, constructorCalldata, nil, nil)

--- a/examples/deployContractUDC/main.go
+++ b/examples/deployContractUDC/main.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"math/big"
-	"math/rand"
 	"time"
 
 	"github.com/NethermindEth/juno/core/felt"
@@ -66,8 +65,6 @@ func main() {
 		panic(err)
 	}
 
-	salt := new(felt.Felt).SetUint64(rand.Uint64()) // to prevent address clashes
-
 	// For modern contracts, strings are represented as `ByteArray` which serialize into multiple felts.
 	nameAsFelts, err := utils.StringToByteArrFelt("My Test Token")
 	if err != nil {
@@ -93,7 +90,7 @@ func main() {
 		recipient, // owner
 	)
 
-	resp, err := accnt.DeployContractWithUDC(context.Background(), classHash, salt, constructorCalldata, nil)
+	resp, err := accnt.DeployContractWithUDC(context.Background(), classHash, constructorCalldata, nil, nil)
 	if err != nil {
 		panic(err)
 	}

--- a/internal/utils/felt.go
+++ b/internal/utils/felt.go
@@ -136,6 +136,8 @@ func FeltArrToStringArr(f []*felt.Felt) []string {
 //
 // [article]: https://docs.starknet.io/architecture-and-concepts/smart-contracts/serialization-of-cairo-types/#serialization_of_byte_arrays
 func StringToByteArrFelt(s string) ([]*felt.Felt, error) {
+	// TODO: make this helper return no error
+
 	const SHORT_LENGTH = 31
 	exp := fmt.Sprintf(".{1,%d}", SHORT_LENGTH)
 	r := regexp.MustCompile(exp)

--- a/mocks/mock_account.go
+++ b/mocks/mock_account.go
@@ -91,6 +91,22 @@ func (mr *MockAccountInterfaceMockRecorder) BuildAndSendInvokeTxn(ctx, functionC
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildAndSendInvokeTxn", reflect.TypeOf((*MockAccountInterface)(nil).BuildAndSendInvokeTxn), ctx, functionCalls, opts)
 }
 
+// DeployContractWithUDC mocks base method.
+func (m *MockAccountInterface) DeployContractWithUDC(ctx context.Context, classHash *felt.Felt, constructorCalldata []*felt.Felt, txnOpts *account.TxnOptions, udcOpts *account.UDCOptions) (*rpc.AddInvokeTransactionResponse, *felt.Felt, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeployContractWithUDC", ctx, classHash, constructorCalldata, txnOpts, udcOpts)
+	ret0, _ := ret[0].(*rpc.AddInvokeTransactionResponse)
+	ret1, _ := ret[1].(*felt.Felt)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// DeployContractWithUDC indicates an expected call of DeployContractWithUDC.
+func (mr *MockAccountInterfaceMockRecorder) DeployContractWithUDC(ctx, classHash, constructorCalldata, txnOpts, udcOpts any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeployContractWithUDC", reflect.TypeOf((*MockAccountInterface)(nil).DeployContractWithUDC), ctx, classHash, constructorCalldata, txnOpts, udcOpts)
+}
+
 // Nonce mocks base method.
 func (m *MockAccountInterface) Nonce(ctx context.Context) (*felt.Felt, error) {
 	m.ctrl.T.Helper()
@@ -221,6 +237,21 @@ func (m *MockAccountInterface) TransactionHashInvoke(invokeTxn rpc.InvokeTxnType
 func (mr *MockAccountInterfaceMockRecorder) TransactionHashInvoke(invokeTxn any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TransactionHashInvoke", reflect.TypeOf((*MockAccountInterface)(nil).TransactionHashInvoke), invokeTxn)
+}
+
+// Verify mocks base method.
+func (m *MockAccountInterface) Verify(msgHash *felt.Felt, signature []*felt.Felt) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Verify", msgHash, signature)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Verify indicates an expected call of Verify.
+func (mr *MockAccountInterfaceMockRecorder) Verify(msgHash, signature any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Verify", reflect.TypeOf((*MockAccountInterface)(nil).Verify), msgHash, signature)
 }
 
 // WaitForTransactionReceipt mocks base method.

--- a/utils/transactions.go
+++ b/utils/transactions.go
@@ -24,6 +24,7 @@ const (
 // Optional settings when building a transaction.
 type TxnOptions struct {
 	// Tip amount in FRI for the transaction. Default: `"0x0"`.
+	// Note: only ready to be used after Starknet v0.14.0 upgrade.
 	Tip rpc.U64
 	// A boolean flag indicating whether the transaction version should have
 	// the query bit when estimating fees. If true, the transaction version

--- a/utils/transactions.go
+++ b/utils/transactions.go
@@ -13,11 +13,12 @@ import (
 	"github.com/NethermindEth/starknet.go/rpc"
 )
 
-var (
-	maxUint64                 uint64 = math.MaxUint64
-	maxUint128                       = "0xffffffffffffffffffffffffffffffff"
-	negativeResourceBoundsErr        = "resource bounds cannot be negative, got '%#x'"
-	invalidResourceBoundsErr         = "invalid resource bounds: '%v' is not a valid big.Int"
+const (
+	maxUint64  uint64 = math.MaxUint64
+	maxUint128        = "0xffffffffffffffffffffffffffffffff"
+
+	negativeResourceBoundsErr = "resource bounds cannot be negative, got '%#x'"
+	invalidResourceBoundsErr  = "invalid resource bounds: '%v' is not a valid big.Int"
 )
 
 // BuildInvokeTxn creates a new invoke transaction (v3) for the StarkNet network.

--- a/utils/udc.go
+++ b/utils/udc.go
@@ -57,15 +57,16 @@ const (
 //
 // Returns:
 //   - the INVOKE txn function call to deploy the contract, including the UDC address and the calldata
+//   - the salt used for the UDC deployment (either the provided one or the random one)
 //   - an error if any
 func BuildUDCCalldata(
 	classHash *felt.Felt,
 	constructorCalldata []*felt.Felt,
 	opts *UDCOptions,
-) (rpc.InvokeFunctionCall, error) {
+) (rpc.InvokeFunctionCall, *felt.Felt, error) {
 	result := rpc.InvokeFunctionCall{}
 	if classHash == nil {
-		return result, errClassHashNotProvided
+		return result, nil, errClassHashNotProvided
 	}
 
 	if opts == nil {
@@ -76,7 +77,7 @@ func BuildUDCCalldata(
 	if opts.Salt == nil {
 		randFelt, err := new(felt.Felt).SetRandom()
 		if err != nil {
-			return result, err
+			return result, nil, err
 		}
 		opts.Salt = randFelt
 	}
@@ -113,7 +114,7 @@ func BuildUDCCalldata(
 		udcAddress = udcAddressCairoV2
 		methodName = "deploy_contract"
 	default:
-		return result, errInvalidUDCVersion
+		return result, nil, errInvalidUDCVersion
 	}
 
 	result = rpc.InvokeFunctionCall{
@@ -122,7 +123,7 @@ func BuildUDCCalldata(
 		CallData:        udcCallData,
 	}
 
-	return result, nil
+	return result, opts.Salt, nil
 }
 
 func PrecomputeAddressForUDC(

--- a/utils/udc.go
+++ b/utils/udc.go
@@ -155,13 +155,6 @@ func PrecomputeAddressForUDC(
 	case UDCCairoV2:
 		hashedSalt = curve.Poseidon(originAccAddress, salt)
 		finalOriginAddress = udcAddressCairoV2
-
-		// The UDCCairoV2 `calldata` constructor parameter is of type `Span<felt>`, so if
-		// it is empty, we need to pass at least the length of the array, which is 0.
-		// ref: https://book.cairo-lang.org/ch102-04-serialization-of-cairo-types.html#serialization-of-arrays-and-spans
-		if len(constructorCalldata) == 0 {
-			constructorCalldata = []*felt.Felt{new(felt.Felt).SetUint64(0)}
-		}
 	default:
 		return nil
 	}

--- a/utils/udc.go
+++ b/utils/udc.go
@@ -1,0 +1,85 @@
+package utils
+
+import (
+	"errors"
+
+	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/starknet.go/rpc"
+)
+
+var (
+	// https://voyager.online/contract/0x041a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf
+	udcAddressCairoV0, _ = new(felt.Felt).SetString("0x041a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf")
+	// https://docs.openzeppelin.com/contracts-cairo/1.0.0/udc#udc_contract_address
+	udcAddressCairoV2, _ = new(felt.Felt).SetString("0x04a64cd09a853868621d94cae9952b106f2c36a3f81260f85de6696c6b050221")
+)
+
+// TODO: add docs
+type UDCOptions struct {
+	Salt       *felt.Felt
+	Unique     bool
+	UDCVersion UDCVersion
+}
+
+// TODO: add docs
+type UDCVersion int
+
+const (
+	UDCCairoV0 UDCVersion = iota
+	UDCCairoV2
+)
+
+// TODO: add docs
+func BuildUDCCalldata(
+	classHash *felt.Felt,
+	constructorCalldata []*felt.Felt,
+	deployOpts *UDCOptions,
+) (*rpc.InvokeFunctionCall, error) {
+	if classHash == nil {
+		return nil, errors.New("classHash not provided")
+	}
+
+	if deployOpts == nil {
+		deployOpts = new(UDCOptions)
+	}
+
+	// salt
+	if deployOpts.Salt == nil {
+		randFelt, err := new(felt.Felt).SetRandom()
+		if err != nil {
+			return nil, err
+		}
+		deployOpts.Salt = randFelt
+	}
+
+	// unique
+	uniqueFelt := new(felt.Felt).SetUint64(0)
+	if deployOpts.Unique {
+		uniqueFelt = new(felt.Felt).SetUint64(1)
+	}
+
+	// response
+	var udcCallData []*felt.Felt
+	var udcAddress *felt.Felt
+	var methodName string
+
+	switch deployOpts.UDCVersion {
+	case UDCCairoV0:
+		calldataLen := new(felt.Felt).SetUint64(uint64(len(constructorCalldata)))
+		udcCallData = append([]*felt.Felt{classHash, deployOpts.Salt, uniqueFelt, calldataLen}, constructorCalldata...)
+		udcAddress = udcAddressCairoV0
+		methodName = "deployContract"
+	case UDCCairoV2:
+		udcCallData = append([]*felt.Felt{classHash, deployOpts.Salt, uniqueFelt}, constructorCalldata...)
+		udcAddress = udcAddressCairoV2
+		methodName = "deploy_contract"
+	}
+
+	fnCall := rpc.InvokeFunctionCall{
+		ContractAddress: udcAddress,
+		FunctionName:    methodName,
+		CallData:        udcCallData,
+	}
+
+	return &fnCall, nil
+}

--- a/utils/udc.go
+++ b/utils/udc.go
@@ -153,7 +153,7 @@ func PrecomputeAddressForUDC(
 		hashedSalt = curve.Pedersen(originAccAddress, salt)
 		finalOriginAddress = udcAddressCairoV0
 	case UDCCairoV2:
-		hashedSalt = curve.Poseidon(originAccAddress, salt)
+		hashedSalt = curve.PoseidonArray(originAccAddress, salt)
 		finalOriginAddress = udcAddressCairoV2
 	default:
 		return nil

--- a/utils/udc.go
+++ b/utils/udc.go
@@ -9,6 +9,9 @@ import (
 	"github.com/NethermindEth/starknet.go/rpc"
 )
 
+// TODO: migrate this to contracts package (hard to do now due to circular imports errors,
+// a new types pkg would solve this)
+
 var (
 	// https://voyager.online/contract/0x041a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf
 	udcAddressCairoV0, _ = new(felt.Felt).SetString("0x041a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf")

--- a/utils/udc.go
+++ b/utils/udc.go
@@ -33,28 +33,28 @@ const (
 func BuildUDCCalldata(
 	classHash *felt.Felt,
 	constructorCalldata []*felt.Felt,
-	deployOpts *UDCOptions,
+	opts *UDCOptions,
 ) (*rpc.InvokeFunctionCall, error) {
 	if classHash == nil {
 		return nil, errors.New("classHash not provided")
 	}
 
-	if deployOpts == nil {
-		deployOpts = new(UDCOptions)
+	if opts == nil {
+		opts = new(UDCOptions)
 	}
 
 	// salt
-	if deployOpts.Salt == nil {
+	if opts.Salt == nil {
 		randFelt, err := new(felt.Felt).SetRandom()
 		if err != nil {
 			return nil, err
 		}
-		deployOpts.Salt = randFelt
+		opts.Salt = randFelt
 	}
 
 	// unique
 	uniqueFelt := new(felt.Felt).SetUint64(0)
-	if deployOpts.Unique {
+	if opts.Unique {
 		uniqueFelt = new(felt.Felt).SetUint64(1)
 	}
 
@@ -63,14 +63,14 @@ func BuildUDCCalldata(
 	var udcAddress *felt.Felt
 	var methodName string
 
-	switch deployOpts.UDCVersion {
+	switch opts.UDCVersion {
 	case UDCCairoV0:
 		calldataLen := new(felt.Felt).SetUint64(uint64(len(constructorCalldata)))
-		udcCallData = append([]*felt.Felt{classHash, deployOpts.Salt, uniqueFelt, calldataLen}, constructorCalldata...)
+		udcCallData = append([]*felt.Felt{classHash, opts.Salt, uniqueFelt, calldataLen}, constructorCalldata...)
 		udcAddress = udcAddressCairoV0
 		methodName = "deployContract"
 	case UDCCairoV2:
-		udcCallData = append([]*felt.Felt{classHash, deployOpts.Salt, uniqueFelt}, constructorCalldata...)
+		udcCallData = append([]*felt.Felt{classHash, opts.Salt, uniqueFelt}, constructorCalldata...)
 		udcAddress = udcAddressCairoV2
 		methodName = "deploy_contract"
 	}

--- a/utils/udc.go
+++ b/utils/udc.go
@@ -60,9 +60,10 @@ func BuildUDCCalldata(
 	classHash *felt.Felt,
 	constructorCalldata []*felt.Felt,
 	opts *UDCOptions,
-) (*rpc.InvokeFunctionCall, error) {
+) (rpc.InvokeFunctionCall, error) {
+	result := rpc.InvokeFunctionCall{}
 	if classHash == nil {
-		return nil, errClassHashNotProvided
+		return result, errClassHashNotProvided
 	}
 
 	if opts == nil {
@@ -73,7 +74,7 @@ func BuildUDCCalldata(
 	if opts.Salt == nil {
 		randFelt, err := new(felt.Felt).SetRandom()
 		if err != nil {
-			return nil, err
+			return result, err
 		}
 		opts.Salt = randFelt
 	}
@@ -105,14 +106,14 @@ func BuildUDCCalldata(
 		udcAddress = udcAddressCairoV2
 		methodName = "deploy_contract"
 	default:
-		return nil, errInvalidUDCVersion
+		return result, errInvalidUDCVersion
 	}
 
-	fnCall := rpc.InvokeFunctionCall{
+	result = rpc.InvokeFunctionCall{
 		ContractAddress: udcAddress,
 		FunctionName:    methodName,
 		CallData:        udcCallData,
 	}
 
-	return &fnCall, nil
+	return result, nil
 }

--- a/utils/udc.go
+++ b/utils/udc.go
@@ -102,6 +102,13 @@ func BuildUDCCalldata(
 			originIndFelt.SetUint64(1)
 		}
 
+		if constructorCalldata == nil {
+			// The UDCCairoV2 `calldata` constructor parameter is of type `Span<felt>`, so if
+			// it is empty, we need to pass at least the length of the array, which is 0.
+			// ref: https://book.cairo-lang.org/ch102-04-serialization-of-cairo-types.html#serialization-of-arrays-and-spans
+			constructorCalldata = []*felt.Felt{new(felt.Felt).SetUint64(0)}
+		}
+
 		udcCallData = append([]*felt.Felt{classHash, opts.Salt, originIndFelt}, constructorCalldata...)
 		udcAddress = udcAddressCairoV2
 		methodName = "deploy_contract"

--- a/utils/udc.go
+++ b/utils/udc.go
@@ -126,6 +126,18 @@ func BuildUDCCalldata(
 	return result, opts.Salt, nil
 }
 
+// Precomputes the address for a UDC deployment.
+//
+// Parameters:
+//   - classHash: the class hash of the contract to deploy
+//   - salt: the salt to be used for the UDC deployment
+//   - constructorCalldata: the calldata to pass to the constructor of the contract
+//   - UDCVersion: the UDC version to be used
+//   - originAccAddress: the address of the account that will deploy the contract. It
+//     must be `nil` if `OriginIndependent` is `true`.
+//
+// Returns:
+//   - the precomputed address for the UDC deployment
 func PrecomputeAddressForUDC(
 	classHash *felt.Felt,
 	salt *felt.Felt,

--- a/utils/udc.go
+++ b/utils/udc.go
@@ -23,6 +23,8 @@ var (
 )
 
 // The options for building the UDC calldata
+//
+//nolint:lll
 type UDCOptions struct {
 	// The salt to be used for the UDC deployment. If not provided, a random value will be used.
 	Salt *felt.Felt
@@ -67,7 +69,7 @@ func BuildUDCCalldata(
 	constructorCalldata []*felt.Felt,
 	opts *UDCOptions,
 ) (rpc.InvokeFunctionCall, *felt.Felt, error) {
-	result := rpc.InvokeFunctionCall{}
+	result := rpc.InvokeFunctionCall{} //nolint:exhaustruct
 	if classHash == nil {
 		return result, nil, errClassHashNotProvided
 	}
@@ -135,7 +137,7 @@ func BuildUDCCalldata(
 //   - classHash: the class hash of the contract to deploy
 //   - salt: the salt to be used for the UDC deployment
 //   - constructorCalldata: the calldata to pass to the constructor of the contract
-//   - UDCVersion: the UDC version to be used
+//   - udcVersion: the UDC version to be used
 //   - originAccAddress: the address of the account that will deploy the contract. It
 //     must be `nil` if `OriginIndependent` is `true`.
 //
@@ -145,7 +147,7 @@ func PrecomputeAddressForUDC(
 	classHash *felt.Felt,
 	salt *felt.Felt,
 	constructorCalldata []*felt.Felt,
-	UDCVersion UDCVersion,
+	udcVersion UDCVersion,
 	originAccAddress *felt.Felt,
 ) *felt.Felt {
 	// Origin-independent deployments (deployed from zero)
@@ -162,7 +164,7 @@ func PrecomputeAddressForUDC(
 	var hashedSalt *felt.Felt
 	var finalOriginAddress *felt.Felt
 
-	switch UDCVersion {
+	switch udcVersion {
 	case UDCCairoV0:
 		hashedSalt = curve.Pedersen(originAccAddress, salt)
 		finalOriginAddress = udcAddressCairoV0

--- a/utils/udc.go
+++ b/utils/udc.go
@@ -14,22 +14,42 @@ var (
 	udcAddressCairoV2, _ = new(felt.Felt).SetString("0x04a64cd09a853868621d94cae9952b106f2c36a3f81260f85de6696c6b050221")
 )
 
-// TODO: add docs
+// The options for building the UDC calldata
 type UDCOptions struct {
-	Salt       *felt.Felt
-	Unique     bool
+	// The salt to be used for the UDC deployment. Default: a random value.
+	Salt *felt.Felt
+	// This parameter is used to determine if the deployer’s address will be included in the contract address calculation.
+	// Default: the address will be included.
+	// It behaves differently depending on the UDC version:
+	//   - UDCCairoV0: true to include the deployer’s address in the contract address calculation, false to exclude it
+	// See more at: https://github.com/starknet-io/starknet-docs/blob/aa1772da8eb42dbc8e6b26ebc37cf898c207f54e/components/Starknet/modules/architecture_and_concepts/pages/Smart_Contracts/universal-deployer.adoc#deployment-types
+	//   - UDCCairoV2: behaves as `from_zero`. True to NOT include the deployer’s address in the contract address calculation, false to include it
+	// See more at: https://docs.openzeppelin.com/contracts-cairo/1.0.0/udc#deployment_types
+	Unique bool
+	// The UDC version to be used. Default: UDCCairoV0.
 	UDCVersion UDCVersion
 }
 
-// TODO: add docs
+// Enum representing the UDC version to be used
 type UDCVersion int
 
 const (
+	// Represents the UDC version with Cairo v0 code, with the address 0x041a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf
 	UDCCairoV0 UDCVersion = iota
+	// Represents the UDC version with Cairo v2 code, with the address 0x04a64cd09a853868621d94cae9952b106f2c36a3f81260f85de6696c6b050221
 	UDCCairoV2
 )
 
-// TODO: add docs
+// Builds the INVOKE txn function call to deploy a contract using the UDC.
+//
+// Parameters:
+//   - classHash: the class hash of the contract to deploy
+//   - constructorCalldata: the calldata to pass to the constructor of the contract
+//   - opts: the options for the UDC deployment. If nil, the default options will be used.
+//
+// Returns:
+//   - the INVOKE txn function call to deploy the contract, including the UDC address and the calldata
+//   - an error if any
 func BuildUDCCalldata(
 	classHash *felt.Felt,
 	constructorCalldata []*felt.Felt,
@@ -73,6 +93,8 @@ func BuildUDCCalldata(
 		udcCallData = append([]*felt.Felt{classHash, opts.Salt, uniqueFelt}, constructorCalldata...)
 		udcAddress = udcAddressCairoV2
 		methodName = "deploy_contract"
+	default:
+		return nil, errors.New("invalid UDC version")
 	}
 
 	fnCall := rpc.InvokeFunctionCall{

--- a/utils/udc.go
+++ b/utils/udc.go
@@ -12,6 +12,9 @@ var (
 	udcAddressCairoV0, _ = new(felt.Felt).SetString("0x041a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf")
 	// https://docs.openzeppelin.com/contracts-cairo/1.0.0/udc#udc_contract_address
 	udcAddressCairoV2, _ = new(felt.Felt).SetString("0x04a64cd09a853868621d94cae9952b106f2c36a3f81260f85de6696c6b050221")
+
+	errInvalidUDCVersion    = errors.New("invalid UDC version")
+	errClassHashNotProvided = errors.New("classHash not provided")
 )
 
 // The options for building the UDC calldata
@@ -59,7 +62,7 @@ func BuildUDCCalldata(
 	opts *UDCOptions,
 ) (*rpc.InvokeFunctionCall, error) {
 	if classHash == nil {
-		return nil, errors.New("classHash not provided")
+		return nil, errClassHashNotProvided
 	}
 
 	if opts == nil {
@@ -102,7 +105,7 @@ func BuildUDCCalldata(
 		udcAddress = udcAddressCairoV2
 		methodName = "deploy_contract"
 	default:
-		return nil, errors.New("invalid UDC version")
+		return nil, errInvalidUDCVersion
 	}
 
 	fnCall := rpc.InvokeFunctionCall{

--- a/utils/udc.go
+++ b/utils/udc.go
@@ -104,12 +104,10 @@ func BuildUDCCalldata(
 			originIndFelt.SetUint64(1)
 		}
 
-		if constructorCalldata == nil {
-			// The UDCCairoV2 `calldata` constructor parameter is of type `Span<felt>`, so if
-			// it is empty, we need to pass at least the length of the array, which is 0.
-			// ref: https://book.cairo-lang.org/ch102-04-serialization-of-cairo-types.html#serialization-of-arrays-and-spans
-			constructorCalldata = []*felt.Felt{new(felt.Felt).SetUint64(0)}
-		}
+		// The UDCCairoV2 `calldata` constructor parameter is of type `Span<felt>`, so
+		// we need to pass the length of the array as the first element.
+		// ref: https://book.cairo-lang.org/ch102-04-serialization-of-cairo-types.html#serialization-of-arrays-and-spans
+		constructorCalldata = append([]*felt.Felt{new(felt.Felt).SetUint64(uint64(len(constructorCalldata)))}, constructorCalldata...)
 
 		udcCallData = append([]*felt.Felt{classHash, opts.Salt, originIndFelt}, constructorCalldata...)
 		udcAddress = udcAddressCairoV2

--- a/utils/udc_test.go
+++ b/utils/udc_test.go
@@ -323,7 +323,7 @@ func TestPrecomputeAddressForUDC(t *testing.T) {
 
 	tests := []TestSet{
 		{ //https://sepolia.voyager.online/tx/0x36f1ae1379dcea5e14938f6e9b5189d5ddb34e8b2eff404d5886e7a7e1ebb48
-			name:             "UDCCairoV0: Origin-independent 0x486002",
+			name:             "UDCCairoV0: Origin-independent 0x36f1ae",
 			originAccAddress: nil,
 			classHash:        internalUtils.TestHexToFelt(t, "0x486002e9e1d1fd7f07852663c0e476853e68c1aaa6afaeaa58cce954e3cf7cf"),
 			salt:             internalUtils.TestHexToFelt(t, "0x23fcbf2e9a467d3081182b138fc605f8743610c4327edf4f24104f478143f66"),
@@ -334,7 +334,7 @@ func TestPrecomputeAddressForUDC(t *testing.T) {
 			expectedAddress: internalUtils.TestHexToFelt(t, "0x77a249aefd797d3ce41ec9d434c26ca7fe929a6ec3458bcec97cc456741fa3f"),
 		},
 		{ //https://sepolia.voyager.online/tx/0x3c79058b1a7a8904d4a5ade66ae87a1dcec6a568a5193a9f95f5c9646d383f3
-			name:             "UDCCairoV0: Origin-independent 0x54328a",
+			name:             "UDCCairoV0: Origin-independent 0x3c7905",
 			originAccAddress: nil,
 			classHash:        internalUtils.TestHexToFelt(t, "0x54328a1075b8820eb43caf0caa233923148c983742402dcfc38541dd843d01a"),
 			salt:             internalUtils.TestHexToFelt(t, "0x52a06f2789d5229e87d5d0dc0d933d0e1e83366306ae069192ca9a3e4e6881f"),
@@ -347,7 +347,7 @@ func TestPrecomputeAddressForUDC(t *testing.T) {
 			expectedAddress: internalUtils.TestHexToFelt(t, "0x48634f9843983eeb06b47bf7f5d156a55a1d297e958da1c86427f9ce077425b"),
 		},
 		{ //https://sepolia.voyager.online/tx/0x4dadb8b32b286acd11ee6698a71206f274f1cf93fdf602f6fcf2d376c197ca4
-			name:             "UDCCairoV0: Origin-dependent 0x54328a",
+			name:             "UDCCairoV0: Origin-dependent 0x4dadb8",
 			originAccAddress: internalUtils.TestHexToFelt(t, "0x000f9e998b2853e6d01f3ae3c598c754c1b9a7bd398fec7657de022f3b778679"),
 			classHash:        internalUtils.TestHexToFelt(t, "0x54328a1075b8820eb43caf0caa233923148c983742402dcfc38541dd843d01a"),
 			salt:             internalUtils.TestHexToFelt(t, "0xb2334ec640982eb272cbfa72f4f9d32769e77166460c620ac950c8a4d94606"),
@@ -360,7 +360,7 @@ func TestPrecomputeAddressForUDC(t *testing.T) {
 			expectedAddress: internalUtils.TestHexToFelt(t, "0x770f3b98c5a23250bc237dbeeb0a9385621f99c04a1fe3842d899264f4a1268"),
 		},
 		{ //https://sepolia.voyager.online/tx/0x17ffdf141abc5e5db10b7ec0f69a5f099e70390c0844e281cdd7877c7c98a54
-			name:                "UDCCairoV0: Origin-dependent 0x387edd",
+			name:                "UDCCairoV0: Origin-dependent 0x17ffdf",
 			originAccAddress:    internalUtils.TestHexToFelt(t, "0x02d54b7dc47eafa80f8e451cf39e7601f51fef6f1bfe5cea44ff12fa563e5457"),
 			classHash:           internalUtils.TestHexToFelt(t, "0x387edd4804deba7af741953fdf64189468f37593a66b618d00d2476be3168f8"),
 			salt:                internalUtils.TestHexToFelt(t, "0x18809706355007129cd38d1719447f454b7ff081c38817c53d9e2951d185243"),
@@ -369,7 +369,7 @@ func TestPrecomputeAddressForUDC(t *testing.T) {
 			expectedAddress:     internalUtils.TestHexToFelt(t, "0x43267890ad2798db4a6a5374ee361cb6f3669facad58e9e58ea88c078c567bb"),
 		},
 		{ //https://sepolia.voyager.online/tx/0x1683dd3917260a8b1572cf703b1525ea9bd6501cd76a4c20d6e4aa316ddff86
-			name:                "UDCCairoV2: Origin-independent 0x387edd",
+			name:                "UDCCairoV2: Origin-independent 0x1683dd",
 			originAccAddress:    nil,
 			classHash:           internalUtils.TestHexToFelt(t, "0x387edd4804deba7af741953fdf64189468f37593a66b618d00d2476be3168f8"),
 			salt:                internalUtils.TestHexToFelt(t, "0x357f0d6bf3f6931e6a0d579ec8936510dad2dbabb8593a3dda16c4cd8fe3dc6"),
@@ -378,7 +378,7 @@ func TestPrecomputeAddressForUDC(t *testing.T) {
 			expectedAddress:     internalUtils.TestHexToFelt(t, "0x2543d193907205cff1ba8818002fb0b7477493e093c7ea605516a21e838648e"),
 		},
 		{ //https://sepolia.voyager.online/tx/0x5c76c4f41451f64276571d5f225ab203e9de19d1749372e548a6c5e5df775af
-			name:                "UDCCairoV2: Origin-dependent 0x387edd",
+			name:                "UDCCairoV2: Origin-dependent 0x5c76c4",
 			originAccAddress:    internalUtils.TestHexToFelt(t, "0x02d54b7dc47eafa80f8e451cf39e7601f51fef6f1bfe5cea44ff12fa563e5457"),
 			classHash:           internalUtils.TestHexToFelt(t, "0x387edd4804deba7af741953fdf64189468f37593a66b618d00d2476be3168f8"),
 			salt:                internalUtils.TestHexToFelt(t, "0x35fd26c7a05d64130bb27636931282cd1fbc19930933c97974d15028771ab72"),
@@ -387,7 +387,7 @@ func TestPrecomputeAddressForUDC(t *testing.T) {
 			expectedAddress:     internalUtils.TestHexToFelt(t, "0x6493b4567665272ef04b30d57abe07a51b5f2c7862eb1f02a84e633ae2f12c7"),
 		},
 		{ //https://sepolia.voyager.online/tx/0x337566e293faf471c13f249c91e72d574d207e16974f46eb96ea056eca272d5
-			name:                "UDCCairoV2: Origin-dependent 0x387edd",
+			name:                "UDCCairoV2: Origin-dependent 0x337566",
 			originAccAddress:    internalUtils.TestHexToFelt(t, "0x02d54b7dc47eafa80f8e451cf39e7601f51fef6f1bfe5cea44ff12fa563e5457"),
 			classHash:           internalUtils.TestHexToFelt(t, "0x387edd4804deba7af741953fdf64189468f37593a66b618d00d2476be3168f8"),
 			salt:                internalUtils.TestHexToFelt(t, "0xe70e5c84498d9c52430ca8bb8e9a89b0804dbb91efe1da91e36b88ff3a2508"),

--- a/utils/udc_test.go
+++ b/utils/udc_test.go
@@ -386,6 +386,15 @@ func TestPrecomputeAddressForUDC(t *testing.T) {
 			udcVersion:          UDCCairoV2,
 			expectedAddress:     internalUtils.TestHexToFelt(t, "0x6493b4567665272ef04b30d57abe07a51b5f2c7862eb1f02a84e633ae2f12c7"),
 		},
+		{ //https://sepolia.voyager.online/tx/0x337566e293faf471c13f249c91e72d574d207e16974f46eb96ea056eca272d5
+			name:                "UDCCairoV2: Origin-dependent 0x387edd",
+			originAccAddress:    internalUtils.TestHexToFelt(t, "0x02d54b7dc47eafa80f8e451cf39e7601f51fef6f1bfe5cea44ff12fa563e5457"),
+			classHash:           internalUtils.TestHexToFelt(t, "0x387edd4804deba7af741953fdf64189468f37593a66b618d00d2476be3168f8"),
+			salt:                internalUtils.TestHexToFelt(t, "0xe70e5c84498d9c52430ca8bb8e9a89b0804dbb91efe1da91e36b88ff3a2508"),
+			constructorCalldata: []*felt.Felt{},
+			udcVersion:          UDCCairoV2,
+			expectedAddress:     internalUtils.TestHexToFelt(t, "0x1899a818fea0c0ab6c3d6e078757f082610f0ccd5ce51a1ca5746d09c7828f3"),
+		},
 	}
 
 	for _, test := range tests {

--- a/utils/udc_test.go
+++ b/utils/udc_test.go
@@ -158,12 +158,26 @@ func checkCallDataContents(t *testing.T, result *rpc.InvokeFunctionCall, classHa
 	}
 
 	// Check the rest based on UDC version
-	if opts != nil && opts.UDCVersion == UDCCairoV0 {
+	if opts != nil && opts.UDCVersion == UDCCairoV2 {
+		// Cairo V2: [classHash, salt, originInd, ...constructorCalldata]
+		originInd := callData[2]
+		expectedOriginInd := new(felt.Felt).SetUint64(0)
+		if opts.OriginIndependent {
+			expectedOriginInd.SetUint64(1)
+		}
+		assert.Equal(t, expectedOriginInd, originInd)
 
+		// Check constructor calldata
+		constructorStart := 3
+		for i, expected := range constructorCalldata {
+			assert.Equal(t, expected, callData[constructorStart+i])
+		}
+
+	} else {
 		// Cairo V0: [classHash, salt, originInd, calldataLen, ...constructorCalldata]
 		originInd := callData[2]
 		expectedOriginInd := new(felt.Felt).SetUint64(1)
-		if opts.OriginIndependent {
+		if opts != nil && opts.OriginIndependent {
 			expectedOriginInd.SetUint64(0)
 		}
 		assert.Equal(t, expectedOriginInd, originInd)
@@ -175,20 +189,6 @@ func checkCallDataContents(t *testing.T, result *rpc.InvokeFunctionCall, classHa
 
 		// Check constructor calldata
 		constructorStart := 4
-		for i, expected := range constructorCalldata {
-			assert.Equal(t, expected, callData[constructorStart+i])
-		}
-	} else {
-		// Cairo V2: [classHash, salt, originInd, ...constructorCalldata]
-		originInd := callData[2]
-		expectedOriginInd := new(felt.Felt).SetUint64(0)
-		if opts.OriginIndependent {
-			expectedOriginInd.SetUint64(1)
-		}
-		assert.Equal(t, expectedOriginInd, originInd)
-
-		// Check constructor calldata
-		constructorStart := 3
 		for i, expected := range constructorCalldata {
 			assert.Equal(t, expected, callData[constructorStart+i])
 		}

--- a/utils/udc_test.go
+++ b/utils/udc_test.go
@@ -140,7 +140,7 @@ func TestBuildUDCCalldata(t *testing.T) {
 	}
 }
 
-func checkCallDataContents(t *testing.T, result *rpc.InvokeFunctionCall, classHash *felt.Felt, constructorCalldata []*felt.Felt, opts *UDCOptions) {
+func checkCallDataContents(t *testing.T, result rpc.InvokeFunctionCall, classHash *felt.Felt, constructorCalldata []*felt.Felt, opts *UDCOptions) {
 	t.Helper()
 	callData := result.CallData
 	require.NotEmpty(t, callData)

--- a/utils/udc_test.go
+++ b/utils/udc_test.go
@@ -1,0 +1,309 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/NethermindEth/juno/core/felt"
+	internalUtils "github.com/NethermindEth/starknet.go/internal/utils"
+	"github.com/NethermindEth/starknet.go/rpc"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildUDCCalldata(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name                  string
+		classHash             *felt.Felt
+		constructorCalldata   []*felt.Felt
+		opts                  *UDCOptions
+		expectedUDCAddress    *felt.Felt
+		expectedFunctionName  string
+		expectedCallDataLen   int
+		expectedError         string
+		checkCallDataContents bool
+	}{
+		{
+			name:                  "UDC Cairo V0 with default options",
+			classHash:             internalUtils.RANDOM_FELT,
+			constructorCalldata:   []*felt.Felt{new(felt.Felt).SetUint64(100), new(felt.Felt).SetUint64(200)},
+			opts:                  nil,
+			expectedUDCAddress:    udcAddressCairoV0,
+			expectedFunctionName:  "deployContract",
+			expectedCallDataLen:   6, // classHash + salt + originInd + calldataLen + 2 constructor args
+			checkCallDataContents: true,
+		},
+		{
+			name:                  "UDC Cairo V0 with custom salt",
+			classHash:             internalUtils.RANDOM_FELT,
+			constructorCalldata:   []*felt.Felt{new(felt.Felt).SetUint64(100)},
+			opts:                  &UDCOptions{Salt: new(felt.Felt).SetUint64(999)},
+			expectedUDCAddress:    udcAddressCairoV0,
+			expectedFunctionName:  "deployContract",
+			expectedCallDataLen:   5, // classHash + salt + originInd + calldataLen + 1 constructor arg
+			checkCallDataContents: true,
+		},
+		{
+			name:                  "UDC Cairo V0 with origin independent",
+			classHash:             internalUtils.RANDOM_FELT,
+			constructorCalldata:   []*felt.Felt{},
+			opts:                  &UDCOptions{OriginIndependent: true},
+			expectedUDCAddress:    udcAddressCairoV0,
+			expectedFunctionName:  "deployContract",
+			expectedCallDataLen:   4, // classHash + salt + originInd + calldataLen
+			checkCallDataContents: true,
+		},
+		{
+			name:                  "UDC Cairo V2 with default options",
+			classHash:             internalUtils.RANDOM_FELT,
+			constructorCalldata:   []*felt.Felt{new(felt.Felt).SetUint64(100), new(felt.Felt).SetUint64(200)},
+			opts:                  &UDCOptions{UDCVersion: UDCCairoV2},
+			expectedUDCAddress:    udcAddressCairoV2,
+			expectedFunctionName:  "deploy_contract",
+			expectedCallDataLen:   5, // classHash + salt + originInd + 2 constructor args
+			checkCallDataContents: true,
+		},
+		{
+			name:                  "UDC Cairo V2 with origin independent",
+			classHash:             internalUtils.RANDOM_FELT,
+			constructorCalldata:   []*felt.Felt{new(felt.Felt).SetUint64(100)},
+			opts:                  &UDCOptions{UDCVersion: UDCCairoV2, OriginIndependent: true},
+			expectedUDCAddress:    udcAddressCairoV2,
+			expectedFunctionName:  "deploy_contract",
+			expectedCallDataLen:   4, // classHash + salt + originInd + 1 constructor arg
+			checkCallDataContents: true,
+		},
+		{
+			name:                  "UDC Cairo V2 with custom salt and origin independent",
+			classHash:             internalUtils.RANDOM_FELT,
+			constructorCalldata:   []*felt.Felt{},
+			opts:                  &UDCOptions{UDCVersion: UDCCairoV2, Salt: new(felt.Felt).SetUint64(888), OriginIndependent: true},
+			expectedUDCAddress:    udcAddressCairoV2,
+			expectedFunctionName:  "deploy_contract",
+			expectedCallDataLen:   3, // classHash + salt + originInd
+			checkCallDataContents: true,
+		},
+		{
+			name:                  "Empty constructor calldata",
+			classHash:             internalUtils.RANDOM_FELT,
+			constructorCalldata:   []*felt.Felt{},
+			opts:                  nil,
+			expectedUDCAddress:    udcAddressCairoV0,
+			expectedFunctionName:  "deployContract",
+			expectedCallDataLen:   4, // classHash + salt + originInd + calldataLen
+			checkCallDataContents: true,
+		},
+		{
+			name:                "Nil classHash",
+			classHash:           nil,
+			constructorCalldata: []*felt.Felt{new(felt.Felt).SetUint64(100)},
+			opts:                nil,
+			expectedError:       "classHash not provided",
+		},
+		{
+			name:                "Invalid UDC version",
+			classHash:           internalUtils.RANDOM_FELT,
+			constructorCalldata: []*felt.Felt{new(felt.Felt).SetUint64(100)},
+			opts:                &UDCOptions{UDCVersion: 999}, // Invalid version
+			expectedError:       "invalid UDC version",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result, err := BuildUDCCalldata(tt.classHash, tt.constructorCalldata, tt.opts)
+
+			if tt.expectedError != "" {
+				require.Error(t, err)
+				assert.Equal(t, tt.expectedError, err.Error())
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+
+			// Check UDC address
+			assert.Equal(t, tt.expectedUDCAddress, result.ContractAddress)
+
+			// Check function name
+			assert.Equal(t, tt.expectedFunctionName, result.FunctionName)
+
+			// Check call data length
+			assert.Equal(t, tt.expectedCallDataLen, len(result.CallData))
+
+			// Check call data contents if requested
+			if tt.checkCallDataContents {
+				checkCallDataContents(t, result, tt.classHash, tt.constructorCalldata, tt.opts)
+			}
+		})
+	}
+}
+
+func checkCallDataContents(t *testing.T, result *rpc.InvokeFunctionCall, classHash *felt.Felt, constructorCalldata []*felt.Felt, opts *UDCOptions) {
+	t.Helper()
+	callData := result.CallData
+	require.NotEmpty(t, callData)
+
+	// First element should always be the class hash
+	assert.Equal(t, classHash, callData[0])
+
+	// Second element should be the salt (either provided or random)
+	require.NotNil(t, callData[1])
+	if opts != nil && opts.Salt != nil {
+		assert.Equal(t, opts.Salt, callData[1])
+	} else {
+		// If no salt provided, it should be a random value (not zero)
+		assert.NotEqual(t, &felt.Zero, callData[1])
+	}
+
+	// Check the rest based on UDC version
+	if opts != nil && opts.UDCVersion == UDCCairoV0 {
+
+		// Cairo V0: [classHash, salt, originInd, calldataLen, ...constructorCalldata]
+		originInd := callData[2]
+		expectedOriginInd := new(felt.Felt).SetUint64(1)
+		if opts != nil && opts.OriginIndependent {
+			expectedOriginInd.SetUint64(0)
+		}
+		assert.Equal(t, expectedOriginInd, originInd)
+
+		// Check calldata length
+		calldataLen := callData[3]
+		expectedCalldataLen := new(felt.Felt).SetUint64(uint64(len(constructorCalldata)))
+		assert.Equal(t, expectedCalldataLen, calldataLen)
+
+		// Check constructor calldata
+		constructorStart := 4
+		for i, expected := range constructorCalldata {
+			assert.Equal(t, expected, callData[constructorStart+i])
+		}
+	} else {
+		// Cairo V2: [classHash, salt, originInd, ...constructorCalldata]
+		originInd := callData[2]
+		expectedOriginInd := new(felt.Felt).SetUint64(0)
+		if opts.OriginIndependent {
+			expectedOriginInd.SetUint64(1)
+		}
+		assert.Equal(t, expectedOriginInd, originInd)
+
+		// Check constructor calldata
+		constructorStart := 3
+		for i, expected := range constructorCalldata {
+			assert.Equal(t, expected, callData[constructorStart+i])
+		}
+	}
+}
+
+func TestBuildUDCCalldata_UDCAddresses(t *testing.T) {
+	t.Parallel()
+	// Test that the UDC addresses are correctly set
+	classHash := new(felt.Felt).SetUint64(12345)
+	constructorCalldata := []*felt.Felt{new(felt.Felt).SetUint64(100)}
+
+	// Test Cairo V0 address
+	result, err := BuildUDCCalldata(classHash, constructorCalldata, &UDCOptions{UDCVersion: UDCCairoV0})
+	require.NoError(t, err)
+	assert.Equal(t, udcAddressCairoV0, result.ContractAddress)
+
+	// Test Cairo V2 address
+	result, err = BuildUDCCalldata(classHash, constructorCalldata, &UDCOptions{UDCVersion: UDCCairoV2})
+	require.NoError(t, err)
+	assert.Equal(t, udcAddressCairoV2, result.ContractAddress)
+}
+
+func TestBuildUDCCalldata_OriginIndependent(t *testing.T) {
+	t.Parallel()
+	classHash := new(felt.Felt).SetUint64(12345)
+	constructorCalldata := []*felt.Felt{new(felt.Felt).SetUint64(100)}
+
+	// **** Test Cairo V0 ****
+	// origin independent
+	result, err := BuildUDCCalldata(classHash, constructorCalldata, &UDCOptions{UDCVersion: UDCCairoV0, OriginIndependent: true})
+	require.NoError(t, err)
+	// Cairo V0: `unique` should be 0 (false) when OriginIndependent is true
+	assert.Equal(t, new(felt.Felt).SetUint64(0), result.CallData[2])
+
+	// not origin independent
+	result, err = BuildUDCCalldata(classHash, constructorCalldata, &UDCOptions{UDCVersion: UDCCairoV0, OriginIndependent: false})
+	require.NoError(t, err)
+	// Cairo V0: `unique` should be 1 (true) when OriginIndependent is false
+	assert.Equal(t, new(felt.Felt).SetUint64(1), result.CallData[2])
+
+	// **** Test Cairo V2 ****
+	// origin independent
+	result, err = BuildUDCCalldata(classHash, constructorCalldata, &UDCOptions{UDCVersion: UDCCairoV2, OriginIndependent: true})
+	require.NoError(t, err)
+	// Cairo V2: `from_zero` should be 1 (true) when OriginIndependent is true
+	assert.Equal(t, new(felt.Felt).SetUint64(1), result.CallData[2])
+
+	// not origin independent
+	result, err = BuildUDCCalldata(classHash, constructorCalldata, &UDCOptions{UDCVersion: UDCCairoV2, OriginIndependent: false})
+	require.NoError(t, err)
+	// Cairo V2: `from_zero` should be 0 (false) when OriginIndependent is false
+	assert.Equal(t, new(felt.Felt).SetUint64(0), result.CallData[2])
+}
+
+func TestBuildUDCCalldata_Salt(t *testing.T) {
+	t.Parallel()
+	t.Run("Random salt", func(t *testing.T) {
+		t.Parallel()
+		classHash := new(felt.Felt).SetUint64(12345)
+		constructorCalldata := []*felt.Felt{new(felt.Felt).SetUint64(100)}
+
+		// Test that when no salt is provided, a random salt is generated
+		result1, err := BuildUDCCalldata(classHash, constructorCalldata, nil)
+		require.NoError(t, err)
+
+		result2, err := BuildUDCCalldata(classHash, constructorCalldata, nil)
+		require.NoError(t, err)
+
+		// The salts should be different (random)
+		assert.NotEqual(t, result1.CallData[1], result2.CallData[1])
+
+		// The salts should not be zero
+		assert.NotEqual(t, &felt.Zero, result1.CallData[1])
+		assert.NotEqual(t, &felt.Zero, result2.CallData[1])
+	})
+
+	t.Run("Custom salt", func(t *testing.T) {
+		t.Parallel()
+		classHash := new(felt.Felt).SetUint64(12345)
+		constructorCalldata := []*felt.Felt{new(felt.Felt).SetUint64(100)}
+		customSalt := new(felt.Felt).SetUint64(999)
+
+		// Test that when a custom salt is provided, it's used
+		result, err := BuildUDCCalldata(classHash, constructorCalldata, &UDCOptions{Salt: customSalt})
+		require.NoError(t, err)
+
+		assert.Equal(t, customSalt, result.CallData[1])
+	})
+}
+
+func TestBuildUDCCalldata_LargeConstructorCalldata(t *testing.T) {
+	t.Parallel()
+	classHash := new(felt.Felt).SetUint64(12345)
+
+	// Create a large constructor calldata
+	largeCalldata := make([]*felt.Felt, 100)
+	for i := range largeCalldata {
+		largeCalldata[i] = new(felt.Felt).SetUint64(uint64(i))
+	}
+
+	result, err := BuildUDCCalldata(classHash, largeCalldata, &UDCOptions{UDCVersion: UDCCairoV0})
+	require.NoError(t, err)
+
+	// Check that all constructor calldata is included
+	expectedLen := 4 + len(largeCalldata) // classHash + salt + originInd + calldataLen + constructor args
+	assert.Equal(t, expectedLen, len(result.CallData))
+
+	// Check calldata length field
+	calldataLen := result.CallData[3]
+	expectedCalldataLen := new(felt.Felt).SetUint64(uint64(len(largeCalldata)))
+	assert.Equal(t, expectedCalldataLen, calldataLen)
+
+	// Check that all constructor arguments are present
+	for i, expected := range largeCalldata {
+		assert.Equal(t, expected, result.CallData[4+i])
+	}
+}

--- a/utils/udc_test.go
+++ b/utils/udc_test.go
@@ -117,6 +117,7 @@ func TestBuildUDCCalldata(t *testing.T) {
 			if tt.expectedError != nil {
 				require.Error(t, err)
 				assert.Equal(t, tt.expectedError, err)
+
 				return
 			}
 
@@ -140,7 +141,13 @@ func TestBuildUDCCalldata(t *testing.T) {
 	}
 }
 
-func checkCallDataContents(t *testing.T, result rpc.InvokeFunctionCall, classHash *felt.Felt, constructorCalldata []*felt.Felt, opts *UDCOptions) {
+func checkCallDataContents(
+	t *testing.T,
+	result rpc.InvokeFunctionCall,
+	classHash *felt.Felt,
+	constructorCalldata []*felt.Felt,
+	opts *UDCOptions,
+) {
 	t.Helper()
 	callData := result.CallData
 	require.NotEmpty(t, callData)
@@ -316,7 +323,7 @@ func TestPrecomputeAddressForUDC(t *testing.T) {
 	}
 
 	tests := []TestSet{
-		{ //https://sepolia.voyager.online/tx/0x36f1ae1379dcea5e14938f6e9b5189d5ddb34e8b2eff404d5886e7a7e1ebb48
+		{ // https://sepolia.voyager.online/tx/0x36f1ae1379dcea5e14938f6e9b5189d5ddb34e8b2eff404d5886e7a7e1ebb48
 			name:             "UDCCairoV0: Origin-independent 0x36f1ae",
 			originAccAddress: nil,
 			classHash:        internalUtils.TestHexToFelt(t, "0x486002e9e1d1fd7f07852663c0e476853e68c1aaa6afaeaa58cce954e3cf7cf"),
@@ -327,7 +334,7 @@ func TestPrecomputeAddressForUDC(t *testing.T) {
 			udcVersion:      UDCCairoV0,
 			expectedAddress: internalUtils.TestHexToFelt(t, "0x77a249aefd797d3ce41ec9d434c26ca7fe929a6ec3458bcec97cc456741fa3f"),
 		},
-		{ //https://sepolia.voyager.online/tx/0x3c79058b1a7a8904d4a5ade66ae87a1dcec6a568a5193a9f95f5c9646d383f3
+		{ // https://sepolia.voyager.online/tx/0x3c79058b1a7a8904d4a5ade66ae87a1dcec6a568a5193a9f95f5c9646d383f3
 			name:             "UDCCairoV0: Origin-independent 0x3c7905",
 			originAccAddress: nil,
 			classHash:        internalUtils.TestHexToFelt(t, "0x54328a1075b8820eb43caf0caa233923148c983742402dcfc38541dd843d01a"),
@@ -340,7 +347,7 @@ func TestPrecomputeAddressForUDC(t *testing.T) {
 			udcVersion:      UDCCairoV0,
 			expectedAddress: internalUtils.TestHexToFelt(t, "0x48634f9843983eeb06b47bf7f5d156a55a1d297e958da1c86427f9ce077425b"),
 		},
-		{ //https://sepolia.voyager.online/tx/0x4dadb8b32b286acd11ee6698a71206f274f1cf93fdf602f6fcf2d376c197ca4
+		{ // https://sepolia.voyager.online/tx/0x4dadb8b32b286acd11ee6698a71206f274f1cf93fdf602f6fcf2d376c197ca4
 			name:             "UDCCairoV0: Origin-dependent 0x4dadb8",
 			originAccAddress: internalUtils.TestHexToFelt(t, "0x000f9e998b2853e6d01f3ae3c598c754c1b9a7bd398fec7657de022f3b778679"),
 			classHash:        internalUtils.TestHexToFelt(t, "0x54328a1075b8820eb43caf0caa233923148c983742402dcfc38541dd843d01a"),
@@ -353,7 +360,7 @@ func TestPrecomputeAddressForUDC(t *testing.T) {
 			udcVersion:      UDCCairoV0,
 			expectedAddress: internalUtils.TestHexToFelt(t, "0x770f3b98c5a23250bc237dbeeb0a9385621f99c04a1fe3842d899264f4a1268"),
 		},
-		{ //https://sepolia.voyager.online/tx/0x17ffdf141abc5e5db10b7ec0f69a5f099e70390c0844e281cdd7877c7c98a54
+		{ // https://sepolia.voyager.online/tx/0x17ffdf141abc5e5db10b7ec0f69a5f099e70390c0844e281cdd7877c7c98a54
 			name:                "UDCCairoV0: Origin-dependent 0x17ffdf",
 			originAccAddress:    internalUtils.TestHexToFelt(t, "0x02d54b7dc47eafa80f8e451cf39e7601f51fef6f1bfe5cea44ff12fa563e5457"),
 			classHash:           internalUtils.TestHexToFelt(t, "0x387edd4804deba7af741953fdf64189468f37593a66b618d00d2476be3168f8"),
@@ -362,7 +369,7 @@ func TestPrecomputeAddressForUDC(t *testing.T) {
 			udcVersion:          UDCCairoV0,
 			expectedAddress:     internalUtils.TestHexToFelt(t, "0x43267890ad2798db4a6a5374ee361cb6f3669facad58e9e58ea88c078c567bb"),
 		},
-		{ //https://sepolia.voyager.online/tx/0x1683dd3917260a8b1572cf703b1525ea9bd6501cd76a4c20d6e4aa316ddff86
+		{ // https://sepolia.voyager.online/tx/0x1683dd3917260a8b1572cf703b1525ea9bd6501cd76a4c20d6e4aa316ddff86
 			name:                "UDCCairoV2: Origin-independent 0x1683dd",
 			originAccAddress:    nil,
 			classHash:           internalUtils.TestHexToFelt(t, "0x387edd4804deba7af741953fdf64189468f37593a66b618d00d2476be3168f8"),
@@ -371,7 +378,7 @@ func TestPrecomputeAddressForUDC(t *testing.T) {
 			udcVersion:          UDCCairoV2,
 			expectedAddress:     internalUtils.TestHexToFelt(t, "0x2543d193907205cff1ba8818002fb0b7477493e093c7ea605516a21e838648e"),
 		},
-		{ //https://sepolia.voyager.online/tx/0x5c76c4f41451f64276571d5f225ab203e9de19d1749372e548a6c5e5df775af
+		{ // https://sepolia.voyager.online/tx/0x5c76c4f41451f64276571d5f225ab203e9de19d1749372e548a6c5e5df775af
 			name:                "UDCCairoV2: Origin-dependent 0x5c76c4",
 			originAccAddress:    internalUtils.TestHexToFelt(t, "0x02d54b7dc47eafa80f8e451cf39e7601f51fef6f1bfe5cea44ff12fa563e5457"),
 			classHash:           internalUtils.TestHexToFelt(t, "0x387edd4804deba7af741953fdf64189468f37593a66b618d00d2476be3168f8"),
@@ -380,7 +387,7 @@ func TestPrecomputeAddressForUDC(t *testing.T) {
 			udcVersion:          UDCCairoV2,
 			expectedAddress:     internalUtils.TestHexToFelt(t, "0x6493b4567665272ef04b30d57abe07a51b5f2c7862eb1f02a84e633ae2f12c7"),
 		},
-		{ //https://sepolia.voyager.online/tx/0x337566e293faf471c13f249c91e72d574d207e16974f46eb96ea056eca272d5
+		{ // https://sepolia.voyager.online/tx/0x337566e293faf471c13f249c91e72d574d207e16974f46eb96ea056eca272d5
 			name:                "UDCCairoV2: Origin-dependent 0x337566",
 			originAccAddress:    internalUtils.TestHexToFelt(t, "0x02d54b7dc47eafa80f8e451cf39e7601f51fef6f1bfe5cea44ff12fa563e5457"),
 			classHash:           internalUtils.TestHexToFelt(t, "0x387edd4804deba7af741953fdf64189468f37593a66b618d00d2476be3168f8"),

--- a/utils/udc_test.go
+++ b/utils/udc_test.go
@@ -368,6 +368,15 @@ func TestPrecomputeAddressForUDC(t *testing.T) {
 			udcVersion:          UDCCairoV0,
 			expectedAddress:     internalUtils.TestHexToFelt(t, "0x43267890ad2798db4a6a5374ee361cb6f3669facad58e9e58ea88c078c567bb"),
 		},
+		{ //https://sepolia.voyager.online/tx/0x1683dd3917260a8b1572cf703b1525ea9bd6501cd76a4c20d6e4aa316ddff86
+			name:                "UDCCairoV2: Origin-independent 0x387edd",
+			originAccAddress:    nil,
+			classHash:           internalUtils.TestHexToFelt(t, "0x387edd4804deba7af741953fdf64189468f37593a66b618d00d2476be3168f8"),
+			salt:                internalUtils.TestHexToFelt(t, "0x357f0d6bf3f6931e6a0d579ec8936510dad2dbabb8593a3dda16c4cd8fe3dc6"),
+			constructorCalldata: []*felt.Felt{},
+			udcVersion:          UDCCairoV2,
+			expectedAddress:     internalUtils.TestHexToFelt(t, "0x2543d193907205cff1ba8818002fb0b7477493e093c7ea605516a21e838648e"),
+		},
 		{ //https://sepolia.voyager.online/tx/0x5c76c4f41451f64276571d5f225ab203e9de19d1749372e548a6c5e5df775af
 			name:                "UDCCairoV2: Origin-dependent 0x387edd",
 			originAccAddress:    internalUtils.TestHexToFelt(t, "0x02d54b7dc47eafa80f8e451cf39e7601f51fef6f1bfe5cea44ff12fa563e5457"),


### PR DESCRIPTION
Addresses issue #381. 
Derived from https://github.com/NethermindEth/starknet.go/pull/752.

Account:
  - `DeployContractWithUDC` method for deploying contracts using the Universal Deployer Contract (UDC)

Utils:
  - `BuildUDCCalldata` function to build calldata for UDC contract deployments
  - `PrecomputeAddressForUDC` function to compute contract addresses deployed with UDC
  - `UDCOptions` type and `UDCVersion` enum for configuring UDC deployments

Also:
- Edited `examples/deployContractUDC/main.go` to use DeployContractWithUDC
- Added tests




