### PR TITLE
Remove global `curve.g1Affline` variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 -->
 
+### Removed
+- `curve.g1Affline` variable, use new instances of `starkcurve.G1Affine` instead. It was causing bugs in the tests when running in parallel.
+
 ### Dev updates
 - Renamed account/tests, rpc/tests, contracts/tests, hash/tests, and typedData/tests folders to testData
 - Migrate internal/test.go file to the new internal/tests pkg

--- a/curve/curve.go
+++ b/curve/curve.go
@@ -65,7 +65,7 @@ func VerifyFelts(msgHash, r, s, pubX *felt.Felt) (bool, error) {
 //   - s: The s component of the signature
 //   - error: An error if any occurred during the signing process
 func Sign(msgHash, privKey *big.Int) (r, s *big.Int, err error) {
-	g1Affline := starkcurve.G1Affine{}
+	g1Affline := starkcurve.G1Affine{} //nolint:exhaustruct // just a struct initialization
 	// generating pub and priv key types from the 'privKey' parameter
 	g1a := g1Affline.ScalarMultiplicationBase(privKey)
 
@@ -133,7 +133,7 @@ func GetRandomKeys() (privKey, x, y *big.Int, err error) {
 //   - x: The x-coordinate of the point on the curve
 //   - y: The y-coordinate of the point on the curve
 func PrivateKeyToPoint(privKey *big.Int) (x, y *big.Int) {
-	g1Affline := starkcurve.G1Affine{}
+	g1Affline := starkcurve.G1Affine{} //nolint:exhaustruct // just a struct initialization
 	res := g1Affline.ScalarMultiplicationBase(privKey)
 
 	return res.X.BigInt(new(big.Int)), res.Y.BigInt(new(big.Int))

--- a/curve/curve.go
+++ b/curve/curve.go
@@ -14,8 +14,6 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/stark-curve/fp"
 )
 
-var g1Affline starkcurve.G1Affine
-
 // Verify verifies the validity of the signature for a given message hash using the StarkCurve.
 //
 // Parameters:
@@ -67,6 +65,7 @@ func VerifyFelts(msgHash, r, s, pubX *felt.Felt) (bool, error) {
 //   - s: The s component of the signature
 //   - error: An error if any occurred during the signing process
 func Sign(msgHash, privKey *big.Int) (r, s *big.Int, err error) {
+	g1Affline := starkcurve.G1Affine{}
 	// generating pub and priv key types from the 'privKey' parameter
 	g1a := g1Affline.ScalarMultiplicationBase(privKey)
 
@@ -134,6 +133,7 @@ func GetRandomKeys() (privKey, x, y *big.Int, err error) {
 //   - x: The x-coordinate of the point on the curve
 //   - y: The y-coordinate of the point on the curve
 func PrivateKeyToPoint(privKey *big.Int) (x, y *big.Int) {
+	g1Affline := starkcurve.G1Affine{}
 	res := g1Affline.ScalarMultiplicationBase(privKey)
 
 	return res.X.BigInt(new(big.Int)), res.Y.BigInt(new(big.Int))

--- a/curve/curve_test.go
+++ b/curve/curve_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/NethermindEth/juno/core/felt"
 	internalUtils "github.com/NethermindEth/starknet.go/internal/utils"
+	starkcurve "github.com/consensys/gnark-crypto/ecc/stark-curve"
 	"github.com/consensys/gnark-crypto/ecc/stark-curve/ecdsa"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -152,6 +153,7 @@ func TestPrivateKeyEndToEnd(t *testing.T) {
 
 				privK := internalUtils.HexToBN(test.privK)
 
+				g1Affline := starkcurve.G1Affine{}
 				g1a := g1Affline.ScalarMultiplicationBase(privK)
 
 				// ****** asserts whether a public key returned by the 'ecdsa.PublicKey' struct is


### PR DESCRIPTION
It was causing bugs in the tests when running in parallel, so it's better to remove this var and let users use new instances of the `starkcurve.G1Affine` type.