### PR TITLE
Fix: client panics sometimes when receiving reorg events in subscriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `account.SendTransaction`
 - The `account.AccountInterface` and the `rpc.RpcProvider` were updated to reflect the new return types.
 
+### Fixed
+- Bug when receiving reorg events from subscriptions, which was panicking in some cases.
+
 ### Dev updates
 - Regenerated mocks for the `account` and `rpc` packages
 - Tests updated accordingly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `account.DeployContractWithUDC`
   - `account.SendTransaction`
 - The `account.AccountInterface` and the `rpc.RpcProvider` were updated to reflect the new return types.
+- Reorg events are now supported in all Starknet subscriptions.
 
 ### Fixed
 - Bug when receiving reorg events from subscriptions, which was panicking in some cases.

--- a/client/client.go
+++ b/client/client.go
@@ -554,7 +554,7 @@ func (c *Client) Subscribe(
 	op := &requestOp{
 		ids:  []json.RawMessage{msg.ID},
 		resp: make(chan []*jsonrpcMessage, 1),
-		sub:  newClientSubscription(c, namespace, chanVal, methodSuffix),
+		sub:  newClientSubscription(c, namespace, chanVal),
 	}
 
 	// Send the subscription request.


### PR DESCRIPTION
There's a bug in Starknet.go related to the Reorg Events in Websocket subscriptions.

If the Starknet.go client is up to date with the node subscription, and a Reorg event arrives, the code works normally. But, if the Starknet.go client can not catch up with the node responses (there's accumulated data in the Starknet.go buffer because the user is not receiving the node response at the same time they arrive), and a Reorg event arrives, this will make Starknet.go crash.

The reason is that the Starknet.go client was based on the go-ethereum client, and Ethereum doesn't have a separate Reorg event type, AFAIK. But with Starknet, the Reorg event has its specific fields; it's a completely different type.
The original code has a buffer storing all the received events for a subscription, and the code adapted to handle the Starknet reorgs was still using the same buffer to store both the original subscription events and the Reorg events.
This works normally if everything is received in a sequential order, because there's a logic that signals if the next event is of the Reorg type, but if, for some reason, the client could not receive the value at the same time the node sends it, the flag will store outdated information.

Here are two examples:
Given the following labels:
`event` = original subscription event (e.g. a `newHeads` type for the `newHeads` subscription)  
`reorg` = the reorg event

Normal workflow:
1. event arrives >
1. event is stored at the end of the buffer >
1. buffer is = [event] >
1. `isReorg`  is false >
1. client sends the value at the top of the buffer to the **event** channel >
1. buffer is = [] >
1. reorg arrives >
1. reorg is stored at the end of the  buffer >
1. buffer is = [reorg] >
1. `isReorg` is true >
1. client sends the value at the top of the buffer to the **reorg** channel >
1. buffer is = [] >
and so on...

Buggy workflow :
1. event arrives >
1. event is stored at the end of the buffer >
1. buffer is = [event] >
1. `isReorg`  is false >
1. client is slow and can't receive the value from the buffer yet >
1. buffer is = [event] >
1. reorg arrives >
1. reorg is stored at the end of the  buffer >
1. buffer is = [event, reorg] >
1. `isReorg` is true >
1. client is slow and can't receive the value from the buffer yet >
1. buffer is = [event, reorg] >
1. event arrives >
1. event is stored at the end of the buffer >
1. buffer is = [event, reorg, event] >
1. `isReorg`  is set to false >
1. client sends the value at the top of the buffer to the **event** channel >
1. buffer now is = [reorg, event] >
1. event arrives >
1. event is stored at the end of the buffer >
1. buffer is = [reorg, event, event] >
1. `isReorg`  is still false >
1. client sends the value at the top of the buffer to the **event** channel >
Since the value at the top of the buffer is of the type `Reorg`, and it's being sent to the `event` channel, the client panics with: `panic: reflect.Select: value of type *client.ReorgEvent is not assignable to type *rpc.BlockHeader`

This PR fixes this issue by implementing a separate buffer for the reorg events. Also, this PR adds an improvement that will soon be part of the Starknet RPC spec, which is to make Reorg events available in all subscriptions.
It was tested with a local Juno node changed to send reorg events each 5 seconds, and a Starknet.go client configured to receive each event with a 20-millisecond delay. Then the Starknet.go client subscribed to newHeads passing a 1000 old block number.
For the old code, the test fails, but it succeeded for the new code in this PR.

Old code from main panicking:
<img width="1203" height="966" alt="image" src="https://github.com/user-attachments/assets/0c0de605-7421-475f-8859-aa88a78dc043" />

New code from this PR, reaching the head without any error:
<img width="1203" height="966" alt="image" src="https://github.com/user-attachments/assets/75f5acc9-9fd9-460c-b62a-096cb2dabc6b" />
