### PR TITLE
Thiagodeev/export-spy-type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The `Err` function now have a specific case for the `InternalError` code.
 
 ### Dev updates
-- New `internal/tests/jsonrpc_spy.go` file containing a `spy` type for spying JSON-RPC calls in tests. The
+- New `internal/tests/jsonrpc_spy.go` file containing a `Spy` type for spying JSON-RPC calls in tests. The
 old `rpc/spy_test.go` file was removed.
 
 ## [0.15.0](https://github.com/NethermindEth/starknet.go/releases/tag/v0.15.0) - 2025-09-03

--- a/internal/tests/jsonrpc_spy.go
+++ b/internal/tests/jsonrpc_spy.go
@@ -8,7 +8,7 @@ import (
 
 type Spy struct {
 	callCloser
-	buff  json.RawMessage
+	buff  []byte
 	mock  bool
 	debug bool
 }

--- a/internal/tests/jsonrpc_spy.go
+++ b/internal/tests/jsonrpc_spy.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 )
 
-type spy struct {
+type Spy struct {
 	callCloser
 	buff  json.RawMessage
 	mock  bool
@@ -21,7 +21,7 @@ type callCloser interface {
 	Close()
 }
 
-var _ callCloser = &spy{} //nolint:exhaustruct
+var _ callCloser = &Spy{} //nolint:exhaustruct
 
 // NewJSONRPCSpy creates a new spy object.
 //
@@ -35,13 +35,13 @@ var _ callCloser = &spy{} //nolint:exhaustruct
 //
 // Returns:
 //   - spy: a new spy object
-func NewJSONRPCSpy(client callCloser, debug ...bool) *spy {
+func NewJSONRPCSpy(client callCloser, debug ...bool) *Spy {
 	d := false
 	if len(debug) > 0 {
 		d = debug[0]
 	}
 	if TEST_ENV == MockEnv {
-		return &spy{
+		return &Spy{
 			callCloser: client,
 			buff:       []byte{},
 			mock:       true,
@@ -49,7 +49,7 @@ func NewJSONRPCSpy(client callCloser, debug ...bool) *spy {
 		}
 	}
 
-	return &spy{
+	return &Spy{
 		callCloser: client,
 		buff:       []byte{},
 		mock:       false,
@@ -67,7 +67,7 @@ func NewJSONRPCSpy(client callCloser, debug ...bool) *spy {
 //
 // Returns:
 //   - error: an error if any occurred during the function call
-func (s *spy) CallContext(ctx context.Context, result interface{}, method string, arg interface{}) error {
+func (s *Spy) CallContext(ctx context.Context, result interface{}, method string, arg interface{}) error {
 	if s.mock {
 		return s.callCloser.CallContext(ctx, result, method, arg)
 	}
@@ -106,7 +106,7 @@ func (s *spy) CallContext(ctx context.Context, result interface{}, method string
 //
 // Returns:
 //   - error: an error if any occurred during the function call
-func (s *spy) CallContextWithSliceArgs(ctx context.Context, result interface{}, method string, args ...interface{}) error {
+func (s *Spy) CallContextWithSliceArgs(ctx context.Context, result interface{}, method string, args ...interface{}) error {
 	if s.mock {
 		return s.callCloser.CallContextWithSliceArgs(ctx, result, method, args...)
 	}
@@ -139,7 +139,7 @@ func (s *spy) CallContextWithSliceArgs(ctx context.Context, result interface{}, 
 
 // LastResponse returns the last response captured by the spy.
 // In other words, it returns the raw JSON response received from the server when calling a `callCloser` method.
-func (s *spy) LastResponse() json.RawMessage {
+func (s *Spy) LastResponse() json.RawMessage {
 	return s.buff
 }
 

--- a/internal/tests/jsonrpc_spy.go
+++ b/internal/tests/jsonrpc_spy.go
@@ -6,6 +6,9 @@ import (
 	"fmt"
 )
 
+// The purpose of the Spy type is to spy on the JSON-RPC calls made by the client.
+// It's used in the tests to mock the JSON-RPC calls and to check if the client is
+// making the correct calls.
 type Spy struct {
 	callCloser
 	buff  []byte
@@ -21,7 +24,19 @@ type callCloser interface {
 	Close()
 }
 
-var _ callCloser = &Spy{} //nolint:exhaustruct
+// The Spyer interface implemented by the Spy type.
+type Spyer interface {
+	CallContext(ctx context.Context, result interface{}, method string, args interface{}) error
+	CallContextWithSliceArgs(ctx context.Context, result interface{}, method string, args ...interface{}) error
+	Close()
+	LastResponse() json.RawMessage
+}
+
+// Assert that the Spy type implements the callCloser and Spyer interfaces.
+var (
+	_ callCloser = &Spy{} //nolint:exhaustruct
+	_ Spyer      = &Spy{} //nolint:exhaustruct
+)
 
 // NewJSONRPCSpy creates a new spy object.
 //
@@ -35,7 +50,7 @@ var _ callCloser = &Spy{} //nolint:exhaustruct
 //
 // Returns:
 //   - spy: a new spy object
-func NewJSONRPCSpy(client callCloser, debug ...bool) *Spy {
+func NewJSONRPCSpy(client callCloser, debug ...bool) Spyer {
 	d := false
 	if len(debug) > 0 {
 		d = debug[0]


### PR DESCRIPTION
Make the spy type exportable to freely use it in the tests.
