### PR TITLE
Fix StorageAt storage key handling

### DIFF
--- a/docs/docs/pages/docs/rpc/methods/storage-at.mdx
+++ b/docs/docs/pages/docs/rpc/methods/storage-at.mdx
@@ -8,9 +8,9 @@ Retrieves the storage value of a contract at a specific key and block state. Thi
 func (provider *Provider) StorageAt(
     ctx context.Context,
     contractAddress *felt.Felt,
-    key string,
+    key StorageKey,
     blockID BlockID,
-) (string, error)
+) (*felt.Felt, error)
 ```
 
 **Source:** [contract.go:L130-L145](https://github.com/NethermindEth/starknet.go/blob/main/rpc/contract.go#L130-L145)
@@ -19,19 +19,29 @@ func (provider *Provider) StorageAt(
 
 - `ctx` (context.Context): Context for request cancellation and timeout
 - `contractAddress` (*felt.Felt): The address of the contract
-- `key` (string): The storage key to retrieve (can be a variable name or hex string)
+- `key` (StorageKey): The storage key to retrieve
 - `blockID` (BlockID): Block identifier (number, hash, or tag)
 
 ## Returns
 
-- `string`: The storage value at the given key (as hex string)
+- `*felt.Felt`: The storage value at the given key
 - `error`: Error if the request fails
 
 :::note
-This can return `ErrContractNotFound` if the contract address doesn't exist, or `ErrBlockNotFound` if the block doesn't exist. The key is automatically converted using `GetSelectorFromName` if it's a variable name.
+This can return `ErrContractNotFound` if the contract address doesn't exist, or `ErrBlockNotFound` if the block doesn't exist. Pass the storage key directly; variable names are not automatically converted.
 :::
 
 ## Type Definitions
+
+### StorageKey
+
+The `key` parameter is a storage key encoded as a hex string.
+
+```go
+type StorageKey string
+```
+
+**Source:** [types_contract.go:L24](https://github.com/NethermindEth/starknet.go/blob/main/rpc/types_contract.go#L24)
 
 ### BlockID
 
@@ -118,42 +128,45 @@ func main() {
         log.Fatal(err)
     }
 
-    // Read token name from storage using variable name
-    // The method automatically converts "ERC20_name" to its storage key
-    nameValue, err := provider.StorageAt(ctx, ethContract, "ERC20_name", rpc.WithBlockTag("latest"))
+    // Read token name from storage
+    nameValue, err := provider.StorageAt(ctx, ethContract, storageKeyFromName("ERC20_name"), rpc.WithBlockTag("latest"))
     if err != nil {
         log.Fatal(err)
     }
 
     // Decode the hex-encoded string to readable text
-    tokenName := decodeShortString(nameValue)
+    tokenName := decodeShortString(nameValue.String())
     fmt.Printf("Token Name: %s (raw: %s)\n", tokenName, nameValue)
 
     // Read token symbol from storage
-    symbolValue, err := provider.StorageAt(ctx, ethContract, "ERC20_symbol", rpc.WithBlockTag("latest"))
+    symbolValue, err := provider.StorageAt(ctx, ethContract, storageKeyFromName("ERC20_symbol"), rpc.WithBlockTag("latest"))
     if err != nil {
         log.Fatal(err)
     }
-    tokenSymbol := decodeShortString(symbolValue)
+    tokenSymbol := decodeShortString(symbolValue.String())
     fmt.Printf("Token Symbol: %s (raw: %s)\n", tokenSymbol, symbolValue)
 
     // Read decimals value and convert to integer
-    decimalsValue, err := provider.StorageAt(ctx, ethContract, "ERC20_decimals", rpc.WithBlockTag("latest"))
+    decimalsValue, err := provider.StorageAt(ctx, ethContract, storageKeyFromName("ERC20_decimals"), rpc.WithBlockTag("latest"))
     if err != nil {
         log.Fatal(err)
     }
     decimals := new(big.Int)
-    decimals.SetString(strings.TrimPrefix(decimalsValue, "0x"), 16)
+    decimals.SetString(strings.TrimPrefix(decimalsValue.String(), "0x"), 16)
     fmt.Printf("Token Decimals: %s (raw: %s)\n", decimals.String(), decimalsValue)
 
     // Query historical total supply at a specific block number
-    totalSupplyValue, err := provider.StorageAt(ctx, ethContract, "ERC20_total_supply", rpc.WithBlockNumber(100000))
+    totalSupplyValue, err := provider.StorageAt(ctx, ethContract, storageKeyFromName("ERC20_total_supply"), rpc.WithBlockNumber(100000))
     if err != nil {
         log.Fatal(err)
     }
     totalSupply := new(big.Int)
-    totalSupply.SetString(strings.TrimPrefix(totalSupplyValue, "0x"), 16)
+    totalSupply.SetString(strings.TrimPrefix(totalSupplyValue.String(), "0x"), 16)
     fmt.Printf("Total Supply at block 100000: %s (raw: %s)\n", totalSupply.String(), totalSupplyValue)
+}
+
+func storageKeyFromName(name string) rpc.StorageKey {
+    return rpc.StorageKey(fmt.Sprintf("0x%x", utils.GetSelectorFromName(name)))
 }
 
 // decodeShortString decodes a hex-encoded short string (Cairo felt string)
@@ -198,9 +211,9 @@ fmt.Printf("Storage value: %s\n", storageValue)
 
 ## Common Use Cases
 
-- ead public state variables from deployed contracts. 
-- Check token balances stored in contract storage. 
-- Retrieve contract configuration values and settings. 
+- Read public state variables from deployed contracts.
+- Check token balances stored in contract storage.
+- Retrieve contract configuration values and settings.
 
 
 

--- a/docs/tests/rpc/contract/storage_at.go
+++ b/docs/tests/rpc/contract/storage_at.go
@@ -1,95 +1,98 @@
 package main
- 
+
 import (
-    "context"
-    "encoding/hex"
-    "fmt"
-    "log"
-    "math/big"
-    "os"
-    "strings"
- 
-    "github.com/NethermindEth/starknet.go/rpc"
-    "github.com/NethermindEth/starknet.go/utils"
-    "github.com/joho/godotenv"
+	"context"
+	"encoding/hex"
+	"fmt"
+	"log"
+	"math/big"
+	"os"
+	"strings"
+
+	"github.com/NethermindEth/starknet.go/rpc"
+	"github.com/NethermindEth/starknet.go/utils"
+	"github.com/joho/godotenv"
 )
- 
+
 func main() {
-    // Load environment variables from .env file
-    err := godotenv.Load()
-    if err != nil {
-        log.Fatal("Error loading .env file")
-    }
- 
-    // Get RPC URL from environment variable
-    rpcURL := os.Getenv("STARKNET_RPC_URL")
-    if rpcURL == "" {
-        log.Fatal("STARKNET_RPC_URL not found in .env file")
-    }
- 
-    // Initialize provider
-    provider, err := rpc.NewProvider(context.Background(), rpcURL)
-    if err != nil {
-        log.Fatal(err)
-    }
- 
-    ctx := context.Background()
- 
-    // ETH contract address on Starknet (SPELOIA)
-    ethContract, err := utils.HexToFelt("0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7")
-    if err != nil {
-        log.Fatal(err)
-    }
- 
-    // Read token name from storage using variable name
-    // The method automatically converts "ERC20_name" to its storage key
-    nameValue, err := provider.StorageAt(ctx, ethContract, "ERC20_name", rpc.WithBlockTag("latest"))
-    if err != nil {
-        log.Fatal(err)
-    }
- 
-    // Decode the hex-encoded string to readable text
-    tokenName := decodeShortString(nameValue)
-    fmt.Printf("Token Name: %s (raw: %s)\n", tokenName, nameValue)
- 
-    // Read token symbol from storage
-    symbolValue, err := provider.StorageAt(ctx, ethContract, "ERC20_symbol", rpc.WithBlockTag("latest"))
-    if err != nil {
-        log.Fatal(err)
-    }
-    tokenSymbol := decodeShortString(symbolValue)
-    fmt.Printf("Token Symbol: %s (raw: %s)\n", tokenSymbol, symbolValue)
- 
-    // Read decimals value and convert to integer
-    decimalsValue, err := provider.StorageAt(ctx, ethContract, "ERC20_decimals", rpc.WithBlockTag("latest"))
-    if err != nil {
-        log.Fatal(err)
-    }
-    decimals := new(big.Int)
-    decimals.SetString(strings.TrimPrefix(decimalsValue, "0x"), 16)
-    fmt.Printf("Token Decimals: %s (raw: %s)\n", decimals.String(), decimalsValue)
- 
-    // Query historical total supply at a specific block number
-    totalSupplyValue, err := provider.StorageAt(ctx, ethContract, "ERC20_total_supply", rpc.WithBlockNumber(100000))
-    if err != nil {
-        log.Fatal(err)
-    }
-    totalSupply := new(big.Int)
-    totalSupply.SetString(strings.TrimPrefix(totalSupplyValue, "0x"), 16)
-    fmt.Printf("Total Supply at block 100000: %s (raw: %s)\n", totalSupply.String(), totalSupplyValue)
+	// Load environment variables from .env file
+	err := godotenv.Load()
+	if err != nil {
+		log.Fatal("Error loading .env file")
+	}
+
+	// Get RPC URL from environment variable
+	rpcURL := os.Getenv("STARKNET_RPC_URL")
+	if rpcURL == "" {
+		log.Fatal("STARKNET_RPC_URL not found in .env file")
+	}
+
+	// Initialize provider
+	provider, err := rpc.NewProvider(context.Background(), rpcURL)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	ctx := context.Background()
+
+	// ETH contract address on Starknet (SPELOIA)
+	ethContract, err := utils.HexToFelt("0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Read token name from storage
+	nameValue, err := provider.StorageAt(ctx, ethContract, storageKeyFromName("ERC20_name"), rpc.WithBlockTag("latest"))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Decode the hex-encoded string to readable text
+	tokenName := decodeShortString(nameValue.String())
+	fmt.Printf("Token Name: %s (raw: %s)\n", tokenName, nameValue)
+
+	// Read token symbol from storage
+	symbolValue, err := provider.StorageAt(ctx, ethContract, storageKeyFromName("ERC20_symbol"), rpc.WithBlockTag("latest"))
+	if err != nil {
+		log.Fatal(err)
+	}
+	tokenSymbol := decodeShortString(symbolValue.String())
+	fmt.Printf("Token Symbol: %s (raw: %s)\n", tokenSymbol, symbolValue)
+
+	// Read decimals value and convert to integer
+	decimalsValue, err := provider.StorageAt(ctx, ethContract, storageKeyFromName("ERC20_decimals"), rpc.WithBlockTag("latest"))
+	if err != nil {
+		log.Fatal(err)
+	}
+	decimals := new(big.Int)
+	decimals.SetString(strings.TrimPrefix(decimalsValue.String(), "0x"), 16)
+	fmt.Printf("Token Decimals: %s (raw: %s)\n", decimals.String(), decimalsValue)
+
+	// Query historical total supply at a specific block number
+	totalSupplyValue, err := provider.StorageAt(ctx, ethContract, storageKeyFromName("ERC20_total_supply"), rpc.WithBlockNumber(100000))
+	if err != nil {
+		log.Fatal(err)
+	}
+	totalSupply := new(big.Int)
+	totalSupply.SetString(strings.TrimPrefix(totalSupplyValue.String(), "0x"), 16)
+	fmt.Printf("Total Supply at block 100000: %s (raw: %s)\n", totalSupply.String(), totalSupplyValue)
 }
- 
+
+func storageKeyFromName(name string) rpc.StorageKey {
+	return rpc.StorageKey(fmt.Sprintf("0x%x", utils.GetSelectorFromName(name)))
+}
+
 // decodeShortString decodes a hex-encoded short string (Cairo felt string)
 func decodeShortString(hexStr string) string {
-    hexStr = strings.TrimPrefix(hexStr, "0x")
-    if len(hexStr)%2 != 0 {
-        hexStr = "0" + hexStr
-    }
- 
-    bytes, err := hex.DecodeString(hexStr)
-    if err != nil {
-        return ""
-    }
- 
-    return string(bytes)
+	hexStr = strings.TrimPrefix(hexStr, "0x")
+	if len(hexStr)%2 != 0 {
+		hexStr = "0" + hexStr
+	}
+
+	bytes, err := hex.DecodeString(hexStr)
+	if err != nil {
+		return ""
+	}
+
+	return string(bytes)
 }

--- a/internal/tests/mocks/rpcv10mock/rpc.go
+++ b/internal/tests/mocks/rpcv10mock/rpc.go
@@ -390,10 +390,10 @@ func (mr *MockRPCProviderMockRecorder) StateUpdate(ctx, blockID any) *gomock.Cal
 }
 
 // StorageAt mocks base method.
-func (m *MockRPCProvider) StorageAt(ctx context.Context, contractAddress *felt.Felt, key string, blockID rpc.BlockID) (string, error) {
+func (m *MockRPCProvider) StorageAt(ctx context.Context, contractAddress *felt.Felt, key rpc.StorageKey, blockID rpc.BlockID) (*felt.Felt, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StorageAt", ctx, contractAddress, key, blockID)
-	ret0, _ := ret[0].(string)
+	ret0, _ := ret[0].(*felt.Felt)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/rpc/contract.go
+++ b/rpc/contract.go
@@ -3,12 +3,10 @@ package rpc
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/starknet.go/client/rpcerr"
 	"github.com/NethermindEth/starknet.go/contracts"
-	internalUtils "github.com/NethermindEth/starknet.go/internal/utils"
 )
 
 // Class retrieves the class information from the Provider with the given hash.
@@ -121,24 +119,23 @@ func (provider *Provider) ClassHashAt(
 // Parameters:
 //   - ctx: The context.Context for the function
 //   - contractAddress: The address of the contract
-//   - key: The key for which to retrieve the storage value
+//   - key: The storage key for which to retrieve the storage value
 //   - blockID: The ID of the block at which to retrieve the storage value
 //
 // Returns:
-//   - string: The value of the storage
+//   - *felt.Felt: The value of the storage
 //   - error: An error if any occurred during the execution
 func (provider *Provider) StorageAt(
 	ctx context.Context,
 	contractAddress *felt.Felt,
-	key string,
+	key StorageKey,
 	blockID BlockID,
-) (string, error) {
-	var value string
-	hashKey := fmt.Sprintf("0x%x", internalUtils.GetSelectorFromName(key))
+) (*felt.Felt, error) {
+	var value *felt.Felt
 	if err := do(
-		ctx, provider.c, "starknet_getStorageAt", &value, contractAddress, hashKey, blockID,
+		ctx, provider.c, "starknet_getStorageAt", &value, contractAddress, key, blockID,
 	); err != nil {
-		return "", rpcerr.UnwrapToRPCErr(err, ErrContractNotFound, ErrBlockNotFound)
+		return nil, rpcerr.UnwrapToRPCErr(err, ErrContractNotFound, ErrBlockNotFound)
 	}
 
 	return value, nil

--- a/rpc/contract_test.go
+++ b/rpc/contract_test.go
@@ -514,20 +514,20 @@ func TestStorageAt(t *testing.T) {
 			{
 				Description:     "normal call",
 				ContractAddress: internalUtils.TestHexToFelt(t, "0x123"),
-				StorageKey:      storageKeyFromName("_signer"),
+				StorageKey:      StorageKey("0x123"),
 				Block:           WithBlockTag(BlockTagLatest),
 			},
 			{
 				Description:     "invalid block",
 				ContractAddress: internalUtils.TestHexToFelt(t, "0x123"),
-				StorageKey:      storageKeyFromName("_signer"),
+				StorageKey:      StorageKey("0x456"),
 				Block:           WithBlockHash(internalUtils.DeadBeef),
 				ExpectedError:   ErrBlockNotFound,
 			},
 			{
 				Description:     "invalid contract address",
 				ContractAddress: internalUtils.DeadBeef,
-				StorageKey:      storageKeyFromName("_signer"),
+				StorageKey:      StorageKey("0x789"),
 				Block:           WithBlockTag(BlockTagLatest),
 				ExpectedError:   ErrContractNotFound,
 			},

--- a/rpc/contract_test.go
+++ b/rpc/contract_test.go
@@ -502,29 +502,32 @@ func TestStorageAt(t *testing.T) {
 	type testSetType struct {
 		Description     string
 		ContractAddress *felt.Felt
-		StorageKey      string
+		StorageKey      StorageKey
 		Block           BlockID
 		ExpectedError   error
+	}
+	storageKeyFromName := func(name string) StorageKey {
+		return StorageKey(fmt.Sprintf("0x%x", internalUtils.GetSelectorFromName(name)))
 	}
 	testSet := map[tests.TestEnv][]testSetType{
 		tests.MockEnv: {
 			{
 				Description:     "normal call",
 				ContractAddress: internalUtils.TestHexToFelt(t, "0x123"),
-				StorageKey:      "_signer",
+				StorageKey:      storageKeyFromName("_signer"),
 				Block:           WithBlockTag(BlockTagLatest),
 			},
 			{
 				Description:     "invalid block",
 				ContractAddress: internalUtils.TestHexToFelt(t, "0x123"),
-				StorageKey:      "_signer",
+				StorageKey:      storageKeyFromName("_signer"),
 				Block:           WithBlockHash(internalUtils.DeadBeef),
 				ExpectedError:   ErrBlockNotFound,
 			},
 			{
 				Description:     "invalid contract address",
 				ContractAddress: internalUtils.DeadBeef,
-				StorageKey:      "_signer",
+				StorageKey:      storageKeyFromName("_signer"),
 				Block:           WithBlockTag(BlockTagLatest),
 				ExpectedError:   ErrContractNotFound,
 			},
@@ -533,7 +536,7 @@ func TestStorageAt(t *testing.T) {
 			{
 				Description:     "normal call",
 				ContractAddress: internalUtils.TestHexToFelt(t, "0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d"),
-				StorageKey:      "ERC20_name",
+				StorageKey:      storageKeyFromName("ERC20_name"),
 				Block:           WithBlockTag(BlockTagLatest),
 			},
 		},
@@ -541,20 +544,20 @@ func TestStorageAt(t *testing.T) {
 			{
 				Description:     "normal call",
 				ContractAddress: internalUtils.TestHexToFelt(t, "0x0200AB5CE3D7aDE524335Dc57CaF4F821A0578BBb2eFc2166cb079a3D29cAF9A"),
-				StorageKey:      "_signer",
+				StorageKey:      storageKeyFromName("_signer"),
 				Block:           WithBlockTag(BlockTagLatest),
 			},
 			{
 				Description:     "invalid block",
 				ContractAddress: internalUtils.TestHexToFelt(t, "0x0200AB5CE3D7aDE524335Dc57CaF4F821A0578BBb2eFc2166cb079a3D29cAF9A"),
-				StorageKey:      "_signer",
+				StorageKey:      storageKeyFromName("_signer"),
 				Block:           WithBlockHash(internalUtils.DeadBeef),
 				ExpectedError:   ErrBlockNotFound,
 			},
 			{
 				Description:     "invalid contract address",
 				ContractAddress: internalUtils.DeadBeef,
-				StorageKey:      "_signer",
+				StorageKey:      storageKeyFromName("_signer"),
 				Block:           WithBlockTag(BlockTagLatest),
 				ExpectedError:   ErrContractNotFound,
 			},
@@ -563,7 +566,7 @@ func TestStorageAt(t *testing.T) {
 			{
 				Description:     "normal call",
 				ContractAddress: internalUtils.TestHexToFelt(t, "0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d"),
-				StorageKey:      "ERC20_decimals",
+				StorageKey:      storageKeyFromName("ERC20_decimals"),
 				Block:           WithBlockTag(BlockTagLatest),
 			},
 		},
@@ -571,7 +574,7 @@ func TestStorageAt(t *testing.T) {
 			{
 				Description:     "normal call",
 				ContractAddress: internalUtils.TestHexToFelt(t, "0x8d17e6a3B92a2b5Fa21B8e7B5a3A794B05e06C5FD6C6451C6F2695Ba77101"),
-				StorageKey:      "_signer",
+				StorageKey:      storageKeyFromName("_signer"),
 				Block:           WithBlockTag(BlockTagLatest),
 			},
 		},
@@ -586,8 +589,7 @@ func TestStorageAt(t *testing.T) {
 						gomock.Any(),
 						"starknet_getStorageAt",
 						test.ContractAddress,
-						// the StorateAt function is not compliant with the spec
-						fmt.Sprintf("0x%x", internalUtils.GetSelectorFromName(test.StorageKey)),
+						test.StorageKey,
 						test.Block,
 					).
 					DoAndReturn(func(_, result, _ any, args ...any) error {

--- a/rpc/provider.go
+++ b/rpc/provider.go
@@ -177,9 +177,9 @@ type RPCProvider interface {
 	StorageAt(
 		ctx context.Context,
 		contractAddress *felt.Felt,
-		key string,
+		key StorageKey,
 		blockID BlockID,
-	) (string, error)
+	) (*felt.Felt, error)
 	StorageProof(
 		ctx context.Context,
 		storageProofInput StorageProofInput,


### PR DESCRIPTION
## Summary
- update `StorageAt` to accept a `StorageKey` directly
- pass the provided key to `starknet_getStorageAt` without selector-name hashing
- return the RPC storage value as `*felt.Felt`
- update tests, mocks, and the storage example call sites

## Rationale
`starknet_getStorageAt` expects a storage key, but the previous implementation accepted a string and always derived a selector from it. That prevented callers from querying arbitrary storage keys directly.

## Verification
- `go test ./rpc -run TestStorageAt -count=1`