### PR TITLE
feat: add EventWith utility and method to filter events (issue #765)

### DIFF
--- a/rpc/events.go
+++ b/rpc/events.go
@@ -2,6 +2,8 @@ package rpc
 
 import (
 	"context"
+
+	internalutils "github.com/NethermindEth/starknet.go/internal/utils"
 )
 
 // Events retrieves events from the provider matching the given filter.
@@ -22,4 +24,20 @@ func (provider *Provider) Events(ctx context.Context, input EventsInput) (*Event
 	}
 
 	return &result, nil
+}
+
+func EventWith(events []Event, key string) *Event {
+	feltKey, err := internalutils.HexToFelt(key)
+	if err != nil {
+		return nil
+	}
+
+	for i := range events {
+		for _, k := range events[i].Keys {
+			if k.Equal(feltKey) {
+				return &events[i]
+			}
+		}
+	}
+	return nil
 }

--- a/rpc/events_test.go
+++ b/rpc/events_test.go
@@ -142,3 +142,41 @@ func TestEvents(t *testing.T) {
 		require.Exactly(t, test.expectedResp.Events[0], events.Events[0], "Events mismatch")
 	}
 }
+
+func TestEventWith(t *testing.T) {
+	key := "0xabc"
+	feltKey := internalUtils.TestHexToFelt(t, key)
+
+	events := []Event{
+		{
+			EventContent: EventContent{
+				Keys: []*felt.Felt{feltKey},
+			},
+		},
+	}
+
+	found := EventWith(events, key)
+	require.NotNil(t, found, "Expected to find event")
+	require.True(t, found.Keys[0].Equal(feltKey), "Expected matching key")
+}
+
+func TestTransactionReceiptWithBlockInfo_EventWith(t *testing.T) {
+	key := "0xdead"
+	feltKey := internalUtils.TestHexToFelt(t, key)
+
+	receipt := &TransactionReceiptWithBlockInfo{
+		TransactionReceipt: TransactionReceipt{
+			Events: []Event{
+				{
+					EventContent: EventContent{
+						Keys: []*felt.Felt{feltKey},
+					},
+				},
+			},
+		},
+	}
+
+	found := receipt.EventWith(key)
+	require.NotNil(t, found, "Expected to find event from receipt method")
+	require.True(t, found.Keys[0].Equal(feltKey), "Expected matching key in receipt method")
+}

--- a/rpc/types_transaction_receipt.go
+++ b/rpc/types_transaction_receipt.go
@@ -205,3 +205,9 @@ func (tr *TransactionReceiptWithBlockInfo) UnmarshalJSON(data []byte) error {
 
 	return nil
 }
+
+// EventWith finds the first event in the transaction receipt that has a specific key.
+// The key is provided as a hex string. If no event is found, it returns nil.
+func (tr *TransactionReceiptWithBlockInfo) EventWith(key string) *Event {
+	return EventWith(tr.Events, key)
+}


### PR DESCRIPTION
## Feat: Add Utility for Filtering Events by Key

This pull request introduces a utility function and an associated method for filtering transaction events by key, addressing [#765](https://github.com/NethermindEth/starknet.go/issues/765).

---

### What’s New

- `EventWith(events []Event, key string) *Event`:  
  A new function added to `rpc/events.go` that scans a slice of events and returns the first event containing a matching key.

- `(*TransactionReceiptWithBlockInfo).EventWith(key string) *Event`:  
  A method added to the `TransactionReceiptWithBlockInfo` struct that internally uses `EventWith(...)` to return the first matching event in its `Events` field.

---

### Changes Made

- Added `EventWith` function to `rpc/events.go` with key-to-`felt` conversion using `internal/utils.HexToFelt`.
- Added `EventWith` method to `TransactionReceiptWithBlockInfo` in `rpc/types_transaction_receipt.go`.
- Wrote unit tests in `rpc/events_test.go` to verify both function and method correctness.

---

### ✅ Verification

- ✅ All tests passed successfully
- ✅ Unit tests written for both the utility function and method.
- ✅ Compatible with existing receipt logic, no breaking changes.

To verify:

 ```bash
  go test ./...