### PR TITLE
Don't omitempty for TransactionExecErrData TransactionIndex

### DIFF
--- a/rpc/errors.go
+++ b/rpc/errors.go
@@ -355,7 +355,7 @@ func (c *ContractErrData) ErrorMessage() string {
 
 // Structured type for the ErrTransactionExecError data
 type TransactionExecErrData struct {
-	TransactionIndex int                    `json:"transaction_index,omitempty"`
+	TransactionIndex int                    `json:"transaction_index"`
 	ExecutionError   ContractExecutionError `json:"execution_error,omitempty"`
 }
 


### PR DESCRIPTION
Currently it results in malformed json when marshaling with 0 index