### PR TITLE
feat: add event utility functions for filtering events

### DIFF
--- a/rpc/types_transaction_receipt.go
+++ b/rpc/types_transaction_receipt.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 
 	"github.com/NethermindEth/juno/core/felt"
+	internalUtils "github.com/NethermindEth/starknet.go/internal/utils"
 )
 
 type MsgToL1 struct {
@@ -246,4 +247,40 @@ type TransactionReceiptWithBlockInfo struct {
 	// If this field is missing, it means the receipt belongs to the pre-confirmed block
 	BlockHash   *felt.Felt `json:"block_hash,omitempty"`
 	BlockNumber uint       `json:"block_number"`
+}
+
+// EventWith returns the first event matching the given event key/selector name.
+// Returns nil if no matching event is found.
+//
+// The function converts the eventKey string to a selector, then searches through
+// the receipt's events for an event whose first key matches the selector.
+//
+// Parameters:
+//   - eventKey: The event name to search for (e.g., "Transfer", "Approval")
+//
+// Returns:
+//   - *Event: A pointer to the first matching event, or nil if not found
+//
+// Example:
+//
+//	receipt, _ := provider.TransactionReceipt(ctx, txHash)
+//	transferEvent := receipt.EventWith("Transfer")
+//	if transferEvent != nil {
+//	    fmt.Println("Found transfer event from:", transferEvent.FromAddress)
+//	}
+func (r *TransactionReceiptWithBlockInfo) EventWith(eventKey string) *Event {
+	if len(r.Events) == 0 {
+		return nil
+	}
+
+	selector := internalUtils.GetSelectorFromNameFelt(eventKey)
+	selectorStr := selector.String()
+
+	for i := range r.Events {
+		if len(r.Events[i].Keys) > 0 && r.Events[i].Keys[0].String() == selectorStr {
+			return &r.Events[i]
+		}
+	}
+
+	return nil
 }

--- a/rpc/types_transaction_receipt_test.go
+++ b/rpc/types_transaction_receipt_test.go
@@ -1,0 +1,161 @@
+package rpc
+
+import (
+	"testing"
+
+	"github.com/NethermindEth/juno/core/felt"
+	internalUtils "github.com/NethermindEth/starknet.go/internal/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTransactionReceiptWithBlockInfo_EventWith(t *testing.T) {
+	transferSelector := internalUtils.GetSelectorFromNameFelt("Transfer")
+	approvalSelector := internalUtils.GetSelectorFromNameFelt("Approval")
+
+	fromAddr := new(felt.Felt).SetUint64(12345)
+	dataFelt := new(felt.Felt).SetUint64(100)
+
+	tests := []struct {
+		name     string
+		receipt  TransactionReceiptWithBlockInfo
+		eventKey string
+		want     *Event
+	}{
+		{
+			name: "empty events returns nil",
+			receipt: TransactionReceiptWithBlockInfo{
+				TransactionReceipt: TransactionReceipt{
+					Events: []Event{},
+				},
+			},
+			eventKey: "Transfer",
+			want:     nil,
+		},
+		{
+			name: "event not found returns nil",
+			receipt: TransactionReceiptWithBlockInfo{
+				TransactionReceipt: TransactionReceipt{
+					Events: []Event{
+						{
+							FromAddress: fromAddr,
+							EventContent: EventContent{
+								Keys: []*felt.Felt{approvalSelector},
+								Data: []*felt.Felt{dataFelt},
+							},
+						},
+					},
+				},
+			},
+			eventKey: "Transfer",
+			want:     nil,
+		},
+		{
+			name: "event found returns correct event",
+			receipt: TransactionReceiptWithBlockInfo{
+				TransactionReceipt: TransactionReceipt{
+					Events: []Event{
+						{
+							FromAddress: fromAddr,
+							EventContent: EventContent{
+								Keys: []*felt.Felt{transferSelector},
+								Data: []*felt.Felt{dataFelt},
+							},
+						},
+					},
+				},
+			},
+			eventKey: "Transfer",
+			want: &Event{
+				FromAddress: fromAddr,
+				EventContent: EventContent{
+					Keys: []*felt.Felt{transferSelector},
+					Data: []*felt.Felt{dataFelt},
+				},
+			},
+		},
+		{
+			name: "multiple events returns first match",
+			receipt: TransactionReceiptWithBlockInfo{
+				TransactionReceipt: TransactionReceipt{
+					Events: []Event{
+						{
+							FromAddress: fromAddr,
+							EventContent: EventContent{
+								Keys: []*felt.Felt{approvalSelector},
+								Data: []*felt.Felt{dataFelt},
+							},
+						},
+						{
+							FromAddress: fromAddr,
+							EventContent: EventContent{
+								Keys: []*felt.Felt{transferSelector},
+								Data: []*felt.Felt{new(felt.Felt).SetUint64(200)},
+							},
+						},
+						{
+							FromAddress: fromAddr,
+							EventContent: EventContent{
+								Keys: []*felt.Felt{transferSelector},
+								Data: []*felt.Felt{new(felt.Felt).SetUint64(300)},
+							},
+						},
+					},
+				},
+			},
+			eventKey: "Transfer",
+			want: &Event{
+				FromAddress: fromAddr,
+				EventContent: EventContent{
+					Keys: []*felt.Felt{transferSelector},
+					Data: []*felt.Felt{new(felt.Felt).SetUint64(200)},
+				},
+			},
+		},
+		{
+			name: "event with empty keys is skipped",
+			receipt: TransactionReceiptWithBlockInfo{
+				TransactionReceipt: TransactionReceipt{
+					Events: []Event{
+						{
+							FromAddress: fromAddr,
+							EventContent: EventContent{
+								Keys: []*felt.Felt{},
+								Data: []*felt.Felt{dataFelt},
+							},
+						},
+						{
+							FromAddress: fromAddr,
+							EventContent: EventContent{
+								Keys: []*felt.Felt{transferSelector},
+								Data: []*felt.Felt{dataFelt},
+							},
+						},
+					},
+				},
+			},
+			eventKey: "Transfer",
+			want: &Event{
+				FromAddress: fromAddr,
+				EventContent: EventContent{
+					Keys: []*felt.Felt{transferSelector},
+					Data: []*felt.Felt{dataFelt},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.receipt.EventWith(tt.eventKey)
+			if tt.want == nil {
+				assert.Nil(t, got)
+			} else {
+				require.NotNil(t, got)
+				assert.Equal(t, tt.want.FromAddress.String(), got.FromAddress.String())
+				assert.Equal(t, tt.want.Keys[0].String(), got.Keys[0].String())
+				assert.Equal(t, tt.want.Data[0].String(), got.Data[0].String())
+			}
+		})
+	}
+}

--- a/utils/events.go
+++ b/utils/events.go
@@ -1,0 +1,81 @@
+package utils
+
+import (
+	"github.com/NethermindEth/starknet.go/rpc"
+)
+
+// EventWith filters events by event key/selector name.
+// Returns the first matching event or nil if not found.
+//
+// The function converts the eventKey string to a selector using GetSelectorFromNameFelt,
+// then searches through the events slice for an event whose first key matches the selector.
+//
+// Parameters:
+//   - events: A slice of rpc.Event to search through
+//   - eventKey: The event name to search for (e.g., "Transfer", "Approval")
+//
+// Returns:
+//   - *rpc.Event: A pointer to the first matching event, or nil if not found
+//
+// Example:
+//
+//	events := []rpc.Event{...}
+//	transferEvent := utils.EventWith(events, "Transfer")
+//	if transferEvent != nil {
+//	    fmt.Println("Found transfer event from:", transferEvent.FromAddress)
+//	}
+func EventWith(events []rpc.Event, eventKey string) *rpc.Event {
+	if len(events) == 0 {
+		return nil
+	}
+
+	selector := GetSelectorFromNameFelt(eventKey)
+	selectorStr := selector.String()
+
+	for i := range events {
+		if len(events[i].Keys) > 0 && events[i].Keys[0].String() == selectorStr {
+			return &events[i]
+		}
+	}
+
+	return nil
+}
+
+// EventsWithKey filters and returns all events matching the given key/selector name.
+//
+// The function converts the eventKey string to a selector using GetSelectorFromNameFelt,
+// then collects all events whose first key matches the selector.
+//
+// Parameters:
+//   - events: A slice of rpc.Event to search through
+//   - eventKey: The event name to search for (e.g., "Transfer", "Approval")
+//
+// Returns:
+//   - []rpc.Event: A slice of all matching events (empty slice if none found)
+//
+// Example:
+//
+//	events := []rpc.Event{...}
+//	allTransfers := utils.EventsWithKey(events, "Transfer")
+//	fmt.Printf("Found %d transfer events\n", len(allTransfers))
+func EventsWithKey(events []rpc.Event, eventKey string) []rpc.Event {
+	if len(events) == 0 {
+		return []rpc.Event{}
+	}
+
+	selector := GetSelectorFromNameFelt(eventKey)
+	selectorStr := selector.String()
+
+	var result []rpc.Event
+	for _, event := range events {
+		if len(event.Keys) > 0 && event.Keys[0].String() == selectorStr {
+			result = append(result, event)
+		}
+	}
+
+	if result == nil {
+		return []rpc.Event{}
+	}
+
+	return result
+}

--- a/utils/events_test.go
+++ b/utils/events_test.go
@@ -1,0 +1,259 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/starknet.go/rpc"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEventWith(t *testing.T) {
+	transferSelector := GetSelectorFromNameFelt("Transfer")
+	approvalSelector := GetSelectorFromNameFelt("Approval")
+
+	fromAddr := new(felt.Felt).SetUint64(12345)
+	dataFelt := new(felt.Felt).SetUint64(100)
+
+	tests := []struct {
+		name     string
+		events   []rpc.Event
+		eventKey string
+		want     *rpc.Event
+	}{
+		{
+			name:     "empty slice returns nil",
+			events:   []rpc.Event{},
+			eventKey: "Transfer",
+			want:     nil,
+		},
+		{
+			name: "event not found returns nil",
+			events: []rpc.Event{
+				{
+					FromAddress: fromAddr,
+					EventContent: rpc.EventContent{
+						Keys: []*felt.Felt{approvalSelector},
+						Data: []*felt.Felt{dataFelt},
+					},
+				},
+			},
+			eventKey: "Transfer",
+			want:     nil,
+		},
+		{
+			name: "event found returns correct event",
+			events: []rpc.Event{
+				{
+					FromAddress: fromAddr,
+					EventContent: rpc.EventContent{
+						Keys: []*felt.Felt{transferSelector},
+						Data: []*felt.Felt{dataFelt},
+					},
+				},
+			},
+			eventKey: "Transfer",
+			want: &rpc.Event{
+				FromAddress: fromAddr,
+				EventContent: rpc.EventContent{
+					Keys: []*felt.Felt{transferSelector},
+					Data: []*felt.Felt{dataFelt},
+				},
+			},
+		},
+		{
+			name: "multiple events returns first match",
+			events: []rpc.Event{
+				{
+					FromAddress: fromAddr,
+					EventContent: rpc.EventContent{
+						Keys: []*felt.Felt{approvalSelector},
+						Data: []*felt.Felt{dataFelt},
+					},
+				},
+				{
+					FromAddress: fromAddr,
+					EventContent: rpc.EventContent{
+						Keys: []*felt.Felt{transferSelector},
+						Data: []*felt.Felt{new(felt.Felt).SetUint64(200)},
+					},
+				},
+				{
+					FromAddress: fromAddr,
+					EventContent: rpc.EventContent{
+						Keys: []*felt.Felt{transferSelector},
+						Data: []*felt.Felt{new(felt.Felt).SetUint64(300)},
+					},
+				},
+			},
+			eventKey: "Transfer",
+			want: &rpc.Event{
+				FromAddress: fromAddr,
+				EventContent: rpc.EventContent{
+					Keys: []*felt.Felt{transferSelector},
+					Data: []*felt.Felt{new(felt.Felt).SetUint64(200)},
+				},
+			},
+		},
+		{
+			name: "event with empty keys is skipped",
+			events: []rpc.Event{
+				{
+					FromAddress: fromAddr,
+					EventContent: rpc.EventContent{
+						Keys: []*felt.Felt{},
+						Data: []*felt.Felt{dataFelt},
+					},
+				},
+				{
+					FromAddress: fromAddr,
+					EventContent: rpc.EventContent{
+						Keys: []*felt.Felt{transferSelector},
+						Data: []*felt.Felt{dataFelt},
+					},
+				},
+			},
+			eventKey: "Transfer",
+			want: &rpc.Event{
+				FromAddress: fromAddr,
+				EventContent: rpc.EventContent{
+					Keys: []*felt.Felt{transferSelector},
+					Data: []*felt.Felt{dataFelt},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := EventWith(tt.events, tt.eventKey)
+			if tt.want == nil {
+				assert.Nil(t, got)
+			} else {
+				require.NotNil(t, got)
+				assert.Equal(t, tt.want.FromAddress.String(), got.FromAddress.String())
+				assert.Equal(t, tt.want.Keys[0].String(), got.Keys[0].String())
+				assert.Equal(t, tt.want.Data[0].String(), got.Data[0].String())
+			}
+		})
+	}
+}
+
+func TestEventsWithKey(t *testing.T) {
+	transferSelector := GetSelectorFromNameFelt("Transfer")
+	approvalSelector := GetSelectorFromNameFelt("Approval")
+
+	fromAddr := new(felt.Felt).SetUint64(12345)
+	dataFelt := new(felt.Felt).SetUint64(100)
+
+	tests := []struct {
+		name      string
+		events    []rpc.Event
+		eventKey  string
+		wantCount int
+	}{
+		{
+			name:      "empty slice returns empty slice",
+			events:   []rpc.Event{},
+			eventKey: "Transfer",
+			wantCount: 0,
+		},
+		{
+			name: "no matches returns empty slice",
+			events: []rpc.Event{
+				{
+					FromAddress: fromAddr,
+					EventContent: rpc.EventContent{
+						Keys: []*felt.Felt{approvalSelector},
+						Data: []*felt.Felt{dataFelt},
+					},
+				},
+			},
+			eventKey: "Transfer",
+			wantCount: 0,
+		},
+		{
+			name: "single match returns one event",
+			events: []rpc.Event{
+				{
+					FromAddress: fromAddr,
+					EventContent: rpc.EventContent{
+						Keys: []*felt.Felt{transferSelector},
+						Data: []*felt.Felt{dataFelt},
+					},
+				},
+			},
+			eventKey: "Transfer",
+			wantCount: 1,
+		},
+		{
+			name: "multiple matches returns all events",
+			events: []rpc.Event{
+				{
+					FromAddress: fromAddr,
+					EventContent: rpc.EventContent{
+						Keys: []*felt.Felt{transferSelector},
+						Data: []*felt.Felt{new(felt.Felt).SetUint64(100)},
+					},
+				},
+				{
+					FromAddress: fromAddr,
+					EventContent: rpc.EventContent{
+						Keys: []*felt.Felt{approvalSelector},
+						Data: []*felt.Felt{new(felt.Felt).SetUint64(200)},
+					},
+				},
+				{
+					FromAddress: fromAddr,
+					EventContent: rpc.EventContent{
+						Keys: []*felt.Felt{transferSelector},
+						Data: []*felt.Felt{new(felt.Felt).SetUint64(300)},
+					},
+				},
+				{
+					FromAddress: fromAddr,
+					EventContent: rpc.EventContent{
+						Keys: []*felt.Felt{transferSelector},
+						Data: []*felt.Felt{new(felt.Felt).SetUint64(400)},
+					},
+				},
+			},
+			eventKey: "Transfer",
+			wantCount: 3,
+		},
+		{
+			name: "events with empty keys are skipped",
+			events: []rpc.Event{
+				{
+					FromAddress: fromAddr,
+					EventContent: rpc.EventContent{
+						Keys: []*felt.Felt{},
+						Data: []*felt.Felt{dataFelt},
+					},
+				},
+				{
+					FromAddress: fromAddr,
+					EventContent: rpc.EventContent{
+						Keys: []*felt.Felt{transferSelector},
+						Data: []*felt.Felt{dataFelt},
+					},
+				},
+			},
+			eventKey: "Transfer",
+			wantCount: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := EventsWithKey(tt.events, tt.eventKey)
+			assert.Len(t, got, tt.wantCount)
+
+			// Verify all returned events have the correct selector
+			for _, event := range got {
+				assert.Equal(t, transferSelector.String(), event.Keys[0].String())
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
Adds utility functions to filter events from `[]rpc.Event` slices and a helper method on `TransactionReceiptWithBlockInfo`.

## Changes
- **utils/events.go**: New file with:
  - `EventWith(events []rpc.Event, eventKey string) *rpc.Event` - Returns first matching event
  - `EventsWithKey(events []rpc.Event, eventKey string) []rpc.Event` - Returns all matching events
- **rpc/types_transaction_receipt.go**: Added method:
  - `(r *TransactionReceiptWithBlockInfo) EventWith(eventKey string) *Event`
- **utils/events_test.go**: Unit tests for utility functions
- **rpc/types_transaction_receipt_test.go**: Unit tests for receipt method

## Usage
```go
// Using utility function
myEvent := utils.EventWith(eventSlice, "event_key")

// Using receipt method
myEvent := txReceipt.EventWith("event_key")
```

## Test Plan
- [x] All existing tests pass (`make mock-test`)
- [x] New unit tests added for all functions

Closes #765