### PR TITLE
Fix OG image preview for social media sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,12 @@
 
 <h1 align="center">Get the gopher Starkpilled</h1>
 
-<a href="https://pkg.go.dev/github.com/NethermindEth/starknet.go">
+<a href="https://starknet-go.nethermind.io">
 <img src="https://img.shields.io/badge/Documentation-Website-yellow"
+ height="50" />
+</a>
+<a href="https://pkg.go.dev/github.com/NethermindEth/starknet.go">
+<img src="https://img.shields.io/badge/Go_Reference-pkg.go.dev-blue"
  height="50" />
 </a>
 <br><br>

--- a/docs/vocs.config.ts
+++ b/docs/vocs.config.ts
@@ -4,8 +4,9 @@ import { sidebar } from './sidebar'
 export default defineConfig({
   title: 'starknet.go',
   titleTemplate: '%s · starknet.go',
-  
-  
+  baseUrl: 'https://starknet-go.nethermind.io',
+  description: 'Get the gopher Starkpilled - The Go SDK for Starknet',
+
   editLink: {
     pattern: 'https://github.com/NethermindEth/starknet.go/edit/main/www/docs/pages/:path',
     text: 'Suggest changes to this page',


### PR DESCRIPTION
## Summary
When sharing starknet.go documentation links on social media platforms like Twitter, Telegram, or Discord, the preview image wasn't displaying correctly.

This PR adds the necessary configuration to ensure proper OG (Open Graph) image rendering:
- Added `baseUrl` pointing to our production docs URL
- Added a `description` meta tag for better context in link previews

## Why this matters
Social platforms require absolute URLs to fetch preview images. Our `ogImageUrl` config was already set up, but without `baseUrl`, the generated URLs were relative and couldn't be resolved by external services.

## Testing
Once deployed, you can verify by sharing the docs link in any messaging platform - the starknet.go branded image should now appear in the link preview.