### PR TITLE
Fix: `starknet_syncing` method and test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 -->
 
+### Fixed
+- `rpc.Syncing` was crashing when the node response was that it was syncing.
+
+### Changed
+- `rpc.Syncing` method now returns a `rpc.SyncStatus` struct instead of a pointer to it.
+- `rpc.SyncStatus` type: `StartingBlockNum`, `HighestBlockNum` and `CurrentBlockNum` are now of type `uint64` instead of `NumAsHex`
+- `rpc.SyncStatus` type: `SyncStatus` field was renamed to `IsSyncing`
+
 ### Removed
-- `curve.g1Affline` variable, use new instances of `starkcurve.G1Affine` instead. It was causing bugs in the tests when running in parallel.
+- `curve.g1Affline` variable, users should use new instances of `starkcurve.G1Affine` instead. It was causing bugs in the tests when running in parallel.
 
 ### Dev updates
 - Renamed account/tests, rpc/tests, contracts/tests, hash/tests, and typedData/tests folders to testData

--- a/mocks/mock_rpc_provider.go
+++ b/mocks/mock_rpc_provider.go
@@ -435,10 +435,10 @@ func (mr *MockRpcProviderMockRecorder) StorageAt(ctx, contractAddress, key, bloc
 }
 
 // Syncing mocks base method.
-func (m *MockRpcProvider) Syncing(ctx context.Context) (*rpc.SyncStatus, error) {
+func (m *MockRpcProvider) Syncing(ctx context.Context) (rpc.SyncStatus, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Syncing", ctx)
-	ret0, _ := ret[0].(*rpc.SyncStatus)
+	ret0, _ := ret[0].(rpc.SyncStatus)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/rpc/chain.go
+++ b/rpc/chain.go
@@ -35,18 +35,11 @@ func (provider *Provider) ChainID(ctx context.Context) (string, error) {
 // Returns:
 //   - *SyncStatus: The synchronisation status
 //   - error: An error if any occurred during the execution
-func (provider *Provider) Syncing(ctx context.Context) (*SyncStatus, error) {
-	var result interface{}
+func (provider *Provider) Syncing(ctx context.Context) (SyncStatus, error) {
+	var result SyncStatus
+	if err := do(ctx, provider.c, "starknet_syncing", &result); err != nil {
+		return SyncStatus{}, tryUnwrapToRPCErr(err)
+	}
 
-	if err := provider.c.CallContextWithSliceArgs(ctx, &result, "starknet_syncing"); err != nil {
-		return nil, Err(InternalError, StringErrData(err.Error()))
-	}
-	switch res := result.(type) {
-	case bool:
-		return &SyncStatus{SyncStatus: &res}, nil //nolint:exhaustruct
-	case SyncStatus:
-		return &res, nil
-	default:
-		return nil, Err(InternalError, StringErrData("internal error with starknet_syncing"))
-	}
+	return result, nil
 }

--- a/rpc/chain_test.go
+++ b/rpc/chain_test.go
@@ -82,11 +82,11 @@ func TestSyncing(t *testing.T) {
 		if tests.TEST_ENV == tests.MockEnv {
 			value := SyncStatus{
 				StartingBlockHash: internalUtils.RANDOM_FELT,
-				StartingBlockNum:  "0x4c602",
+				StartingBlockNum:  1234,
 				CurrentBlockHash:  internalUtils.RANDOM_FELT,
-				CurrentBlockNum:   "0x4c727",
+				CurrentBlockNum:   1234,
 				HighestBlockHash:  internalUtils.RANDOM_FELT,
-				HighestBlockNum:   "0x4c727",
+				HighestBlockNum:   1234,
 			}
 			require.Exactly(t, &value, sync)
 

--- a/rpc/chain_test.go
+++ b/rpc/chain_test.go
@@ -81,6 +81,7 @@ func TestSyncing(t *testing.T) {
 
 		if tests.TEST_ENV == tests.MockEnv {
 			value := SyncStatus{
+				IsSyncing:         true,
 				StartingBlockHash: internalUtils.RANDOM_FELT,
 				StartingBlockNum:  1234,
 				CurrentBlockHash:  internalUtils.RANDOM_FELT,
@@ -88,7 +89,7 @@ func TestSyncing(t *testing.T) {
 				HighestBlockHash:  internalUtils.RANDOM_FELT,
 				HighestBlockNum:   1234,
 			}
-			require.Exactly(t, &value, sync)
+			require.Exactly(t, value, sync)
 
 			continue
 		}

--- a/rpc/chain_test.go
+++ b/rpc/chain_test.go
@@ -93,7 +93,7 @@ func TestSyncing(t *testing.T) {
 			continue
 		}
 
-		if sync.SyncStatus == nil {
+		if sync.IsSyncing {
 			require.True(
 				t,
 				strings.HasPrefix(sync.CurrentBlockHash.String(), "0x"),
@@ -106,7 +106,7 @@ func TestSyncing(t *testing.T) {
 			require.NotZero(t, sync.HighestBlockHash)
 			require.NotZero(t, sync.HighestBlockNum)
 		} else {
-			require.False(t, *sync.SyncStatus)
+			require.False(t, sync.IsSyncing)
 			require.Zero(t, sync.StartingBlockHash)
 			require.Zero(t, sync.StartingBlockNum)
 			require.Zero(t, sync.CurrentBlockHash)

--- a/rpc/mock_test.go
+++ b/rpc/mock_test.go
@@ -226,7 +226,7 @@ func mock_starknet_chainId(result interface{}, args ...interface{}) error {
 //   - error: an error if there is a wrong type or wrong number of arguments
 func mock_starknet_syncing(result interface{}, args ...interface{}) error {
 	// Note: Since starknet_syncing returns with bool or SyncStatus, we pass in interface{}
-	r, ok := result.(*interface{})
+	r, ok := result.(*json.RawMessage)
 	if !ok {
 		return errWrongType
 	}
@@ -235,6 +235,7 @@ func mock_starknet_syncing(result interface{}, args ...interface{}) error {
 	}
 
 	value := SyncStatus{
+		IsSyncing:         true,
 		StartingBlockHash: internalUtils.RANDOM_FELT,
 		StartingBlockNum:  1234,
 		CurrentBlockHash:  internalUtils.RANDOM_FELT,
@@ -242,9 +243,13 @@ func mock_starknet_syncing(result interface{}, args ...interface{}) error {
 		HighestBlockHash:  internalUtils.RANDOM_FELT,
 		HighestBlockNum:   1234,
 	}
-	*r = value
 
-	return nil
+	resp, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+
+	return json.Unmarshal(resp, r)
 }
 
 // mock_starknet_getTransactionByBlockIdAndIndex is a function that mocks the behaviour of getting

--- a/rpc/mock_test.go
+++ b/rpc/mock_test.go
@@ -236,11 +236,11 @@ func mock_starknet_syncing(result interface{}, args ...interface{}) error {
 
 	value := SyncStatus{
 		StartingBlockHash: internalUtils.RANDOM_FELT,
-		StartingBlockNum:  "0x4c602",
+		StartingBlockNum:  1234,
 		CurrentBlockHash:  internalUtils.RANDOM_FELT,
-		CurrentBlockNum:   "0x4c727",
+		CurrentBlockNum:   1234,
 		HighestBlockHash:  internalUtils.RANDOM_FELT,
-		HighestBlockNum:   "0x4c727",
+		HighestBlockNum:   1234,
 	}
 	*r = value
 

--- a/rpc/provider.go
+++ b/rpc/provider.go
@@ -136,7 +136,7 @@ type RpcProvider interface {
 	StateUpdate(ctx context.Context, blockID BlockID) (*StateUpdateOutput, error)
 	StorageAt(ctx context.Context, contractAddress *felt.Felt, key string, blockID BlockID) (string, error)
 	SpecVersion(ctx context.Context) (string, error)
-	Syncing(ctx context.Context) (*SyncStatus, error)
+	Syncing(ctx context.Context) (SyncStatus, error)
 	TraceBlockTransactions(ctx context.Context, blockID BlockID) ([]Trace, error)
 	TransactionByBlockIdAndIndex(ctx context.Context, blockID BlockID, index uint64) (*BlockTransaction, error)
 	TransactionByHash(ctx context.Context, hash *felt.Felt) (*BlockTransaction, error)

--- a/rpc/types.go
+++ b/rpc/types.go
@@ -99,7 +99,7 @@ type PendingStateUpdate struct {
 
 // SyncStatus is An object describing the node synchronisation status
 type SyncStatus struct {
-	SyncStatus        *bool
+	IsSyncing         bool
 	StartingBlockHash *felt.Felt `json:"starting_block_hash,omitempty"`
 	StartingBlockNum  NumAsHex   `json:"starting_block_num,omitempty"`
 	CurrentBlockHash  *felt.Felt `json:"current_block_hash,omitempty"`
@@ -124,7 +124,7 @@ type SyncStatus struct {
 //
 //nolint:gocritic
 func (s SyncStatus) MarshalJSON() ([]byte, error) {
-	if !*s.SyncStatus {
+	if !s.IsSyncing {
 		return []byte("false"), nil
 	}
 	output := map[string]interface{}{}
@@ -149,7 +149,7 @@ func (s SyncStatus) MarshalJSON() ([]byte, error) {
 func (s *SyncStatus) UnmarshalJSON(data []byte) error {
 	var b bool
 	if string(data) == "false" {
-		s.SyncStatus = &b
+		s.IsSyncing = b
 
 		return nil
 	}
@@ -163,7 +163,7 @@ func (s *SyncStatus) UnmarshalJSON(data []byte) error {
 	}
 
 	*s = SyncStatus(result)
-	s.SyncStatus = &b
+	s.IsSyncing = b
 
 	return nil
 }

--- a/rpc/types.go
+++ b/rpc/types.go
@@ -99,13 +99,16 @@ type PendingStateUpdate struct {
 
 // SyncStatus is An object describing the node synchronisation status
 type SyncStatus struct {
-	IsSyncing         bool
+	// A boolean indicating whether the node is syncing. If false, all other fields are empty.
+	IsSyncing bool
+
+	// All these fields are only present if IsSyncing is true.
 	StartingBlockHash *felt.Felt `json:"starting_block_hash,omitempty"`
-	StartingBlockNum  NumAsHex   `json:"starting_block_num,omitempty"`
+	StartingBlockNum  uint64     `json:"starting_block_num,omitempty"`
 	CurrentBlockHash  *felt.Felt `json:"current_block_hash,omitempty"`
-	CurrentBlockNum   NumAsHex   `json:"current_block_num,omitempty"`
+	CurrentBlockNum   uint64     `json:"current_block_num,omitempty"`
 	HighestBlockHash  *felt.Felt `json:"highest_block_hash,omitempty"`
-	HighestBlockNum   NumAsHex   `json:"highest_block_num,omitempty"`
+	HighestBlockNum   uint64     `json:"highest_block_num,omitempty"`
 }
 
 // MarshalJSON marshals the SyncStatus struct into JSON format.
@@ -147,13 +150,11 @@ func (s SyncStatus) MarshalJSON() ([]byte, error) {
 // Returns:
 //   - error: an error if the unmarshaling fails
 func (s *SyncStatus) UnmarshalJSON(data []byte) error {
-	var b bool
 	if string(data) == "false" {
-		s.IsSyncing = b
+		s.IsSyncing = false
 
 		return nil
 	}
-	b = true
 
 	type alias SyncStatus
 	var result alias
@@ -163,7 +164,7 @@ func (s *SyncStatus) UnmarshalJSON(data []byte) error {
 	}
 
 	*s = SyncStatus(result)
-	s.IsSyncing = b
+	s.IsSyncing = true
 
 	return nil
 }

--- a/rpc/types.go
+++ b/rpc/types.go
@@ -125,7 +125,7 @@ type SyncStatus struct {
 //   - []byte: the JSON encoding of the SyncStatus struct
 //   - error: any error that occurred during the marshalling process
 //
-//nolint:gocritic
+
 func (s SyncStatus) MarshalJSON() ([]byte, error) {
 	if !s.IsSyncing {
 		return []byte("false"), nil


### PR DESCRIPTION
Fix the `starknet_syncing` method error. It was crashing when the node response was that it was syncing. The error was due to some fields being a string instead of a number.
