### PR TITLE
Thiagodeev/fix-snip-12-selector-encode

### DIFF
--- a/typedData/testData/avnu_paymaster_invoke.json
+++ b/typedData/testData/avnu_paymaster_invoke.json
@@ -1,0 +1,81 @@
+{
+  "types": {
+    "StarknetDomain": [
+      {
+        "name": "name",
+        "type": "shortstring"
+      },
+      {
+        "name": "version",
+        "type": "shortstring"
+      },
+      {
+        "name": "chainId",
+        "type": "shortstring"
+      },
+      {
+        "name": "revision",
+        "type": "shortstring"
+      }
+    ],
+    "OutsideExecution": [
+      {
+        "name": "Caller",
+        "type": "ContractAddress"
+      },
+      {
+        "name": "Nonce",
+        "type": "felt"
+      },
+      {
+        "name": "Execute After",
+        "type": "u128"
+      },
+      {
+        "name": "Execute Before",
+        "type": "u128"
+      },
+      {
+        "name": "Calls",
+        "type": "Call*"
+      }
+    ],
+    "Call": [
+      {
+        "name": "To",
+        "type": "ContractAddress"
+      },
+      {
+        "name": "Selector",
+        "type": "selector"
+      },
+      {
+        "name": "Calldata",
+        "type": "felt*"
+      }
+    ]
+  },
+  "domain": {
+    "name": "Account.execute_from_outside",
+    "version": "2",
+    "chainId": "SN_SEPOLIA",
+    "revision": "1"
+  },
+  "primaryType": "OutsideExecution",
+  "message": {
+    "Caller": "0x75a180e18e56da1b1cae181c92a288f586f5fe22c18df21cf97886f1e4b316c",
+    "Nonce": "0x89ac3804c1e246bb124ae7c586a17cd8",
+    "Execute After": "0x1",
+    "Execute Before": "0x68d2eea3",
+    "Calls": [
+      {
+        "To": "0x669e24364ce0ae7ec2864fb03eedbe60cfbc9d1c74438d10fa4b86552907d54",
+        "Selector": "0x2f0b3c5710379609eb5495f1ecd348cb28167711b73609fe565a72734550354",
+        "Calldata": [
+          "0x2710",
+          "0x0"
+        ]
+      }
+    ]
+  }
+}

--- a/typedData/typedData.go
+++ b/typedData/typedData.go
@@ -819,10 +819,25 @@ func encodePieceOfData(typeName string, data any, rev *revision) (resp *felt.Fel
 	case "selector":
 		value := fmt.Sprintf("%v", data)
 
+		// To the case of the value being an already hashed selector, so we
+		// skip the hashing step
+		if isHexString(value) {
+			return internalUtils.HexToFelt(value)
+		}
+
 		return internalUtils.GetSelectorFromNameFelt(value), nil
 	default:
 		return resp, fmt.Errorf("invalid type '%s'", typeName)
 	}
+}
+
+func isHexString(str string) bool {
+	res, err := regexp.MatchString("^0x[0-9a-fA-F]+$", str)
+	if err != nil {
+		return false
+	}
+
+	return res
 }
 
 // UnmarshalJSON implements the json.Unmarshaler interface for TypedData

--- a/typedData/typedData_test.go
+++ b/typedData/typedData_test.go
@@ -23,6 +23,7 @@ var (
 		"v1Nested",
 		"allInOne",
 		"example_enumNested",
+		"avnu_paymaster_invoke",
 	}
 )
 
@@ -122,7 +123,6 @@ func TestGetMessageHash(t *testing.T) {
 		ExpectedMessageHash string
 	}
 
-	//nolint:dupl
 	testSet := []testSetType{
 		{
 			TypedDataName:       "baseExample",
@@ -173,6 +173,11 @@ func TestGetMessageHash(t *testing.T) {
 			TypedDataName:       "example_enumNested",
 			Address:             "0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826",
 			ExpectedMessageHash: "0x691fc54567306a8ea5431130f1b98299e74a748ac391540a86736f20ef5f2b7",
+		},
+		{
+			TypedDataName:       "avnu_paymaster_invoke",
+			Address:             "0x05c74db20fa8f151bfd3a7a462cf2e8d4578a88aa4bd7a1746955201c48d8e5e",
+			ExpectedMessageHash: "0x523f153f2a3ca228a2ea222fb5114437a9191bdade099667ef0c113f5444fa0",
 		},
 	}
 
@@ -236,6 +241,11 @@ func TestGetTypeHash(t *testing.T) {
 			TypeName:      "Example",
 			ExpectedHash:  "0x2143bb787fabace39d62e9acf8b6e97d9a369000516c3e6ffd963dc1370fc1a",
 		},
+		{
+			TypedDataName: "avnu_paymaster_invoke",
+			TypeName:      "OutsideExecution",
+			ExpectedHash:  "0x312b56c05a7965066ddbda31c016d8d05afc305071c0ca3cdc2192c3c2f1f0f",
+		},
 	}
 	for _, test := range testSet {
 		t.Run(test.TypedDataName, func(t *testing.T) {
@@ -268,7 +278,6 @@ func TestEncodeType(t *testing.T) {
 		ExpectedEncode string
 	}
 
-	//nolint:dupl
 	testSet := []testSetType{
 		{
 			TypedDataName:  "baseExample",
@@ -379,6 +388,11 @@ func TestGetStructHash(t *testing.T) {
 			TypedDataName: "example_enum",
 			TypeName:      "Example",
 			ExpectedHash:  "0x1e1bb5d477e92cbf562b3b766c5c1e5f8590f2df868d4c8249c0db8416f8c37",
+		},
+		{
+			TypedDataName: "avnu_paymaster_invoke",
+			TypeName:      "OutsideExecution",
+			ExpectedHash:  "0x117e7ef9a7d447eb4bb3d9ebbb60594e0630f463ec7875f6fcc0ffad8d71c96",
 		},
 	}
 	for _, test := range testSet {


### PR DESCRIPTION
This PR aims to fix an error in the SNIP-12 `selector` type encoding.

The SNIP only says that this type should be keccak-hashed (and that's exactly what Starknet.go currently does, it just takes the JSON value and hashes it), but there are some other cases when this is not correct.

Here's one edge case: instead of a user passing a method name string (like `transfer`), they pass the already keccak-hashed hex string (e.g. `0x2f0b3c5710379609eb5495f1ecd348cb28167711b73609fe565a72734550354`). In this case, hashing the JSON value will lead to a different encoding, as we would be hashing a different value than the function name, leading to a different final message hash of the entire typedData. 

This is exactly what was happening in Starknet.go. The AVNU paymaster was returning a typedData with an already hashed selector string as the `selector` value, and we are hashing it again.
Now, we will do the same as Starknet.js, which is check if the JSON value is a hex string, and skip the hashing process if true. That way we can avoid this error.

It's not SNIP-12 compliant, but we can say this is more like a SNIP-12 description problem than an implementation problem.

Starknet.js refs:
- related issue https://github.com/starknet-io/starknet.js/issues/1348
- their decision about the matter https://github.com/starknet-io/starknet.js/pull/1413#issuecomment-2944048571